### PR TITLE
[TYCHE-07] Create refresh token entity, table, and refresh endpoint

### DIFF
--- a/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
@@ -7,8 +7,10 @@ public final class AuthConstants {
 
   public static final String LOGIN_PASSWORD_POLICY =
       "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^\\w\\s]).{8,72}$";
+
   public static final int BCRYPT_MAX_PASSWORD_BYTES = 72;
   public static final String TOKEN_TYPE_BEARER = "Bearer";
+  public static final int REFRESH_TOKEN_BYTE_LENGTH = 32;
 
   private AuthConstants() {}
 }

--- a/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -8,10 +8,12 @@ public final class LogConstants {
   public static final String USER = "[user]";
   public static final String REGISTER_ACTION = "[register]";
   public static final String LOGIN_ACTION = "[login]";
+  public static final String REFRESH_TOKEN_ACTION = "[refresh-token]";
 
   public static final String REQUEST_START = BASE_LOG + " Request started";
   public static final String REQUEST_SUCCESS = BASE_LOG + " Request succeeded";
   public static final String REQUEST_CONFLICT = BASE_LOG + " Request rejected: {}";
+  public static final String INVALID_REFRESH_TOKEN_MESSAGE = "invalid refresh token";
   public static final String REGISTER_REQUEST_FIELDS = " username={}, email={}";
   public static final String LOGIN_REQUEST_FIELDS = " email={}";
   public static final String REGISTER_CREATED_USER_ID = " userId={}";

--- a/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
+++ b/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
@@ -5,8 +5,10 @@ import static com.tychewealth.constants.ApiConstants.REQUEST_PRODUCES;
 import static com.tychewealth.constants.ApiConstants.URL_FOLDER_V1;
 
 import com.tychewealth.dto.user.LoginResponseDto;
+import com.tychewealth.dto.user.RefreshTokenResponseDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.dto.user.request.LoginRequestDto;
+import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -24,4 +26,8 @@ public interface AuthApi {
 
   @PostMapping(value = "/login", consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
   ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto login);
+
+  @PostMapping(value = "/refresh", consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
+  ResponseEntity<RefreshTokenResponseDto> refresh(
+      @Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto);
 }

--- a/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
+++ b/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
@@ -3,8 +3,10 @@ package com.tychewealth.controller.impl;
 import com.tychewealth.constants.LogConstants;
 import com.tychewealth.controller.AuthApi;
 import com.tychewealth.dto.user.LoginResponseDto;
+import com.tychewealth.dto.user.RefreshTokenResponseDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.dto.user.request.LoginRequestDto;
+import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
 import com.tychewealth.service.AuthService;
 import com.tychewealth.utils.LogContextFactory;
@@ -45,6 +47,15 @@ public class AuthApiController implements AuthApi {
         LogContextFactory.mask(login.getEmail()));
 
     LoginResponseDto response = authService.login(login);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @Override
+  public ResponseEntity<RefreshTokenResponseDto> refresh(
+      @Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto) {
+    log.info(LogConstants.REQUEST_START, LogConstants.AUTH, LogConstants.REFRESH_TOKEN_ACTION);
+
+    RefreshTokenResponseDto response = authService.refresh(refreshTokenRequestDto);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/dto/user/RefreshTokenResponseDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/user/RefreshTokenResponseDto.java
@@ -1,5 +1,6 @@
 package com.tychewealth.dto.user;
 
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +10,10 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginResponseDto {
+public class RefreshTokenResponseDto {
 
   private String tokenType;
   private String accessToken;
+  private Instant expiresAt;
   private String refreshToken;
-  private long expiresIn;
-  private UserResponseDto user;
 }

--- a/user-service/src/main/java/com/tychewealth/dto/user/request/RefreshTokenRequestDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/user/request/RefreshTokenRequestDto.java
@@ -1,5 +1,6 @@
-package com.tychewealth.dto.user;
+package com.tychewealth.dto.user.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +10,8 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginResponseDto {
+public class RefreshTokenRequestDto {
 
-  private String tokenType;
-  private String accessToken;
+  @NotBlank(message = "Refresh token cannot be blank")
   private String refreshToken;
-  private long expiresIn;
-  private UserResponseDto user;
 }

--- a/user-service/src/main/java/com/tychewealth/entity/RefreshTokenEntity.java
+++ b/user-service/src/main/java/com/tychewealth/entity/RefreshTokenEntity.java
@@ -1,0 +1,53 @@
+package com.tychewealth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "refresh_tokens")
+public class RefreshTokenEntity {
+
+  @Id
+  @SequenceGenerator(
+      name = "refresh_token_seq_gen",
+      sequenceName = "refresh_token_seq",
+      allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "refresh_token_seq_gen")
+  private Long id;
+
+  @Column(name = "token", nullable = false, unique = true, length = 200)
+  private String token;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private UserEntity user;
+
+  @Column(name = "expires_at", nullable = false)
+  private Instant expiresAt;
+
+  @Column(name = "revoked")
+  private boolean revoked;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @PrePersist
+  void onCreate() {
+    createdAt = Instant.now();
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
@@ -24,7 +24,9 @@ public enum ErrorDefinition {
   AUTH_LOGIN_PASSWORD_FORMAT_INVALID(
       "TYCHE-102",
       "AUTH_LOGIN_PASSWORD_FORMAT_INVALID",
-      "Password must be 8-72 characters and include at least one uppercase letter, one lowercase letter, one number, and one symbol");
+      "Password must be 8-72 characters and include at least one uppercase letter, one lowercase letter, one number, and one symbol"),
+  AUTH_REFRESH_TOKEN_INVALID(
+      "TYCHE-103", "AUTH_REFRESH_TOKEN_INVALID", "The provided refresh token is invalid");
 
   private final String code;
   private final String type;

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -37,6 +38,15 @@ public class ErrorHandler {
   @ExceptionHandler(ConstraintViolationException.class)
   public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
     return build(ErrorDefinition.GENERIC_VALIDATION_ERROR, HttpStatus.BAD_REQUEST, ex.getMessage());
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
+      HttpMessageNotReadableException ex) {
+    return build(
+        ErrorDefinition.GENERIC_BAD_REQUEST,
+        HttpStatus.BAD_REQUEST,
+        ErrorDefinition.GENERIC_BAD_REQUEST.getDescription());
   }
 
   @ExceptionHandler(ResponseStatusException.class)

--- a/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
@@ -1,0 +1,20 @@
+package com.tychewealth.repository;
+
+import com.tychewealth.entity.RefreshTokenEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
+
+  Optional<RefreshTokenEntity> findByToken(String token);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "update RefreshTokenEntity rt set rt.revoked = true where rt.user.id = :userId and rt.revoked = false")
+  int revokeActiveTokensByUserId(@Param("userId") Long userId);
+}

--- a/user-service/src/main/java/com/tychewealth/service/AuthService.java
+++ b/user-service/src/main/java/com/tychewealth/service/AuthService.java
@@ -1,8 +1,10 @@
 package com.tychewealth.service;
 
 import com.tychewealth.dto.user.LoginResponseDto;
+import com.tychewealth.dto.user.RefreshTokenResponseDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.dto.user.request.LoginRequestDto;
+import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
 
 public interface AuthService {
@@ -10,4 +12,6 @@ public interface AuthService {
   UserResponseDto register(RegisterRequestDto register);
 
   LoginResponseDto login(LoginRequestDto login);
+
+  RefreshTokenResponseDto refresh(RefreshTokenRequestDto refreshTokenRequestDto);
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthLoginHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthLoginHelper.java
@@ -6,6 +6,7 @@ import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.mapper.user.UserMapper;
 import com.tychewealth.service.token.AuthTokenPayload;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,11 +17,16 @@ import org.springframework.stereotype.Component;
 public class AuthLoginHelper {
 
   private final AuthTokenHelper authTokenHelper;
+  private final AuthRefreshTokenHelper refreshTokenHelper;
   private final UserMapper userMapper;
 
   public LoginResponseDto login(UserEntity user) {
     UserResponseDto response = userMapper.toDto(user);
     AuthTokenPayload tokenPayload = authTokenHelper.generateAccessToken(user);
+    refreshTokenHelper.revokeActiveTokensByUserId(user.getId());
+    String refreshToken = refreshTokenHelper.generateRefreshToken();
+    Instant refreshTokenExpiresAt = refreshTokenHelper.calculateRefreshTokenExpiration();
+    refreshTokenHelper.saveToken(user, refreshToken, refreshTokenExpiresAt);
 
     log.info(
         LogConstants.REQUEST_SUCCESS + LogConstants.LOGIN_USER_ID,
@@ -29,6 +35,10 @@ public class AuthLoginHelper {
         user.getId());
 
     return new LoginResponseDto(
-        tokenPayload.tokenType(), tokenPayload.accessToken(), tokenPayload.expiresIn(), response);
+        tokenPayload.tokenType(),
+        tokenPayload.accessToken(),
+        refreshToken,
+        tokenPayload.expiresIn(),
+        response);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
@@ -1,0 +1,70 @@
+package com.tychewealth.service.helper;
+
+import static com.tychewealth.constants.AuthConstants.REFRESH_TOKEN_BYTE_LENGTH;
+
+import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.repository.RefreshTokenRepository;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AuthRefreshTokenHelper {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final SecureRandom secureRandom = new SecureRandom();
+  private final long refreshTokenTtlSeconds;
+
+  public AuthRefreshTokenHelper(
+      RefreshTokenRepository refreshTokenRepository,
+      @Value("${app.auth.jwt.refresh-token-ttl-seconds:1209600}") long refreshTokenTtlSeconds) {
+    this.refreshTokenRepository = refreshTokenRepository;
+    this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
+  }
+
+  public void saveToken(UserEntity user, String token, Instant expiresAt) {
+    RefreshTokenEntity refreshToken = new RefreshTokenEntity();
+
+    refreshToken.setUser(user);
+    refreshToken.setToken(token);
+    refreshToken.setExpiresAt(expiresAt);
+    refreshToken.setRevoked(false);
+
+    refreshTokenRepository.save(refreshToken);
+  }
+
+  @Transactional
+  public int revokeActiveTokensByUserId(Long userId) {
+    return refreshTokenRepository.revokeActiveTokensByUserId(userId);
+  }
+
+  @Transactional
+  public boolean revokeToken(String token) {
+    return refreshTokenRepository
+        .findByToken(token)
+        .map(
+            refreshToken -> {
+              if (refreshToken.isRevoked()) {
+                return false;
+              }
+              refreshToken.setRevoked(true);
+              refreshTokenRepository.save(refreshToken);
+              return true;
+            })
+        .orElse(false);
+  }
+
+  public String generateRefreshToken() {
+    byte[] tokenBytes = new byte[REFRESH_TOKEN_BYTE_LENGTH];
+    secureRandom.nextBytes(tokenBytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+  }
+
+  public Instant calculateRefreshTokenExpiration() {
+    return Instant.now().plusSeconds(refreshTokenTtlSeconds);
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthTokenHelper.java
@@ -21,7 +21,7 @@ public class AuthTokenHelper {
 
   public AuthTokenHelper(
       @Value("${app.auth.jwt.secret}") String jwtSecret,
-      @Value("${app.auth.jwt.access-token-ttl-seconds:3600}") long accessTokenTtlSeconds) {
+      @Value("${app.auth.jwt.access-token-ttl-seconds:900}") long accessTokenTtlSeconds) {
 
     if (accessTokenTtlSeconds <= 0)
       throw new IllegalArgumentException(

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthValidationHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthValidationHelper.java
@@ -4,18 +4,23 @@ import static com.tychewealth.constants.AuthConstants.LOGIN_PASSWORD_POLICY;
 
 import com.tychewealth.constants.LogConstants;
 import com.tychewealth.dto.user.request.LoginRequestDto;
+import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
+import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.utils.Utils;
+import java.time.Instant;
 import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Component
@@ -25,6 +30,7 @@ public class AuthValidationHelper {
   private static final Pattern LOGIN_PASSWORD_PATTERN = Pattern.compile(LOGIN_PASSWORD_POLICY);
 
   private final UserRepository userRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
 
   public void validateRegisterRequest(RegisterRequestDto register) {
@@ -112,5 +118,46 @@ public class AuthValidationHelper {
       throw new AuthException(
           ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, null, HttpStatus.UNAUTHORIZED);
     }
+  }
+
+  public RefreshTokenEntity validateRefreshToken(RefreshTokenRequestDto refreshTokenRequestDto) {
+    if (refreshTokenRequestDto == null
+        || !StringUtils.hasText(refreshTokenRequestDto.getRefreshToken())) {
+      log.warn(
+          LogConstants.REQUEST_CONFLICT,
+          LogConstants.AUTH,
+          LogConstants.REFRESH_TOKEN_ACTION,
+          LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
+
+      throw new AuthException(
+          ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
+    }
+
+    RefreshTokenEntity token =
+        refreshTokenRepository
+            .findByToken(refreshTokenRequestDto.getRefreshToken())
+            .orElseThrow(
+                () -> {
+                  log.warn(
+                      LogConstants.REQUEST_CONFLICT,
+                      LogConstants.AUTH,
+                      LogConstants.REFRESH_TOKEN_ACTION,
+                      LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
+                  return new AuthException(
+                      ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
+                });
+
+    if (token.isRevoked() || token.getExpiresAt().isBefore(Instant.now())) {
+      log.warn(
+          LogConstants.REQUEST_CONFLICT,
+          LogConstants.AUTH,
+          LogConstants.REFRESH_TOKEN_ACTION,
+          LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
+
+      throw new AuthException(
+          ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
+    }
+
+    return token;
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -5,16 +5,23 @@ import static com.tychewealth.constants.AuthConstants.USERNAME_CONSTRAINT;
 
 import com.tychewealth.constants.LogConstants;
 import com.tychewealth.dto.user.LoginResponseDto;
+import com.tychewealth.dto.user.RefreshTokenResponseDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.dto.user.request.LoginRequestDto;
+import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
+import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.service.AuthService;
 import com.tychewealth.service.helper.AuthLoginHelper;
+import com.tychewealth.service.helper.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.AuthRegisterHelper;
+import com.tychewealth.service.helper.AuthTokenHelper;
 import com.tychewealth.service.helper.AuthValidationHelper;
+import com.tychewealth.service.token.AuthTokenPayload;
+import java.time.Instant;
 import java.util.Locale;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +29,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -31,6 +39,8 @@ public class AuthServiceImpl implements AuthService {
   private final AuthValidationHelper authValidationHelper;
   private final AuthRegisterHelper authRegisterHelper;
   private final AuthLoginHelper authLoginHelper;
+  private final AuthRefreshTokenHelper authRefreshTokenHelper;
+  private final AuthTokenHelper authTokenHelper;
 
   @Override
   public UserResponseDto register(RegisterRequestDto register) {
@@ -58,6 +68,29 @@ public class AuthServiceImpl implements AuthService {
   public LoginResponseDto login(LoginRequestDto login) {
     UserEntity user = authValidationHelper.validateLoginRequest(login);
     return authLoginHelper.login(user);
+  }
+
+  @Override
+  @Transactional
+  public RefreshTokenResponseDto refresh(RefreshTokenRequestDto refreshTokenRequestDto) {
+    RefreshTokenEntity currentRefreshToken =
+        authValidationHelper.validateRefreshToken(refreshTokenRequestDto);
+
+    authRefreshTokenHelper.revokeToken(currentRefreshToken.getToken());
+
+    UserEntity user = currentRefreshToken.getUser();
+    AuthTokenPayload accessTokenPayload = authTokenHelper.generateAccessToken(user);
+
+    String newRefreshToken = authRefreshTokenHelper.generateRefreshToken();
+    Instant newRefreshTokenExpiration = authRefreshTokenHelper.calculateRefreshTokenExpiration();
+    authRefreshTokenHelper.saveToken(user, newRefreshToken, newRefreshTokenExpiration);
+
+    Instant accessTokenExpiration = Instant.now().plusSeconds(accessTokenPayload.expiresIn());
+    return new RefreshTokenResponseDto(
+        accessTokenPayload.tokenType(),
+        accessTokenPayload.accessToken(),
+        accessTokenExpiration,
+        newRefreshToken);
   }
 
   private boolean isUserUniqueConstraintViolation(Throwable throwable) {

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -21,4 +21,5 @@ spring.jpa.show-sql=true
 
 # JWT login token config
 app.auth.jwt.secret=${JWT_SECRET}
-app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:3600}
+app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
+app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}

--- a/user-service/src/main/resources/db.changelog/changelog-master.xml
+++ b/user-service/src/main/resources/db.changelog/changelog-master.xml
@@ -8,5 +8,6 @@
     <include file="user-changelog/user-changelog-master.xml" relativeToChangelogFile="true"/>
     <include file="portfolio-changelog/portfolio-changelog-master.xml" relativeToChangelogFile="true"/>
     <include file="asset-changelog/asset-changelog-master.xml" relativeToChangelogFile="true"/>
+    <include file="refresh-token-changelog/refresh-token-changelog-master.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/user-service/src/main/resources/db.changelog/refresh-token-changelog/refresh-token-changelog-dll.xml
+++ b/user-service/src/main/resources/db.changelog/refresh-token-changelog/refresh-token-changelog-dll.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="create-refresh-token-sequence" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <sequenceExists sequenceName="refresh_token_seq"/>
+            </not>
+        </preConditions>
+
+        <createSequence sequenceName="refresh_token_seq" startValue="1" incrementBy="1"/>
+
+        <rollback>
+            <dropSequence sequenceName="refresh_token_seq"/>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="create-refresh-token-table" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <tableExists tableName="refresh_tokens"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="refresh_tokens">
+            <column name="id" type="BIGINT" defaultValueSequenceNext="refresh_token_seq">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="token" type="VARCHAR(200)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="uk_refresh_token"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="expires_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="revoked" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="refresh_tokens"
+                baseColumnNames="user_id"
+                constraintName="fk_refresh_tokens_users"
+                referencedTableName="users"
+                referencedColumnNames="id"/>
+
+        <rollback>
+            <dropTable tableName="refresh_tokens"/>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="create-refresh-tokens-user-id-index" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <indexExists indexName="idx_refresh_tokens_user_id" tableName="refresh_tokens"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="idx_refresh_tokens_user_id" tableName="refresh_tokens">
+            <column name="user_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_refresh_tokens_user_id" tableName="refresh_tokens"/>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/user-service/src/main/resources/db.changelog/refresh-token-changelog/refresh-token-changelog-master.xml
+++ b/user-service/src/main/resources/db.changelog/refresh-token-changelog/refresh-token-changelog-master.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <include file="refresh-token-changelog-dll.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -1,0 +1,36 @@
+package com.tychewealth.config;
+
+import com.tychewealth.controller.impl.AuthApiController;
+import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.handler.ErrorHandler;
+import com.tychewealth.mapper.user.UserMapper;
+import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.helper.*;
+import com.tychewealth.service.impl.AuthServiceImpl;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(IntegrationTestConfig.class)
+@ComponentScan(
+    basePackageClasses = {
+      AuthApiController.class,
+      AuthServiceImpl.class,
+      AuthValidationHelper.class,
+      AuthRegisterHelper.class,
+      AuthLoginHelper.class,
+      AuthTokenHelper.class,
+      AuthRefreshTokenHelper.class,
+      ErrorHandler.class,
+      UserMapper.class
+    })
+@EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
+@EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
+public class AuthIntegrationTestConfig {}

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -1,7 +1,11 @@
 package com.tychewealth.controller;
 
 import static com.tychewealth.constants.ApiConstants.URL_FOLDER_V1;
+import static com.tychewealth.testdata.EntityBuilder.buildRefreshToken;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,11 +14,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tychewealth.config.IntegrationTestConfig;
+import com.tychewealth.config.AuthIntegrationTestConfig;
+import com.tychewealth.dto.user.LoginResponseDto;
+import com.tychewealth.dto.user.RefreshTokenResponseDto;
 import com.tychewealth.dto.user.request.LoginRequestDto;
+import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
+import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
+import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,24 +32,26 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(
+    classes = AuthIntegrationTestConfig.class,
+    properties = "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=")
 @AutoConfigureMockMvc
-@Import(IntegrationTestConfig.class)
 class AuthApiControllerIntegrationTest {
 
   private static final String REGISTER_URL = URL_FOLDER_V1 + "/auth/register";
   private static final String LOGIN_URL = URL_FOLDER_V1 + "/auth/login";
+  private static final String REFRESH_URL = URL_FOLDER_V1 + "/auth/refresh";
 
   @Autowired private MockMvc mockMvc;
 
   @Autowired private ObjectMapper objectMapper;
 
   @Autowired private UserRepository userRepository;
+  @Autowired private RefreshTokenRepository refreshTokenRepository;
 
   @Autowired private PasswordEncoder passwordEncoder;
 
@@ -53,6 +65,7 @@ class AuthApiControllerIntegrationTest {
 
   @BeforeEach
   void setUp() {
+    refreshTokenRepository.deleteAll();
     userRepository.deleteAll();
     validRequest =
         new RegisterRequestDto("laura.gomez@tychewealth.com", "lauragomez", "Secret123!");
@@ -159,6 +172,7 @@ class AuthApiControllerIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.tokenType").value("Bearer"))
         .andExpect(jsonPath("$.accessToken").isString())
+        .andExpect(jsonPath("$.refreshToken").isString())
         .andExpect(jsonPath("$.expiresIn").isNumber())
         .andExpect(jsonPath("$.user.id").isNumber())
         .andExpect(jsonPath("$.user.email").value(validRequest.getEmail()))
@@ -179,8 +193,63 @@ class AuthApiControllerIntegrationTest {
                 .content(objectMapper.writeValueAsString(invalidLoginRequest)))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value("TYCHE-101"))
-        .andExpect(jsonPath("$.type").value("AUTH_LOGIN_CONFLICT"))
+        .andExpect(jsonPath("$.type").value("AUTH_LOGIN_INVALID_CREDENTIALS"))
         .andExpect(jsonPath("$.description").value("The provided login credentials are invalid"));
+  }
+
+  @Test
+  void secondLoginRevokesPreviousRefreshToken() throws Exception {
+    userRepository.save(existingLoginUser);
+
+    String firstLoginBody =
+        mockMvc
+            .perform(
+                post(LOGIN_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(validLoginRequest)))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    LoginResponseDto firstLoginResponse =
+        objectMapper.readValue(firstLoginBody, LoginResponseDto.class);
+
+    String secondLoginBody =
+        mockMvc
+            .perform(
+                post(LOGIN_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(validLoginRequest)))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    LoginResponseDto secondLoginResponse =
+        objectMapper.readValue(secondLoginBody, LoginResponseDto.class);
+    assertNotEquals(firstLoginResponse.getRefreshToken(), secondLoginResponse.getRefreshToken());
+
+    mockMvc
+        .perform(
+            post(REFRESH_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshTokenRequestDto(firstLoginResponse.getRefreshToken()))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("TYCHE-103"))
+        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"));
+
+    mockMvc
+        .perform(
+            post(REFRESH_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshTokenRequestDto(secondLoginResponse.getRefreshToken()))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.refreshToken").isString());
   }
 
   @ParameterizedTest
@@ -196,5 +265,125 @@ class AuthApiControllerIntegrationTest {
         .andExpect(jsonPath("$.code").value("TYCHE-002"))
         .andExpect(jsonPath("$.type").value("GENERIC_VALIDATION_ERROR"))
         .andExpect(jsonPath("$.description").value(containsString(expectedMessage)));
+  }
+
+  @Test
+  void refreshRotatesTokensWhenRefreshTokenIsValid() throws Exception {
+    UserEntity user = userRepository.save(buildUser("refresh.user@tychewealth.com", "refreshuser"));
+    String previousTokenValue = "existing-refresh-token";
+    RefreshTokenEntity previousToken =
+        refreshTokenRepository.save(
+            buildRefreshToken(previousTokenValue, user, Instant.now().plusSeconds(3600), false));
+
+    String responseBody =
+        mockMvc
+            .perform(
+                post(REFRESH_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(
+                            new RefreshTokenRequestDto(previousTokenValue))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.tokenType").value("Bearer"))
+            .andExpect(jsonPath("$.accessToken").isString())
+            .andExpect(jsonPath("$.expiresAt").exists())
+            .andExpect(jsonPath("$.refreshToken").isString())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    RefreshTokenResponseDto refreshResponse =
+        objectMapper.readValue(responseBody, RefreshTokenResponseDto.class);
+
+    assertNotEquals(previousTokenValue, refreshResponse.getRefreshToken());
+    assertTrue(refreshTokenRepository.findByToken(refreshResponse.getRefreshToken()).isPresent());
+    assertFalse(
+        refreshTokenRepository
+            .findByToken(refreshResponse.getRefreshToken())
+            .orElseThrow()
+            .isRevoked());
+    assertTrue(refreshTokenRepository.findByToken(previousTokenValue).orElseThrow().isRevoked());
+    assertEquals(
+        previousToken.getUser().getId(),
+        refreshTokenRepository
+            .findByToken(refreshResponse.getRefreshToken())
+            .orElseThrow()
+            .getUser()
+            .getId());
+  }
+
+  @Test
+  void refreshReturnsUnauthorizedWhenRefreshTokenDoesNotExist() throws Exception {
+    mockMvc
+        .perform(
+            post(REFRESH_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(new RefreshTokenRequestDto("missing-token"))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("TYCHE-103"))
+        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"))
+        .andExpect(jsonPath("$.description").value("The provided refresh token is invalid"));
+  }
+
+  @Test
+  void refreshReturnsUnauthorizedWhenRefreshTokenIsRevoked() throws Exception {
+    UserEntity user =
+        userRepository.save(buildUser("refresh.revoked@tychewealth.com", "refreshrevoked"));
+    refreshTokenRepository.save(
+        buildRefreshToken("revoked-refresh-token", user, Instant.now().plusSeconds(3600), true));
+
+    mockMvc
+        .perform(
+            post(REFRESH_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshTokenRequestDto("revoked-refresh-token"))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("TYCHE-103"))
+        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"))
+        .andExpect(jsonPath("$.description").value("The provided refresh token is invalid"));
+  }
+
+  @Test
+  void refreshReturnsUnauthorizedWhenRefreshTokenIsExpired() throws Exception {
+    UserEntity user =
+        userRepository.save(buildUser("refresh.expired@tychewealth.com", "refreshexpired"));
+    refreshTokenRepository.save(
+        buildRefreshToken("expired-refresh-token", user, Instant.now().minusSeconds(5), false));
+
+    mockMvc
+        .perform(
+            post(REFRESH_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshTokenRequestDto("expired-refresh-token"))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("TYCHE-103"))
+        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"))
+        .andExpect(jsonPath("$.description").value("The provided refresh token is invalid"));
+  }
+
+  @Test
+  void refreshReturnsBadRequestWhenPayloadIsInvalid() throws Exception {
+    mockMvc
+        .perform(
+            post(REFRESH_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"refreshToken\":\" \"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("TYCHE-002"))
+        .andExpect(jsonPath("$.type").value("GENERIC_VALIDATION_ERROR"));
+  }
+
+  @Test
+  void refreshReturnsBadRequestWhenRequestBodyIsEmpty() throws Exception {
+    mockMvc
+        .perform(post(REFRESH_URL).contentType(MediaType.APPLICATION_JSON).content(""))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("TYCHE-003"))
+        .andExpect(jsonPath("$.type").value("GENERIC_BAD_REQUEST"));
   }
 }

--- a/user-service/src/test/java/com/tychewealth/repository/AssetRepositoryTest.java
+++ b/user-service/src/test/java/com/tychewealth/repository/AssetRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.tychewealth.repository;
 
+import static com.tychewealth.testdata.EntityBuilder.buildAsset;
+import static com.tychewealth.testdata.EntityBuilder.buildPortfolio;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,7 +15,6 @@ import com.tychewealth.enums.CurrencyCodeEnum;
 import com.tychewealth.enums.InvestmentHorizonEnum;
 import com.tychewealth.enums.RiskProfileEnum;
 import com.tychewealth.enums.StrategyTypeEnum;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,47 +102,5 @@ class AssetRepositoryTest {
     Boolean exists = assetRepository.existsByPortfolioIdAndSymbol(portfolio.getId(), "TSLA");
 
     assertEquals(Boolean.TRUE, exists);
-  }
-
-  private UserEntity buildUser(String email, String username) {
-    UserEntity user = new UserEntity();
-    user.setEmail(email);
-    user.setUsername(username);
-    user.setPassword("secret123");
-    return user;
-  }
-
-  private PortfolioEntity buildPortfolio(
-      UserEntity user,
-      String name,
-      CurrencyCodeEnum currency,
-      RiskProfileEnum riskProfile,
-      StrategyTypeEnum strategyType,
-      InvestmentHorizonEnum investmentHorizon) {
-    PortfolioEntity item = new PortfolioEntity();
-    item.setUser(user);
-    item.setName(name);
-    item.setDescription(name + " description");
-    item.setBaseCurrency(currency);
-    item.setRiskProfile(riskProfile);
-    item.setInvestmentHorizon(investmentHorizon);
-    item.setStrategyType(strategyType);
-    item.setMaxRisk(new BigDecimal("0.40"));
-    return item;
-  }
-
-  private AssetEntity buildAsset(
-      PortfolioEntity portfolio,
-      String symbol,
-      AssetTypeEnum assetType,
-      CurrencyCodeEnum currency) {
-    AssetEntity item = new AssetEntity();
-    item.setPortfolio(portfolio);
-    item.setSymbol(symbol);
-    item.setAssetType(assetType);
-    item.setQuantity(new BigDecimal("10.00000000"));
-    item.setAveragePrice(new BigDecimal("123.4567"));
-    item.setCurrency(currency);
-    return item;
   }
 }

--- a/user-service/src/test/java/com/tychewealth/repository/PortfolioRepositoryTest.java
+++ b/user-service/src/test/java/com/tychewealth/repository/PortfolioRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.tychewealth.repository;
 
+import static com.tychewealth.testdata.EntityBuilder.buildPortfolio;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,7 +12,6 @@ import com.tychewealth.enums.CurrencyCodeEnum;
 import com.tychewealth.enums.InvestmentHorizonEnum;
 import com.tychewealth.enums.RiskProfileEnum;
 import com.tychewealth.enums.StrategyTypeEnum;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,31 +160,5 @@ class PortfolioRepositoryTest {
     Boolean exists = portfolioRepository.existsByUserIdAndName(user.getId(), "Retiro");
 
     assertEquals(Boolean.TRUE, exists);
-  }
-
-  private UserEntity buildUser(String email, String username) {
-    user.setEmail(email);
-    user.setUsername(username);
-    user.setPassword("secret123");
-    return user;
-  }
-
-  private PortfolioEntity buildPortfolio(
-      UserEntity user,
-      String name,
-      CurrencyCodeEnum currency,
-      RiskProfileEnum riskProfile,
-      StrategyTypeEnum strategyType,
-      InvestmentHorizonEnum investmentHorizon) {
-    PortfolioEntity portfolio = new PortfolioEntity();
-    portfolio.setUser(user);
-    portfolio.setName(name);
-    portfolio.setDescription(name + " description");
-    portfolio.setBaseCurrency(currency);
-    portfolio.setRiskProfile(riskProfile);
-    portfolio.setInvestmentHorizon(investmentHorizon);
-    portfolio.setStrategyType(strategyType);
-    portfolio.setMaxRisk(new BigDecimal("0.40"));
-    return portfolio;
   }
 }

--- a/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
+++ b/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,59 @@
+package com.tychewealth.repository;
+
+import static com.tychewealth.testdata.EntityBuilder.buildRefreshToken;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.UserEntity;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest(
+    properties = {"spring.liquibase.enabled=false", "spring.jpa.hibernate.ddl-auto=create-drop"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class RefreshTokenRepositoryTest {
+
+  @Autowired private RefreshTokenRepository refreshTokenRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Test
+  void findByTokenReturnsSavedToken() {
+    UserEntity user = userRepository.save(buildUser("lucia@tyche.com", "lucia"));
+    Instant expiresAt = Instant.now().plusSeconds(3600);
+    refreshTokenRepository.save(buildRefreshToken("refresh-token-123", user, expiresAt, false));
+
+    Optional<RefreshTokenEntity> result = refreshTokenRepository.findByToken("refresh-token-123");
+
+    assertTrue(result.isPresent());
+    assertEquals(user.getId(), result.get().getUser().getId());
+    assertEquals(expiresAt, result.get().getExpiresAt());
+    assertFalse(result.get().isRevoked());
+  }
+
+  @Test
+  void findByTokenReturnsEmptyWhenTokenDoesNotExist() {
+    Optional<RefreshTokenEntity> result = refreshTokenRepository.findByToken("missing-token");
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void saveAssignsIdAndCreatedAt() {
+    UserEntity user = userRepository.save(buildUser("marco@tyche.com", "marco"));
+    RefreshTokenEntity saved =
+        refreshTokenRepository.save(
+            buildRefreshToken("refresh-token-456", user, Instant.now().plusSeconds(1800), false));
+
+    assertNotNull(saved.getId());
+    assertNotNull(saved.getCreatedAt());
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/repository/UserRepositoryTest.java
+++ b/user-service/src/test/java/com/tychewealth/repository/UserRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.tychewealth.repository;
 
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,13 +38,5 @@ class UserRepositoryTest {
 
     assertTrue(result.isPresent());
     assertEquals("carlos@tyche.com", result.get().getEmail());
-  }
-
-  private UserEntity buildUser(String email, String username) {
-    UserEntity user = new UserEntity();
-    user.setEmail(email);
-    user.setUsername(username);
-    user.setPassword("secret123");
-    return user;
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testdata/AuthTestData.java
+++ b/user-service/src/test/java/com/tychewealth/testdata/AuthTestData.java
@@ -12,21 +12,21 @@ public final class AuthTestData {
   public static Stream<Arguments> invalidCreateRequests() {
     return Stream.of(
         Arguments.of(
-            new RegisterRequestDto(" ", "validuser", "Secret123"), "Email cannot be blank"),
+            new RegisterRequestDto(" ", "validuser", "Secret123!"), "Email cannot be blank"),
         Arguments.of(
-            new RegisterRequestDto("not-an-email", "validuser", "Secret123"),
+            new RegisterRequestDto("not-an-email", "validuser", "Secret123!"),
             "Email format is invalid"),
         Arguments.of(
-            new RegisterRequestDto(buildLongEmail(), "validuser", "Secret123"),
+            new RegisterRequestDto(buildLongEmail(), "validuser", "Secret123!"),
             "Email must be at most 254 characters"),
         Arguments.of(
-            new RegisterRequestDto("valid@tychewealth.com", " ", "Secret123"),
+            new RegisterRequestDto("valid@tychewealth.com", " ", "Secret123!"),
             "Username cannot be blank"),
         Arguments.of(
-            new RegisterRequestDto("valid@tychewealth.com", "ab", "Secret123"),
+            new RegisterRequestDto("valid@tychewealth.com", "ab", "Secret123!"),
             "Username must be between 3 and 30 characters"),
         Arguments.of(
-            new RegisterRequestDto("valid@tychewealth.com", "a".repeat(31), "Secret123"),
+            new RegisterRequestDto("valid@tychewealth.com", "a".repeat(31), "Secret123!"),
             "Username must be between 3 and 30 characters"),
         Arguments.of(
             new RegisterRequestDto("valid@tychewealth.com", "validuser", " "),
@@ -56,8 +56,9 @@ public final class AuthTestData {
   }
 
   private static String buildLongEmail() {
-    String domain = "@tychewealth.com";
-    int localLength = 254 - domain.length();
-    return "a".repeat(localLength) + domain;
+    String local = "a".repeat(64);
+    String label63 = "b".repeat(63);
+    String domain = label63 + "." + label63 + "." + label63 + ".es";
+    return local + "@" + domain;
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testdata/EntityBuilder.java
+++ b/user-service/src/test/java/com/tychewealth/testdata/EntityBuilder.java
@@ -1,0 +1,70 @@
+package com.tychewealth.testdata;
+
+import com.tychewealth.entity.AssetEntity;
+import com.tychewealth.entity.PortfolioEntity;
+import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AssetTypeEnum;
+import com.tychewealth.enums.CurrencyCodeEnum;
+import com.tychewealth.enums.InvestmentHorizonEnum;
+import com.tychewealth.enums.RiskProfileEnum;
+import com.tychewealth.enums.StrategyTypeEnum;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public final class EntityBuilder {
+
+  private EntityBuilder() {}
+
+  public static UserEntity buildUser(String email, String username) {
+    UserEntity user = new UserEntity();
+    user.setEmail(email);
+    user.setUsername(username);
+    user.setPassword("secret123");
+    return user;
+  }
+
+  public static PortfolioEntity buildPortfolio(
+      UserEntity user,
+      String name,
+      CurrencyCodeEnum currency,
+      RiskProfileEnum riskProfile,
+      StrategyTypeEnum strategyType,
+      InvestmentHorizonEnum investmentHorizon) {
+    PortfolioEntity portfolio = new PortfolioEntity();
+    portfolio.setUser(user);
+    portfolio.setName(name);
+    portfolio.setDescription(name + " description");
+    portfolio.setBaseCurrency(currency);
+    portfolio.setRiskProfile(riskProfile);
+    portfolio.setInvestmentHorizon(investmentHorizon);
+    portfolio.setStrategyType(strategyType);
+    portfolio.setMaxRisk(new BigDecimal("0.40"));
+    return portfolio;
+  }
+
+  public static RefreshTokenEntity buildRefreshToken(
+      String token, UserEntity user, Instant expiresAt, boolean revoked) {
+    RefreshTokenEntity refreshToken = new RefreshTokenEntity();
+    refreshToken.setToken(token);
+    refreshToken.setUser(user);
+    refreshToken.setExpiresAt(expiresAt);
+    refreshToken.setRevoked(revoked);
+    return refreshToken;
+  }
+
+  public static AssetEntity buildAsset(
+      PortfolioEntity portfolio,
+      String symbol,
+      AssetTypeEnum assetType,
+      CurrencyCodeEnum currency) {
+    AssetEntity asset = new AssetEntity();
+    asset.setPortfolio(portfolio);
+    asset.setSymbol(symbol);
+    asset.setAssetType(assetType);
+    asset.setQuantity(new BigDecimal("10.00000000"));
+    asset.setAveragePrice(new BigDecimal("123.4567"));
+    asset.setCurrency(currency);
+    return asset;
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Refresh token mechanism added—users can now obtain new access tokens without re-logging in
  * New `/refresh` endpoint available for token refresh operations
  * Login responses now include refresh tokens

* **Improvements**
  * Access token lifetime reduced to 15 minutes (previously 1 hour)
  * Enhanced error handling for malformed API requests

Closes #13 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->