### PR TITLE
[TYCHE-08] Implement auth rate limit interceptor and metrics for login, register and refresh

### DIFF
--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -113,6 +113,10 @@
             <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/user-service/src/main/java/com/tychewealth/config/AuthRateLimitProperties.java
+++ b/user-service/src/main/java/com/tychewealth/config/AuthRateLimitProperties.java
@@ -1,0 +1,30 @@
+package com.tychewealth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.auth")
+public class AuthRateLimitProperties {
+
+  private RateLimit loginRateLimit = new RateLimit(10, 60);
+  private RateLimit registerRateLimit = new RateLimit(5, 300);
+  private RateLimit refreshRateLimit = new RateLimit(10, 60);
+
+  @Getter
+  @Setter
+  public static class RateLimit {
+
+    private int maxRequests;
+    private long windowSeconds;
+
+    public RateLimit() {}
+
+    public RateLimit(int maxRequests, long windowSeconds) {
+      this.maxRequests = maxRequests;
+      this.windowSeconds = windowSeconds;
+    }
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/config/AuthRateLimitProperties.java
+++ b/user-service/src/main/java/com/tychewealth/config/AuthRateLimitProperties.java
@@ -1,24 +1,31 @@
 package com.tychewealth.config;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 @Getter
 @Setter
+@Validated
 @ConfigurationProperties(prefix = "app.auth")
 public class AuthRateLimitProperties {
 
-  private RateLimit loginRateLimit = new RateLimit(10, 60);
-  private RateLimit registerRateLimit = new RateLimit(5, 300);
-  private RateLimit refreshRateLimit = new RateLimit(10, 60);
+  @Valid private RateLimit loginRateLimit = new RateLimit(10, 60);
+
+  @Valid private RateLimit registerRateLimit = new RateLimit(5, 300);
+
+  @Valid private RateLimit refreshRateLimit = new RateLimit(10, 60);
 
   @Getter
   @Setter
   public static class RateLimit {
 
-    private int maxRequests;
-    private long windowSeconds;
+    @Positive private int maxRequests;
+
+    @Positive private long windowSeconds;
 
     public RateLimit() {}
 

--- a/user-service/src/main/java/com/tychewealth/config/RefreshRateLimitConfig.java
+++ b/user-service/src/main/java/com/tychewealth/config/RefreshRateLimitConfig.java
@@ -1,0 +1,75 @@
+package com.tychewealth.config;
+
+import static com.tychewealth.constants.ApiConstants.AUTH_LOGIN_URL;
+import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
+import static com.tychewealth.constants.ApiConstants.AUTH_REGISTER_URL;
+
+import com.tychewealth.service.monitoring.AuthMetrics;
+import com.tychewealth.web.AuthRateLimitInterceptor;
+import com.tychewealth.web.RefreshRateLimitInterceptor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableConfigurationProperties(AuthRateLimitProperties.class)
+public class RefreshRateLimitConfig implements WebMvcConfigurer {
+
+  private final RefreshRateLimitInterceptor refreshRateLimitInterceptor;
+  private final AuthRateLimitInterceptor loginRateLimitInterceptor;
+  private final AuthRateLimitInterceptor registerRateLimitInterceptor;
+
+  public RefreshRateLimitConfig(AuthRateLimitProperties properties, AuthMetrics authMetrics) {
+    AuthRateLimitProperties.RateLimit login = properties.getLoginRateLimit();
+    AuthRateLimitProperties.RateLimit register = properties.getRegisterRateLimit();
+    AuthRateLimitProperties.RateLimit refresh = properties.getRefreshRateLimit();
+
+    this.loginRateLimitInterceptor =
+        new AuthRateLimitInterceptor(
+            login.getMaxRequests(),
+            login.getWindowSeconds(),
+            "Too many login requests",
+            ignored -> authMetrics.recordLoginRequest(),
+            ignored -> authMetrics.recordLoginRateLimited());
+    this.registerRateLimitInterceptor =
+        new AuthRateLimitInterceptor(
+            register.getMaxRequests(),
+            register.getWindowSeconds(),
+            "Too many register requests",
+            ignored -> authMetrics.recordRegisterRequest(),
+            ignored -> authMetrics.recordRegisterRateLimited());
+    this.refreshRateLimitInterceptor =
+        new RefreshRateLimitInterceptor(
+            refresh.getMaxRequests(), refresh.getWindowSeconds(), authMetrics);
+  }
+
+  @Bean
+  public AuthRateLimitInterceptor loginRateLimitInterceptor() {
+    return loginRateLimitInterceptor;
+  }
+
+  @Bean
+  public AuthRateLimitInterceptor registerRateLimitInterceptor() {
+    return registerRateLimitInterceptor;
+  }
+
+  @Bean
+  public RefreshRateLimitInterceptor refreshRateLimitInterceptor() {
+    return refreshRateLimitInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(registerRateLimitInterceptor).addPathPatterns(AUTH_REGISTER_URL);
+    registry.addInterceptor(loginRateLimitInterceptor).addPathPatterns(AUTH_LOGIN_URL);
+    registry.addInterceptor(refreshRateLimitInterceptor).addPathPatterns(AUTH_REFRESH_URL);
+  }
+
+  public void resetAll() {
+    registerRateLimitInterceptor.reset();
+    loginRateLimitInterceptor.reset();
+    refreshRateLimitInterceptor.reset();
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/config/RefreshRateLimitConfig.java
+++ b/user-service/src/main/java/com/tychewealth/config/RefreshRateLimitConfig.java
@@ -3,6 +3,8 @@ package com.tychewealth.config;
 import static com.tychewealth.constants.ApiConstants.AUTH_LOGIN_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REGISTER_URL;
+import static com.tychewealth.constants.AuthConstants.LOGIN_RATE_LIMIT_MESSAGE;
+import static com.tychewealth.constants.AuthConstants.REGISTER_RATE_LIMIT_MESSAGE;
 
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.web.AuthRateLimitInterceptor;
@@ -30,14 +32,14 @@ public class RefreshRateLimitConfig implements WebMvcConfigurer {
         new AuthRateLimitInterceptor(
             login.getMaxRequests(),
             login.getWindowSeconds(),
-            "Too many login requests",
+            LOGIN_RATE_LIMIT_MESSAGE,
             ignored -> authMetrics.recordLoginRequest(),
             ignored -> authMetrics.recordLoginRateLimited());
     this.registerRateLimitInterceptor =
         new AuthRateLimitInterceptor(
             register.getMaxRequests(),
             register.getWindowSeconds(),
-            "Too many register requests",
+            REGISTER_RATE_LIMIT_MESSAGE,
             ignored -> authMetrics.recordRegisterRequest(),
             ignored -> authMetrics.recordRegisterRateLimited());
     this.refreshRateLimitInterceptor =

--- a/user-service/src/main/java/com/tychewealth/constants/ApiConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/ApiConstants.java
@@ -7,6 +7,11 @@ public class ApiConstants {
   public static final String VERSION_1 = "/v1";
   public static final String URL_FOLDER_V1 = URL_FOLDER + VERSION_1;
 
+  public static final String AUTH_BASE_URL = URL_FOLDER_V1 + "/auth";
+  public static final String AUTH_REGISTER_URL = AUTH_BASE_URL + "/register";
+  public static final String AUTH_LOGIN_URL = AUTH_BASE_URL + "/login";
+  public static final String AUTH_REFRESH_URL = AUTH_BASE_URL + "/refresh";
+
   public static final String REQUEST_PRODUCES = MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8";
   public static final String REQUEST_CONSUMES = MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8";
 

--- a/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
@@ -12,5 +12,25 @@ public final class AuthConstants {
   public static final String TOKEN_TYPE_BEARER = "Bearer";
   public static final int REFRESH_TOKEN_BYTE_LENGTH = 32;
 
+  public static final String METRIC_AUTH_REGISTER_REQUESTS = "tyche.auth.register.requests";
+  public static final String METRIC_AUTH_REGISTER_SUCCESS = "tyche.auth.register.success";
+  public static final String METRIC_AUTH_REGISTER_FAILURE = "tyche.auth.register.failure";
+  public static final String METRIC_AUTH_REGISTER_RATE_LIMITED = "tyche.auth.register.rate_limited";
+  public static final String METRIC_AUTH_REGISTER_CONFLICT = "tyche.auth.register.conflict";
+
+  public static final String METRIC_AUTH_LOGIN_REQUESTS = "tyche.auth.login.requests";
+  public static final String METRIC_AUTH_LOGIN_SUCCESS = "tyche.auth.login.success";
+  public static final String METRIC_AUTH_LOGIN_FAILURE = "tyche.auth.login.failure";
+  public static final String METRIC_AUTH_LOGIN_RATE_LIMITED = "tyche.auth.login.rate_limited";
+  public static final String METRIC_AUTH_LOGIN_INVALID_CREDENTIALS =
+      "tyche.auth.login.invalid_credentials";
+
+  public static final String METRIC_AUTH_REFRESH_REQUESTS = "tyche.auth.refresh.requests";
+  public static final String METRIC_AUTH_REFRESH_SUCCESS = "tyche.auth.refresh.success";
+  public static final String METRIC_AUTH_REFRESH_FAILURE = "tyche.auth.refresh.failure";
+  public static final String METRIC_AUTH_REFRESH_RATE_LIMITED = "tyche.auth.refresh.rate_limited";
+  public static final String METRIC_AUTH_REFRESH_TOKEN_ISSUED = "tyche.auth.refresh_token.issued";
+  public static final String METRIC_AUTH_REFRESH_TOKEN_REVOKED = "tyche.auth.refresh_token.revoked";
+
   private AuthConstants() {}
 }

--- a/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
@@ -12,6 +12,10 @@ public final class AuthConstants {
   public static final String TOKEN_TYPE_BEARER = "Bearer";
   public static final int REFRESH_TOKEN_BYTE_LENGTH = 32;
 
+  public static final String LOGIN_RATE_LIMIT_MESSAGE = "Too many login requests";
+  public static final String REGISTER_RATE_LIMIT_MESSAGE = "Too many register requests";
+  public static final String REFRESH_RATE_LIMIT_MESSAGE = "Too many refresh token requests";
+
   public static final String METRIC_AUTH_REGISTER_REQUESTS = "tyche.auth.register.requests";
   public static final String METRIC_AUTH_REGISTER_SUCCESS = "tyche.auth.register.success";
   public static final String METRIC_AUTH_REGISTER_FAILURE = "tyche.auth.register.failure";

--- a/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -13,11 +13,11 @@ public final class LogConstants {
   public static final String REQUEST_START = BASE_LOG + " Request started";
   public static final String REQUEST_SUCCESS = BASE_LOG + " Request succeeded";
   public static final String REQUEST_CONFLICT = BASE_LOG + " Request rejected: {}";
-  public static final String INVALID_REFRESH_TOKEN_MESSAGE = "invalid refresh token";
   public static final String REGISTER_REQUEST_FIELDS = " username={}, email={}";
   public static final String LOGIN_REQUEST_FIELDS = " email={}";
   public static final String REGISTER_CREATED_USER_ID = " userId={}";
   public static final String LOGIN_USER_ID = " userId={}";
+  public static final String INVALID_REFRESH_TOKEN_MESSAGE = "invalid refresh token";
 
   private LogConstants() {}
 }

--- a/user-service/src/main/java/com/tychewealth/dto/user/RefreshTokenResponseDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/user/RefreshTokenResponseDto.java
@@ -1,6 +1,5 @@
 package com.tychewealth.dto.user;
 
-import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +13,6 @@ public class RefreshTokenResponseDto {
 
   private String tokenType;
   private String accessToken;
-  private Instant expiresAt;
+  private long expiresIn;
   private String refreshToken;
 }

--- a/user-service/src/main/java/com/tychewealth/entity/RefreshTokenEntity.java
+++ b/user-service/src/main/java/com/tychewealth/entity/RefreshTokenEntity.java
@@ -40,7 +40,7 @@ public class RefreshTokenEntity {
   @Column(name = "expires_at", nullable = false)
   private Instant expiresAt;
 
-  @Column(name = "revoked")
+  @Column(name = "revoked", nullable = false)
   private boolean revoked;
 
   @Column(name = "created_at", nullable = false)

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
@@ -13,6 +13,7 @@ public enum ErrorDefinition {
   CONFLICT("TYCHE-005", "CONFLICT", "The operation conflicts with current state"),
   UNAUTHORIZED("TYCHE-006", "UNAUTHORIZED", "Authentication is required"),
   FORBIDDEN("TYCHE-007", "FORBIDDEN", "You do not have permission to perform this action"),
+  RATE_LIMITED("TYCHE-008", "RATE_LIMITED", "Too many requests"),
 
   // AUTH
   AUTH_REGISTRATION_CONFLICT(

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
@@ -27,7 +27,11 @@ public enum ErrorDefinition {
       "AUTH_LOGIN_PASSWORD_FORMAT_INVALID",
       "Password must be 8-72 characters and include at least one uppercase letter, one lowercase letter, one number, and one symbol"),
   AUTH_REFRESH_TOKEN_INVALID(
-      "TYCHE-103", "AUTH_REFRESH_TOKEN_INVALID", "The provided refresh token is invalid");
+      "TYCHE-103", "AUTH_REFRESH_TOKEN_INVALID", "The provided refresh token is invalid"),
+  AUTH_REGISTER_PASSWORD_FORMAT_INVALID(
+      "TYCHE-104",
+      "AUTH_REGISTER_PASSWORD_FORMAT_INVALID",
+      "Password must be 8-72 characters and include at least one uppercase letter, one lowercase letter, one number, and one symbol");
 
   private final String code;
   private final String type;

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
@@ -95,6 +95,7 @@ public class ErrorHandler {
       case FORBIDDEN -> ErrorDefinition.FORBIDDEN;
       case NOT_FOUND -> ErrorDefinition.RESOURCE_NOT_FOUND;
       case CONFLICT -> ErrorDefinition.CONFLICT;
+      case TOO_MANY_REQUESTS -> ErrorDefinition.RATE_LIMITED;
       default -> ErrorDefinition.GENERIC_INTERNAL_ERROR;
     };
   }

--- a/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
@@ -18,8 +18,15 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity
   @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
-      "update RefreshTokenEntity rt set rt.revoked = true where rt.user.id = :userId and rt.revoked = false")
-  int revokeActiveTokensByUserId(@Param("userId") Long userId);
+      """
+      update RefreshTokenEntity rt
+         set rt.revoked = true
+       where rt.user.id = :userId
+         and rt.revoked = false
+         and rt.expiresAt > :currentTime
+      """)
+  int revokeActiveTokensByUserId(
+      @Param("userId") Long userId, @Param("currentTime") Instant currentTime);
 
   @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package com.tychewealth.repository;
 
 import com.tychewealth.entity.RefreshTokenEntity;
+import java.time.Instant;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -19,4 +20,16 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity
   @Query(
       "update RefreshTokenEntity rt set rt.revoked = true where rt.user.id = :userId and rt.revoked = false")
   int revokeActiveTokensByUserId(@Param("userId") Long userId);
+
+  @Transactional
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      """
+      update RefreshTokenEntity rt
+         set rt.revoked = true
+       where rt.token = :token
+         and rt.revoked = false
+         and rt.expiresAt > :currentTime
+      """)
+  int revokeTokenIfActive(@Param("token") String token, @Param("currentTime") Instant currentTime);
 }

--- a/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
@@ -7,12 +7,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
 
   Optional<RefreshTokenEntity> findByToken(String token);
 
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
       "update RefreshTokenEntity rt set rt.revoked = true where rt.user.id = :userId and rt.revoked = false")

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthLoginHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthLoginHelper.java
@@ -5,6 +5,7 @@ import com.tychewealth.dto.user.LoginResponseDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.mapper.user.UserMapper;
+import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
@@ -19,6 +20,7 @@ public class AuthLoginHelper {
   private final AuthTokenHelper authTokenHelper;
   private final AuthRefreshTokenHelper refreshTokenHelper;
   private final UserMapper userMapper;
+  private final AuthMetrics authMetrics;
 
   public LoginResponseDto login(UserEntity user) {
     UserResponseDto response = userMapper.toDto(user);
@@ -27,6 +29,7 @@ public class AuthLoginHelper {
     String refreshToken = refreshTokenHelper.generateRefreshToken();
     Instant refreshTokenExpiresAt = refreshTokenHelper.calculateRefreshTokenExpiration();
     refreshTokenHelper.saveToken(user, refreshToken, refreshTokenExpiresAt);
+    authMetrics.recordLoginSuccess();
 
     log.info(
         LogConstants.REQUEST_SUCCESS + LogConstants.LOGIN_USER_ID,

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
@@ -5,6 +5,7 @@ import static com.tychewealth.constants.AuthConstants.REFRESH_TOKEN_BYTE_LENGTH;
 import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.service.monitoring.AuthMetrics;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Base64;
@@ -16,16 +17,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthRefreshTokenHelper {
 
   private final RefreshTokenRepository refreshTokenRepository;
+  private final AuthMetrics authMetrics;
   private final SecureRandom secureRandom = new SecureRandom();
   private final long refreshTokenTtlSeconds;
 
   public AuthRefreshTokenHelper(
       RefreshTokenRepository refreshTokenRepository,
+      AuthMetrics authMetrics,
       @Value("${app.auth.jwt.refresh-token-ttl-seconds:1209600}") long refreshTokenTtlSeconds) {
+    if (refreshTokenTtlSeconds <= 0) {
+      throw new IllegalArgumentException("Refresh token TTL must be positive");
+    }
     this.refreshTokenRepository = refreshTokenRepository;
+    this.authMetrics = authMetrics;
     this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
   }
 
+  @Transactional
   public void saveToken(UserEntity user, String token, Instant expiresAt) {
     RefreshTokenEntity refreshToken = new RefreshTokenEntity();
 
@@ -35,11 +43,14 @@ public class AuthRefreshTokenHelper {
     refreshToken.setRevoked(false);
 
     refreshTokenRepository.save(refreshToken);
+    authMetrics.recordTokensIssued(1);
   }
 
   @Transactional
   public int revokeActiveTokensByUserId(Long userId) {
-    return refreshTokenRepository.revokeActiveTokensByUserId(userId);
+    int revokedCount = refreshTokenRepository.revokeActiveTokensByUserId(userId);
+    authMetrics.recordTokensRevoked(revokedCount);
+    return revokedCount;
   }
 
   @Transactional
@@ -53,6 +64,7 @@ public class AuthRefreshTokenHelper {
               }
               refreshToken.setRevoked(true);
               refreshTokenRepository.save(refreshToken);
+              authMetrics.recordTokensRevoked(1);
               return true;
             })
         .orElse(false);

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
@@ -1,18 +1,28 @@
 package com.tychewealth.service.helper;
 
 import static com.tychewealth.constants.AuthConstants.REFRESH_TOKEN_BYTE_LENGTH;
+import static com.tychewealth.constants.LogConstants.AUTH;
+import static com.tychewealth.constants.LogConstants.INVALID_REFRESH_TOKEN_MESSAGE;
+import static com.tychewealth.constants.LogConstants.REFRESH_TOKEN_ACTION;
+import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
 
 import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Component
 public class AuthRefreshTokenHelper {
 
@@ -54,20 +64,30 @@ public class AuthRefreshTokenHelper {
   }
 
   @Transactional
-  public boolean revokeToken(String token) {
-    return refreshTokenRepository
-        .findByToken(token)
-        .map(
-            refreshToken -> {
-              if (refreshToken.isRevoked()) {
-                return false;
-              }
-              refreshToken.setRevoked(true);
-              refreshTokenRepository.save(refreshToken);
-              authMetrics.recordTokensRevoked(1);
-              return true;
-            })
-        .orElse(false);
+  public RefreshTokenEntity validateRefreshToken(String token) {
+    int revokedCount = refreshTokenRepository.revokeTokenIfActive(token, Instant.now());
+    authMetrics.recordTokensRevoked(revokedCount);
+
+    if (revokedCount == 0) {
+      throwInvalidRefreshToken();
+    }
+
+    return findByToken(token)
+        .orElseThrow(
+            () ->
+                new IllegalStateException("Refresh token disappeared after successful revocation"));
+  }
+
+  public Optional<RefreshTokenEntity> findByToken(String token) {
+    return refreshTokenRepository.findByToken(token);
+  }
+
+  private void throwInvalidRefreshToken() {
+    log.warn(REQUEST_CONFLICT, AUTH, REFRESH_TOKEN_ACTION, INVALID_REFRESH_TOKEN_MESSAGE);
+    authMetrics.recordRefreshFailure();
+
+    throw new AuthException(
+        ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
   }
 
   public String generateRefreshToken() {

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthRefreshTokenHelper.java
@@ -58,7 +58,7 @@ public class AuthRefreshTokenHelper {
 
   @Transactional
   public int revokeActiveTokensByUserId(Long userId) {
-    int revokedCount = refreshTokenRepository.revokeActiveTokensByUserId(userId);
+    int revokedCount = refreshTokenRepository.revokeActiveTokensByUserId(userId, Instant.now());
     authMetrics.recordTokensRevoked(revokedCount);
     return revokedCount;
   }

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthRegisterHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthRegisterHelper.java
@@ -6,6 +6,7 @@ import com.tychewealth.dto.user.request.RegisterRequestDto;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.mapper.user.UserMapper;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.monitoring.AuthMetrics;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,12 +20,14 @@ public class AuthRegisterHelper {
   private final UserRepository userRepository;
   private final UserMapper userMapper;
   private final PasswordEncoder passwordEncoder;
+  private final AuthMetrics authMetrics;
 
   public UserResponseDto createUser(RegisterRequestDto register) {
     UserEntity toCreate = userMapper.create(register);
     toCreate.setPassword(passwordEncoder.encode(register.getPassword()));
     UserEntity created = userRepository.save(toCreate);
     UserResponseDto response = userMapper.toDto(created);
+    authMetrics.recordRegisterSuccess();
 
     log.info(
         LogConstants.REQUEST_SUCCESS + LogConstants.REGISTER_CREATED_USER_ID,

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthValidationHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthValidationHelper.java
@@ -6,15 +6,12 @@ import com.tychewealth.constants.LogConstants;
 import com.tychewealth.dto.user.request.LoginRequestDto;
 import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
-import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
-import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.utils.Utils;
-import java.time.Instant;
 import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,14 +28,13 @@ public class AuthValidationHelper {
   private static final Pattern LOGIN_PASSWORD_PATTERN = Pattern.compile(LOGIN_PASSWORD_POLICY);
 
   private final UserRepository userRepository;
-  private final RefreshTokenRepository refreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
   private final AuthMetrics authMetrics;
 
   public void validateRegisterRequest(RegisterRequestDto register) {
     validateEmailIsAvailable(register.getEmail());
     validateUsernameIsAvailable(register.getUsername());
-    validateLoginPasswordFormat(register.getPassword());
+    validateRegisterPasswordFormat(register.getPassword());
   }
 
   public UserEntity validateLoginRequest(LoginRequestDto login) {
@@ -102,6 +98,20 @@ public class AuthValidationHelper {
     validateLoginPasswordMatches(rawPassword, encodedPassword);
   }
 
+  public void validateRegisterPasswordFormat(String password) {
+    if (password == null || !LOGIN_PASSWORD_PATTERN.matcher(password).matches()) {
+      log.warn(
+          LogConstants.REQUEST_CONFLICT,
+          LogConstants.AUTH,
+          LogConstants.REGISTER_ACTION,
+          "invalid password format for register");
+      authMetrics.recordRegisterFailure();
+
+      throw new AuthException(
+          ErrorDefinition.AUTH_REGISTER_PASSWORD_FORMAT_INVALID, null, HttpStatus.BAD_REQUEST);
+    }
+  }
+
   public void validateLoginPasswordFormat(String password) {
     if (password == null || !LOGIN_PASSWORD_PATTERN.matcher(password).matches()) {
       log.warn(
@@ -131,7 +141,7 @@ public class AuthValidationHelper {
     }
   }
 
-  public RefreshTokenEntity validateRefreshToken(RefreshTokenRequestDto refreshTokenRequestDto) {
+  public void validateRefreshTokenRequest(RefreshTokenRequestDto refreshTokenRequestDto) {
     if (refreshTokenRequestDto == null
         || !StringUtils.hasText(refreshTokenRequestDto.getRefreshToken())) {
       log.warn(
@@ -144,34 +154,5 @@ public class AuthValidationHelper {
       throw new AuthException(
           ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
     }
-
-    RefreshTokenEntity token =
-        refreshTokenRepository
-            .findByToken(refreshTokenRequestDto.getRefreshToken())
-            .orElseThrow(
-                () -> {
-                  log.warn(
-                      LogConstants.REQUEST_CONFLICT,
-                      LogConstants.AUTH,
-                      LogConstants.REFRESH_TOKEN_ACTION,
-                      LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
-                  authMetrics.recordRefreshFailure();
-                  return new AuthException(
-                      ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
-                });
-
-    if (token.isRevoked() || token.getExpiresAt().isBefore(Instant.now())) {
-      log.warn(
-          LogConstants.REQUEST_CONFLICT,
-          LogConstants.AUTH,
-          LogConstants.REFRESH_TOKEN_ACTION,
-          LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
-      authMetrics.recordRefreshFailure();
-
-      throw new AuthException(
-          ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
-    }
-
-    return token;
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/AuthValidationHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/AuthValidationHelper.java
@@ -12,6 +12,7 @@ import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.utils.Utils;
 import java.time.Instant;
 import java.util.regex.Pattern;
@@ -32,6 +33,7 @@ public class AuthValidationHelper {
   private final UserRepository userRepository;
   private final RefreshTokenRepository refreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
+  private final AuthMetrics authMetrics;
 
   public void validateRegisterRequest(RegisterRequestDto register) {
     validateEmailIsAvailable(register.getEmail());
@@ -53,6 +55,8 @@ public class AuthValidationHelper {
           LogConstants.AUTH,
           LogConstants.REGISTER_ACTION,
           "email already exists");
+      authMetrics.recordRegisterFailure();
+      authMetrics.recordRegisterConflict();
 
       throw new AuthException(
           ErrorDefinition.AUTH_REGISTRATION_CONFLICT, null, HttpStatus.CONFLICT);
@@ -67,6 +71,8 @@ public class AuthValidationHelper {
           LogConstants.AUTH,
           LogConstants.REGISTER_ACTION,
           "username already exists");
+      authMetrics.recordRegisterFailure();
+      authMetrics.recordRegisterConflict();
 
       throw new AuthException(
           ErrorDefinition.AUTH_REGISTRATION_CONFLICT, null, HttpStatus.CONFLICT);
@@ -84,6 +90,8 @@ public class AuthValidationHelper {
                   LogConstants.AUTH,
                   LogConstants.LOGIN_ACTION,
                   "invalid login credentials");
+              authMetrics.recordLoginFailure();
+              authMetrics.recordLoginInvalidCredentials();
               return new AuthException(
                   ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, null, HttpStatus.UNAUTHORIZED);
             });
@@ -101,6 +109,7 @@ public class AuthValidationHelper {
           LogConstants.AUTH,
           LogConstants.LOGIN_ACTION,
           "invalid password format for login");
+      authMetrics.recordLoginFailure();
 
       throw new AuthException(
           ErrorDefinition.AUTH_LOGIN_PASSWORD_FORMAT_INVALID, null, HttpStatus.BAD_REQUEST);
@@ -114,6 +123,8 @@ public class AuthValidationHelper {
           LogConstants.AUTH,
           LogConstants.LOGIN_ACTION,
           "invalid login credentials");
+      authMetrics.recordLoginFailure();
+      authMetrics.recordLoginInvalidCredentials();
 
       throw new AuthException(
           ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, null, HttpStatus.UNAUTHORIZED);
@@ -128,6 +139,7 @@ public class AuthValidationHelper {
           LogConstants.AUTH,
           LogConstants.REFRESH_TOKEN_ACTION,
           LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
+      authMetrics.recordRefreshFailure();
 
       throw new AuthException(
           ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
@@ -143,6 +155,7 @@ public class AuthValidationHelper {
                       LogConstants.AUTH,
                       LogConstants.REFRESH_TOKEN_ACTION,
                       LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
+                  authMetrics.recordRefreshFailure();
                   return new AuthException(
                       ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);
                 });
@@ -153,6 +166,7 @@ public class AuthValidationHelper {
           LogConstants.AUTH,
           LogConstants.REFRESH_TOKEN_ACTION,
           LogConstants.INVALID_REFRESH_TOKEN_MESSAGE);
+      authMetrics.recordRefreshFailure();
 
       throw new AuthException(
           ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, null, HttpStatus.UNAUTHORIZED);

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -20,6 +20,7 @@ import com.tychewealth.service.helper.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.AuthRegisterHelper;
 import com.tychewealth.service.helper.AuthTokenHelper;
 import com.tychewealth.service.helper.AuthValidationHelper;
+import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
 import java.time.Instant;
 import java.util.Locale;
@@ -41,6 +42,7 @@ public class AuthServiceImpl implements AuthService {
   private final AuthLoginHelper authLoginHelper;
   private final AuthRefreshTokenHelper authRefreshTokenHelper;
   private final AuthTokenHelper authTokenHelper;
+  private final AuthMetrics authMetrics;
 
   @Override
   public UserResponseDto register(RegisterRequestDto register) {
@@ -58,6 +60,8 @@ public class AuthServiceImpl implements AuthService {
           LogConstants.AUTH,
           LogConstants.REGISTER_ACTION,
           "registration conflict detected at persistence layer");
+      authMetrics.recordRegisterFailure();
+      authMetrics.recordRegisterConflict();
 
       throw new AuthException(
           ErrorDefinition.AUTH_REGISTRATION_CONFLICT, null, HttpStatus.CONFLICT);
@@ -84,12 +88,12 @@ public class AuthServiceImpl implements AuthService {
     String newRefreshToken = authRefreshTokenHelper.generateRefreshToken();
     Instant newRefreshTokenExpiration = authRefreshTokenHelper.calculateRefreshTokenExpiration();
     authRefreshTokenHelper.saveToken(user, newRefreshToken, newRefreshTokenExpiration);
+    authMetrics.recordRefreshSuccess();
 
-    Instant accessTokenExpiration = Instant.now().plusSeconds(accessTokenPayload.expiresIn());
     return new RefreshTokenResponseDto(
         accessTokenPayload.tokenType(),
         accessTokenPayload.accessToken(),
-        accessTokenExpiration,
+        accessTokenPayload.expiresIn(),
         newRefreshToken);
   }
 

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -77,10 +77,10 @@ public class AuthServiceImpl implements AuthService {
   @Override
   @Transactional
   public RefreshTokenResponseDto refresh(RefreshTokenRequestDto refreshTokenRequestDto) {
-    RefreshTokenEntity currentRefreshToken =
-        authValidationHelper.validateRefreshToken(refreshTokenRequestDto);
+    authValidationHelper.validateRefreshTokenRequest(refreshTokenRequestDto);
 
-    authRefreshTokenHelper.revokeToken(currentRefreshToken.getToken());
+    RefreshTokenEntity currentRefreshToken =
+        authRefreshTokenHelper.validateRefreshToken(refreshTokenRequestDto.getRefreshToken());
 
     UserEntity user = currentRefreshToken.getUser();
     AuthTokenPayload accessTokenPayload = authTokenHelper.generateAccessToken(user);

--- a/user-service/src/main/java/com/tychewealth/service/monitoring/AuthMetrics.java
+++ b/user-service/src/main/java/com/tychewealth/service/monitoring/AuthMetrics.java
@@ -1,0 +1,134 @@
+package com.tychewealth.service.monitoring;
+
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_FAILURE;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_INVALID_CREDENTIALS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_RATE_LIMITED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_REQUESTS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_SUCCESS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_FAILURE;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_RATE_LIMITED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_REQUESTS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_SUCCESS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_TOKEN_ISSUED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_TOKEN_REVOKED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_CONFLICT;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_FAILURE;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_RATE_LIMITED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_REQUESTS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_SUCCESS;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthMetrics {
+
+  private final Counter registerRequests;
+  private final Counter registerSuccesses;
+  private final Counter registerFailures;
+  private final Counter registerRateLimited;
+  private final Counter registerConflicts;
+
+  private final Counter loginRequests;
+  private final Counter loginSuccesses;
+  private final Counter loginFailures;
+  private final Counter loginRateLimited;
+  private final Counter loginInvalidCredentials;
+
+  private final Counter refreshRequests;
+  private final Counter refreshSuccesses;
+  private final Counter refreshFailures;
+  private final Counter refreshRateLimited;
+  private final Counter refreshTokensIssued;
+  private final Counter refreshTokensRevoked;
+
+  public AuthMetrics(MeterRegistry meterRegistry) {
+    this.registerRequests = meterRegistry.counter(METRIC_AUTH_REGISTER_REQUESTS);
+    this.registerSuccesses = meterRegistry.counter(METRIC_AUTH_REGISTER_SUCCESS);
+    this.registerFailures = meterRegistry.counter(METRIC_AUTH_REGISTER_FAILURE);
+    this.registerRateLimited = meterRegistry.counter(METRIC_AUTH_REGISTER_RATE_LIMITED);
+    this.registerConflicts = meterRegistry.counter(METRIC_AUTH_REGISTER_CONFLICT);
+
+    this.loginRequests = meterRegistry.counter(METRIC_AUTH_LOGIN_REQUESTS);
+    this.loginSuccesses = meterRegistry.counter(METRIC_AUTH_LOGIN_SUCCESS);
+    this.loginFailures = meterRegistry.counter(METRIC_AUTH_LOGIN_FAILURE);
+    this.loginRateLimited = meterRegistry.counter(METRIC_AUTH_LOGIN_RATE_LIMITED);
+    this.loginInvalidCredentials = meterRegistry.counter(METRIC_AUTH_LOGIN_INVALID_CREDENTIALS);
+
+    this.refreshRequests = meterRegistry.counter(METRIC_AUTH_REFRESH_REQUESTS);
+    this.refreshSuccesses = meterRegistry.counter(METRIC_AUTH_REFRESH_SUCCESS);
+    this.refreshFailures = meterRegistry.counter(METRIC_AUTH_REFRESH_FAILURE);
+    this.refreshRateLimited = meterRegistry.counter(METRIC_AUTH_REFRESH_RATE_LIMITED);
+    this.refreshTokensIssued = meterRegistry.counter(METRIC_AUTH_REFRESH_TOKEN_ISSUED);
+    this.refreshTokensRevoked = meterRegistry.counter(METRIC_AUTH_REFRESH_TOKEN_REVOKED);
+  }
+
+  public void recordRegisterRequest() {
+    registerRequests.increment();
+  }
+
+  public void recordRegisterSuccess() {
+    registerSuccesses.increment();
+  }
+
+  public void recordRegisterFailure() {
+    registerFailures.increment();
+  }
+
+  public void recordRegisterRateLimited() {
+    registerRateLimited.increment();
+  }
+
+  public void recordRegisterConflict() {
+    registerConflicts.increment();
+  }
+
+  public void recordLoginRequest() {
+    loginRequests.increment();
+  }
+
+  public void recordLoginSuccess() {
+    loginSuccesses.increment();
+  }
+
+  public void recordLoginFailure() {
+    loginFailures.increment();
+  }
+
+  public void recordLoginRateLimited() {
+    loginRateLimited.increment();
+  }
+
+  public void recordLoginInvalidCredentials() {
+    loginInvalidCredentials.increment();
+  }
+
+  public void recordRefreshRequest() {
+    refreshRequests.increment();
+  }
+
+  public void recordRefreshSuccess() {
+    refreshSuccesses.increment();
+  }
+
+  public void recordRefreshFailure() {
+    refreshFailures.increment();
+  }
+
+  public void recordRefreshRateLimited() {
+    refreshRateLimited.increment();
+  }
+
+  public void recordTokensIssued(double count) {
+    if (count > 0) {
+      refreshTokensIssued.increment(count);
+    }
+  }
+
+  public void recordTokensRevoked(double count) {
+    if (count > 0) {
+      refreshTokensRevoked.increment(count);
+    }
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/web/AuthRateLimitInterceptor.java
+++ b/user-service/src/main/java/com/tychewealth/web/AuthRateLimitInterceptor.java
@@ -1,0 +1,108 @@
+package com.tychewealth.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AuthRateLimitInterceptor implements HandlerInterceptor {
+
+  private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+
+  private final int maxRequests;
+  private final long windowMillis;
+  private final String rejectionMessage;
+  private final Consumer<String> requestMetricRecorder;
+  private final Consumer<String> rateLimitedMetricRecorder;
+  private final Clock clock;
+  private final Map<String, Deque<Long>> requestsByClient = new ConcurrentHashMap<>();
+
+  public AuthRateLimitInterceptor(
+      int maxRequests,
+      long windowSeconds,
+      String rejectionMessage,
+      Consumer<String> requestMetricRecorder,
+      Consumer<String> rateLimitedMetricRecorder) {
+    this(
+        maxRequests,
+        windowSeconds,
+        rejectionMessage,
+        requestMetricRecorder,
+        rateLimitedMetricRecorder,
+        Clock.systemUTC());
+  }
+
+  AuthRateLimitInterceptor(
+      int maxRequests,
+      long windowSeconds,
+      String rejectionMessage,
+      Consumer<String> requestMetricRecorder,
+      Consumer<String> rateLimitedMetricRecorder,
+      Clock clock) {
+    if (maxRequests <= 0) {
+      throw new IllegalArgumentException("Rate limit max requests must be positive");
+    }
+    if (windowSeconds <= 0) {
+      throw new IllegalArgumentException("Rate limit window must be positive");
+    }
+    this.maxRequests = maxRequests;
+    this.windowMillis = windowSeconds * 1000;
+    this.rejectionMessage = rejectionMessage;
+    this.requestMetricRecorder = requestMetricRecorder;
+    this.rateLimitedMetricRecorder = rateLimitedMetricRecorder;
+    this.clock = clock;
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (requestMetricRecorder != null) {
+      requestMetricRecorder.accept(request.getRequestURI());
+    }
+
+    String clientKey = resolveClientKey(request);
+    long now = clock.millis();
+    Deque<Long> timestamps =
+        requestsByClient.computeIfAbsent(clientKey, ignored -> new ArrayDeque<>());
+
+    synchronized (timestamps) {
+      evictExpiredRequests(timestamps, now);
+      if (timestamps.size() >= maxRequests) {
+        if (rateLimitedMetricRecorder != null) {
+          rateLimitedMetricRecorder.accept(request.getRequestURI());
+        }
+        throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, rejectionMessage);
+      }
+      timestamps.addLast(now);
+    }
+
+    return true;
+  }
+
+  public void reset() {
+    requestsByClient.clear();
+  }
+
+  private void evictExpiredRequests(Deque<Long> timestamps, long now) {
+    long threshold = now - windowMillis;
+    while (!timestamps.isEmpty() && timestamps.peekFirst() < threshold) {
+      timestamps.removeFirst();
+    }
+  }
+
+  private String resolveClientKey(HttpServletRequest request) {
+    String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
+    if (StringUtils.hasText(forwardedFor)) {
+      return forwardedFor.split(",")[0].trim();
+    }
+    return request.getRemoteAddr();
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/web/AuthRateLimitInterceptor.java
+++ b/user-service/src/main/java/com/tychewealth/web/AuthRateLimitInterceptor.java
@@ -1,21 +1,19 @@
 package com.tychewealth.web;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import org.springframework.http.HttpStatus;
-import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class AuthRateLimitInterceptor implements HandlerInterceptor {
-
-  private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
 
   private final int maxRequests;
   private final long windowMillis;
@@ -23,7 +21,7 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
   private final Consumer<String> requestMetricRecorder;
   private final Consumer<String> rateLimitedMetricRecorder;
   private final Clock clock;
-  private final Map<String, Deque<Long>> requestsByClient = new ConcurrentHashMap<>();
+  private final Cache<String, Deque<Long>> requestsByClient;
 
   public AuthRateLimitInterceptor(
       int maxRequests,
@@ -37,6 +35,7 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
         rejectionMessage,
         requestMetricRecorder,
         rateLimitedMetricRecorder,
+        buildRequestsByClientCache(windowSeconds),
         Clock.systemUTC());
   }
 
@@ -46,6 +45,7 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
       String rejectionMessage,
       Consumer<String> requestMetricRecorder,
       Consumer<String> rateLimitedMetricRecorder,
+      Cache<String, Deque<Long>> requestsByClient,
       Clock clock) {
     if (maxRequests <= 0) {
       throw new IllegalArgumentException("Rate limit max requests must be positive");
@@ -58,6 +58,7 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
     this.rejectionMessage = rejectionMessage;
     this.requestMetricRecorder = requestMetricRecorder;
     this.rateLimitedMetricRecorder = rateLimitedMetricRecorder;
+    this.requestsByClient = requestsByClient;
     this.clock = clock;
   }
 
@@ -70,8 +71,7 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
 
     String clientKey = resolveClientKey(request);
     long now = clock.millis();
-    Deque<Long> timestamps =
-        requestsByClient.computeIfAbsent(clientKey, ignored -> new ArrayDeque<>());
+    Deque<Long> timestamps = requestsByClient.get(clientKey, ignored -> new ArrayDeque<>());
 
     synchronized (timestamps) {
       evictExpiredRequests(timestamps, now);
@@ -88,7 +88,7 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
   }
 
   public void reset() {
-    requestsByClient.clear();
+    requestsByClient.invalidateAll();
   }
 
   private void evictExpiredRequests(Deque<Long> timestamps, long now) {
@@ -99,10 +99,10 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
   }
 
   private String resolveClientKey(HttpServletRequest request) {
-    String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
-    if (StringUtils.hasText(forwardedFor)) {
-      return forwardedFor.split(",")[0].trim();
-    }
     return request.getRemoteAddr();
+  }
+
+  private static Cache<String, Deque<Long>> buildRequestsByClientCache(long windowSeconds) {
+    return Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(windowSeconds)).build();
   }
 }

--- a/user-service/src/main/java/com/tychewealth/web/AuthRateLimitInterceptor.java
+++ b/user-service/src/main/java/com/tychewealth/web/AuthRateLimitInterceptor.java
@@ -93,7 +93,7 @@ public class AuthRateLimitInterceptor implements HandlerInterceptor {
 
   private void evictExpiredRequests(Deque<Long> timestamps, long now) {
     long threshold = now - windowMillis;
-    while (!timestamps.isEmpty() && timestamps.peekFirst() < threshold) {
+    while (!timestamps.isEmpty() && timestamps.peekFirst() <= threshold) {
       timestamps.removeFirst();
     }
   }

--- a/user-service/src/main/java/com/tychewealth/web/RefreshRateLimitInterceptor.java
+++ b/user-service/src/main/java/com/tychewealth/web/RefreshRateLimitInterceptor.java
@@ -1,0 +1,85 @@
+package com.tychewealth.web;
+
+import com.tychewealth.service.monitoring.AuthMetrics;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class RefreshRateLimitInterceptor implements HandlerInterceptor {
+
+  private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+
+  private final int maxRequests;
+  private final long windowMillis;
+  private final AuthMetrics authMetrics;
+  private final Clock clock;
+  private final Map<String, Deque<Long>> requestsByClient = new ConcurrentHashMap<>();
+
+  public RefreshRateLimitInterceptor(int maxRequests, long windowSeconds, AuthMetrics authMetrics) {
+    this(maxRequests, windowSeconds, authMetrics, Clock.systemUTC());
+  }
+
+  RefreshRateLimitInterceptor(
+      int maxRequests, long windowSeconds, AuthMetrics authMetrics, Clock clock) {
+    if (maxRequests <= 0) {
+      throw new IllegalArgumentException("Refresh rate limit max requests must be positive");
+    }
+    if (windowSeconds <= 0) {
+      throw new IllegalArgumentException("Refresh rate limit window must be positive");
+    }
+    this.maxRequests = maxRequests;
+    this.windowMillis = windowSeconds * 1000;
+    this.authMetrics = authMetrics;
+    this.clock = clock;
+  }
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    authMetrics.recordRefreshRequest();
+
+    String clientKey = resolveClientKey(request);
+    long now = clock.millis();
+    Deque<Long> timestamps =
+        requestsByClient.computeIfAbsent(clientKey, ignored -> new ArrayDeque<>());
+
+    synchronized (timestamps) {
+      evictExpiredRequests(timestamps, now);
+      if (timestamps.size() >= maxRequests) {
+        authMetrics.recordRefreshRateLimited();
+        throw new ResponseStatusException(
+            HttpStatus.TOO_MANY_REQUESTS, "Too many refresh token requests");
+      }
+      timestamps.addLast(now);
+    }
+
+    return true;
+  }
+
+  private void evictExpiredRequests(Deque<Long> timestamps, long now) {
+    long threshold = now - windowMillis;
+    while (!timestamps.isEmpty() && timestamps.peekFirst() < threshold) {
+      timestamps.removeFirst();
+    }
+  }
+
+  private String resolveClientKey(HttpServletRequest request) {
+    String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
+    if (StringUtils.hasText(forwardedFor)) {
+      return forwardedFor.split(",")[0].trim();
+    }
+    return request.getRemoteAddr();
+  }
+
+  public void reset() {
+    requestsByClient.clear();
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/web/RefreshRateLimitInterceptor.java
+++ b/user-service/src/main/java/com/tychewealth/web/RefreshRateLimitInterceptor.java
@@ -74,7 +74,7 @@ public class RefreshRateLimitInterceptor implements HandlerInterceptor {
 
   private void evictExpiredRequests(Deque<Long> timestamps, long now) {
     long threshold = now - windowMillis;
-    while (!timestamps.isEmpty() && timestamps.peekFirst() < threshold) {
+    while (!timestamps.isEmpty() && timestamps.peekFirst() <= threshold) {
       timestamps.removeFirst();
     }
   }

--- a/user-service/src/main/java/com/tychewealth/web/RefreshRateLimitInterceptor.java
+++ b/user-service/src/main/java/com/tychewealth/web/RefreshRateLimitInterceptor.java
@@ -1,34 +1,43 @@
 package com.tychewealth.web;
 
+import static com.tychewealth.constants.AuthConstants.REFRESH_RATE_LIMIT_MESSAGE;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.http.HttpStatus;
-import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class RefreshRateLimitInterceptor implements HandlerInterceptor {
 
-  private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
-
   private final int maxRequests;
   private final long windowMillis;
   private final AuthMetrics authMetrics;
   private final Clock clock;
-  private final Map<String, Deque<Long>> requestsByClient = new ConcurrentHashMap<>();
+  private final Cache<String, Deque<Long>> requestsByClient;
 
   public RefreshRateLimitInterceptor(int maxRequests, long windowSeconds, AuthMetrics authMetrics) {
-    this(maxRequests, windowSeconds, authMetrics, Clock.systemUTC());
+    this(
+        maxRequests,
+        windowSeconds,
+        authMetrics,
+        buildRequestsByClientCache(windowSeconds),
+        Clock.systemUTC());
   }
 
   RefreshRateLimitInterceptor(
-      int maxRequests, long windowSeconds, AuthMetrics authMetrics, Clock clock) {
+      int maxRequests,
+      long windowSeconds,
+      AuthMetrics authMetrics,
+      Cache<String, Deque<Long>> requestsByClient,
+      Clock clock) {
     if (maxRequests <= 0) {
       throw new IllegalArgumentException("Refresh rate limit max requests must be positive");
     }
@@ -38,6 +47,7 @@ public class RefreshRateLimitInterceptor implements HandlerInterceptor {
     this.maxRequests = maxRequests;
     this.windowMillis = windowSeconds * 1000;
     this.authMetrics = authMetrics;
+    this.requestsByClient = requestsByClient;
     this.clock = clock;
   }
 
@@ -48,15 +58,13 @@ public class RefreshRateLimitInterceptor implements HandlerInterceptor {
 
     String clientKey = resolveClientKey(request);
     long now = clock.millis();
-    Deque<Long> timestamps =
-        requestsByClient.computeIfAbsent(clientKey, ignored -> new ArrayDeque<>());
+    Deque<Long> timestamps = requestsByClient.get(clientKey, ignored -> new ArrayDeque<>());
 
     synchronized (timestamps) {
       evictExpiredRequests(timestamps, now);
       if (timestamps.size() >= maxRequests) {
         authMetrics.recordRefreshRateLimited();
-        throw new ResponseStatusException(
-            HttpStatus.TOO_MANY_REQUESTS, "Too many refresh token requests");
+        throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, REFRESH_RATE_LIMIT_MESSAGE);
       }
       timestamps.addLast(now);
     }
@@ -72,14 +80,14 @@ public class RefreshRateLimitInterceptor implements HandlerInterceptor {
   }
 
   private String resolveClientKey(HttpServletRequest request) {
-    String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
-    if (StringUtils.hasText(forwardedFor)) {
-      return forwardedFor.split(",")[0].trim();
-    }
     return request.getRemoteAddr();
   }
 
   public void reset() {
-    requestsByClient.clear();
+    requestsByClient.invalidateAll();
+  }
+
+  private static Cache<String, Deque<Long>> buildRequestsByClientCache(long windowSeconds) {
+    return Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(windowSeconds)).build();
   }
 }

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -1,21 +1,21 @@
-# Puerto por defecto
+# Default port
 server.port=8080
 
 spring.application.name=user-service
 
-# Carga opcional de configuracion local no versionada
+# Optional import of unversioned local configuration
 spring.config.import=optional:file:./application-local.properties,optional:file:./user-service/application-local.properties
 
-# Liquibase - ruta del changelog principal
+# Liquibase - main changelog path
 spring.liquibase.change-log=classpath:db.changelog/changelog-master.xml
 
-# Configuracion PostgreSQL (usa variables de entorno o application-local.properties)
+# PostgreSQL configuration (uses environment variables or application-local.properties)
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# Dejar la creacion/actualizacion de esquema a Liquibase
+# Let Liquibase manage schema creation and updates
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 
@@ -23,3 +23,15 @@ spring.jpa.show-sql=true
 app.auth.jwt.secret=${JWT_SECRET}
 app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
+
+# Register endpoint protections
+app.auth.register-rate-limit.max-requests=${AUTH_REGISTER_RATE_LIMIT_MAX_REQUESTS:5}
+app.auth.register-rate-limit.window-seconds=${AUTH_REGISTER_RATE_LIMIT_WINDOW_SECONDS:300}
+
+# Login endpoint protections
+app.auth.login-rate-limit.max-requests=${AUTH_LOGIN_RATE_LIMIT_MAX_REQUESTS:10}
+app.auth.login-rate-limit.window-seconds=${AUTH_LOGIN_RATE_LIMIT_WINDOW_SECONDS:60}
+
+# Refresh endpoint protections aligned with app.auth.jwt.refresh-token-ttl-seconds / JWT_REFRESH_TOKEN_TTL_SECONDS
+app.auth.refresh-rate-limit.max-requests=${AUTH_REFRESH_RATE_LIMIT_MAX_REQUESTS:10}
+app.auth.refresh-rate-limit.window-seconds=${AUTH_REFRESH_RATE_LIMIT_WINDOW_SECONDS:60}

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -7,18 +7,26 @@ import com.tychewealth.error.handler.ErrorHandler;
 import com.tychewealth.mapper.user.UserMapper;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
-import com.tychewealth.service.helper.*;
+import com.tychewealth.service.helper.AuthLoginHelper;
+import com.tychewealth.service.helper.AuthRefreshTokenHelper;
+import com.tychewealth.service.helper.AuthRegisterHelper;
+import com.tychewealth.service.helper.AuthTokenHelper;
+import com.tychewealth.service.helper.AuthValidationHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
+import com.tychewealth.service.monitoring.AuthMetrics;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootConfiguration
 @EnableAutoConfiguration
-@Import(IntegrationTestConfig.class)
+@Import({IntegrationTestConfig.class, RefreshRateLimitConfig.class})
 @ComponentScan(
     basePackageClasses = {
       AuthApiController.class,
@@ -28,9 +36,29 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
       AuthLoginHelper.class,
       AuthTokenHelper.class,
       AuthRefreshTokenHelper.class,
+      AuthMetrics.class,
       ErrorHandler.class,
       UserMapper.class
     })
 @EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
 @EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
-public class AuthIntegrationTestConfig {}
+public class AuthIntegrationTestConfig {
+
+  public static class Initializer
+      implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+      TestPropertyValues.of(
+              "spring.liquibase.change-log=classpath:db.changelog/changelog-master.xml",
+              "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
+              "app.auth.register-rate-limit.max-requests=2",
+              "app.auth.register-rate-limit.window-seconds=300",
+              "app.auth.login-rate-limit.max-requests=2",
+              "app.auth.login-rate-limit.window-seconds=60",
+              "app.auth.refresh-rate-limit.max-requests=2",
+              "app.auth.refresh-rate-limit.window-seconds=60")
+          .applyTo(applicationContext.getEnvironment());
+    }
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -1,8 +1,25 @@
 package com.tychewealth.controller;
 
-import static com.tychewealth.constants.ApiConstants.URL_FOLDER_V1;
+import static com.tychewealth.constants.ApiConstants.AUTH_LOGIN_URL;
+import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
+import static com.tychewealth.constants.ApiConstants.AUTH_REGISTER_URL;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_FAILURE;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_INVALID_CREDENTIALS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_RATE_LIMITED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_REQUESTS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_SUCCESS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_RATE_LIMITED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_REQUESTS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_SUCCESS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_TOKEN_ISSUED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REFRESH_TOKEN_REVOKED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_CONFLICT;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_FAILURE;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_RATE_LIMITED;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_REQUESTS;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_SUCCESS;
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
 import static com.tychewealth.testdata.EntityBuilder.buildRefreshToken;
-import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,6 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tychewealth.config.AuthIntegrationTestConfig;
+import com.tychewealth.config.RefreshRateLimitConfig;
 import com.tychewealth.dto.user.LoginResponseDto;
 import com.tychewealth.dto.user.RefreshTokenResponseDto;
 import com.tychewealth.dto.user.request.LoginRequestDto;
@@ -22,8 +40,10 @@ import com.tychewealth.dto.user.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.user.request.RegisterRequestDto;
 import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,17 +54,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(
-    classes = AuthIntegrationTestConfig.class,
-    properties = "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=")
+@SpringBootTest(classes = AuthIntegrationTestConfig.class)
+@ContextConfiguration(initializers = AuthIntegrationTestConfig.Initializer.class)
 @AutoConfigureMockMvc
 class AuthApiControllerIntegrationTest {
 
-  private static final String REGISTER_URL = URL_FOLDER_V1 + "/auth/register";
-  private static final String LOGIN_URL = URL_FOLDER_V1 + "/auth/login";
-  private static final String REFRESH_URL = URL_FOLDER_V1 + "/auth/refresh";
+  private static final String MISSING_REFRESH_TOKEN = "missing-token";
+  private static final String VALID_PASSWORD = "Secret123!";
+  private static final String INVALID_PASSWORD = "Wrong123!";
 
   @Autowired private MockMvc mockMvc;
 
@@ -52,6 +72,8 @@ class AuthApiControllerIntegrationTest {
 
   @Autowired private UserRepository userRepository;
   @Autowired private RefreshTokenRepository refreshTokenRepository;
+  @Autowired private MeterRegistry meterRegistry;
+  @Autowired private RefreshRateLimitConfig rateLimitConfig;
 
   @Autowired private PasswordEncoder passwordEncoder;
 
@@ -67,23 +89,24 @@ class AuthApiControllerIntegrationTest {
   void setUp() {
     refreshTokenRepository.deleteAll();
     userRepository.deleteAll();
+    rateLimitConfig.resetAll();
     validRequest =
-        new RegisterRequestDto("laura.gomez@tychewealth.com", "lauragomez", "Secret123!");
+        new RegisterRequestDto("laura.gomez@tychewealth.com", "lauragomez", VALID_PASSWORD);
     conflictByEmailRequest =
-        new RegisterRequestDto(validRequest.getEmail(), "carlosmartin", "Secret123!");
+        new RegisterRequestDto(validRequest.getEmail(), "carlosmartin", VALID_PASSWORD);
     conflictByUsernameRequest =
         new RegisterRequestDto(
-            "pablo.ortega@tychewealth.com", validRequest.getUsername(), "Secret123!");
+            "pablo.ortega@tychewealth.com", validRequest.getUsername(), VALID_PASSWORD);
 
     existingEmailUser = new UserEntity();
     existingEmailUser.setEmail(validRequest.getEmail());
     existingEmailUser.setUsername("anabelruiz");
-    existingEmailUser.setPassword(passwordEncoder.encode("Secret123!"));
+    existingEmailUser.setPassword(passwordEncoder.encode(VALID_PASSWORD));
 
     existingUsernameUser = new UserEntity();
     existingUsernameUser.setEmail("mario.santos@tychewealth.com");
     existingUsernameUser.setUsername(validRequest.getUsername());
-    existingUsernameUser.setPassword(passwordEncoder.encode("Secret123!"));
+    existingUsernameUser.setPassword(passwordEncoder.encode(VALID_PASSWORD));
 
     existingLoginUser = new UserEntity();
     existingLoginUser.setEmail(validRequest.getEmail());
@@ -95,9 +118,12 @@ class AuthApiControllerIntegrationTest {
 
   @Test
   void registerCreatesUserWhenRequestIsValid() throws Exception {
+    double requestsBefore = counterValue(METRIC_AUTH_REGISTER_REQUESTS);
+    double successBefore = counterValue(METRIC_AUTH_REGISTER_SUCCESS);
+
     mockMvc
         .perform(
-            post(REGISTER_URL)
+            post(AUTH_REGISTER_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(validRequest)))
         .andExpect(status().isCreated())
@@ -111,22 +137,30 @@ class AuthApiControllerIntegrationTest {
     assertNotNull(created.getId());
     assertNotEquals(validRequest.getPassword(), created.getPassword());
     assertTrue(passwordEncoder.matches(validRequest.getPassword(), created.getPassword()));
+    assertEquals(requestsBefore + 1, counterValue(METRIC_AUTH_REGISTER_REQUESTS));
+    assertEquals(successBefore + 1, counterValue(METRIC_AUTH_REGISTER_SUCCESS));
   }
 
   @Test
   void registerReturnsConflictWhenEmailAlreadyExists() throws Exception {
     userRepository.save(existingEmailUser);
+    double failureBefore = counterValue(METRIC_AUTH_REGISTER_FAILURE);
+    double conflictBefore = counterValue(METRIC_AUTH_REGISTER_CONFLICT);
 
     mockMvc
         .perform(
-            post(REGISTER_URL)
+            post(AUTH_REGISTER_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(conflictByEmailRequest)))
         .andExpect(status().isConflict())
-        .andExpect(jsonPath("$.code").value("TYCHE-100"))
-        .andExpect(jsonPath("$.type").value("AUTH_REGISTRATION_CONFLICT"))
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getType()))
         .andExpect(
-            jsonPath("$.description").value("A user with the provided credentials already exists"));
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getDescription()));
+
+    assertEquals(failureBefore + 1, counterValue(METRIC_AUTH_REGISTER_FAILURE));
+    assertEquals(conflictBefore + 1, counterValue(METRIC_AUTH_REGISTER_CONFLICT));
   }
 
   @Test
@@ -135,14 +169,39 @@ class AuthApiControllerIntegrationTest {
 
     mockMvc
         .perform(
-            post(REGISTER_URL)
+            post(AUTH_REGISTER_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(conflictByUsernameRequest)))
         .andExpect(status().isConflict())
-        .andExpect(jsonPath("$.code").value("TYCHE-100"))
-        .andExpect(jsonPath("$.type").value("AUTH_REGISTRATION_CONFLICT"))
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getType()))
         .andExpect(
-            jsonPath("$.description").value("A user with the provided credentials already exists"));
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getDescription()));
+  }
+
+  @Test
+  void registerReturnsTooManyRequestsWhenRateLimitIsExceeded() throws Exception {
+    RegisterRequestDto invalidRegisterRequest = new RegisterRequestDto("", "", "short");
+    double requestsBefore = counterValue(METRIC_AUTH_REGISTER_REQUESTS);
+    double rateLimitedBefore = counterValue(METRIC_AUTH_REGISTER_RATE_LIMITED);
+
+    registerRequest(invalidRegisterRequest).andExpect(status().isBadRequest());
+
+    registerRequest(invalidRegisterRequest).andExpect(status().isBadRequest());
+
+    mockMvc
+        .perform(
+            post(AUTH_REGISTER_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidRegisterRequest)))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.RATE_LIMITED.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.RATE_LIMITED.getType()))
+        .andExpect(jsonPath("$.description").value("Too many register requests"));
+
+    assertEquals(requestsBefore + 3, counterValue(METRIC_AUTH_REGISTER_REQUESTS));
+    assertEquals(rateLimitedBefore + 1, counterValue(METRIC_AUTH_REGISTER_RATE_LIMITED));
   }
 
   @ParameterizedTest
@@ -151,26 +210,28 @@ class AuthApiControllerIntegrationTest {
       RegisterRequestDto invalidRequest, String expectedMessage) throws Exception {
     mockMvc
         .perform(
-            post(REGISTER_URL)
+            post(AUTH_REGISTER_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(invalidRequest)))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("TYCHE-002"))
-        .andExpect(jsonPath("$.type").value("GENERIC_VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()))
         .andExpect(jsonPath("$.description").value(containsString(expectedMessage)));
   }
 
   @Test
   void loginReturnsTokenAndUserWhenCredentialsAreValid() throws Exception {
     userRepository.save(existingLoginUser);
+    double requestsBefore = counterValue(METRIC_AUTH_LOGIN_REQUESTS);
+    double successBefore = counterValue(METRIC_AUTH_LOGIN_SUCCESS);
 
     mockMvc
         .perform(
-            post(LOGIN_URL)
+            post(AUTH_LOGIN_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(validLoginRequest)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.tokenType").value("Bearer"))
+        .andExpect(jsonPath("$.tokenType").value(TOKEN_TYPE_BEARER))
         .andExpect(jsonPath("$.accessToken").isString())
         .andExpect(jsonPath("$.refreshToken").isString())
         .andExpect(jsonPath("$.expiresIn").isNumber())
@@ -178,76 +239,79 @@ class AuthApiControllerIntegrationTest {
         .andExpect(jsonPath("$.user.email").value(validRequest.getEmail()))
         .andExpect(jsonPath("$.user.username").value(validRequest.getUsername()))
         .andExpect(jsonPath("$.user.password").doesNotExist());
+
+    assertEquals(requestsBefore + 1, counterValue(METRIC_AUTH_LOGIN_REQUESTS));
+    assertEquals(successBefore + 1, counterValue(METRIC_AUTH_LOGIN_SUCCESS));
   }
 
   @Test
   void loginReturnsUnauthorizedWhenCredentialsAreInvalid() throws Exception {
     userRepository.save(existingLoginUser);
+    double failureBefore = counterValue(METRIC_AUTH_LOGIN_FAILURE);
+    double invalidCredentialsBefore = counterValue(METRIC_AUTH_LOGIN_INVALID_CREDENTIALS);
 
-    LoginRequestDto invalidLoginRequest = new LoginRequestDto(validRequest.getEmail(), "Wrong123!");
+    LoginRequestDto invalidLoginRequest =
+        new LoginRequestDto(validRequest.getEmail(), INVALID_PASSWORD);
 
     mockMvc
         .perform(
-            post(LOGIN_URL)
+            post(AUTH_LOGIN_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(invalidLoginRequest)))
         .andExpect(status().isUnauthorized())
-        .andExpect(jsonPath("$.code").value("TYCHE-101"))
-        .andExpect(jsonPath("$.type").value("AUTH_LOGIN_INVALID_CREDENTIALS"))
-        .andExpect(jsonPath("$.description").value("The provided login credentials are invalid"));
+        .andExpect(
+            jsonPath("$.code").value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getCode()))
+        .andExpect(
+            jsonPath("$.type").value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getType()))
+        .andExpect(
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getDescription()));
+
+    assertEquals(failureBefore + 1, counterValue(METRIC_AUTH_LOGIN_FAILURE));
+    assertEquals(invalidCredentialsBefore + 1, counterValue(METRIC_AUTH_LOGIN_INVALID_CREDENTIALS));
+  }
+
+  @Test
+  void loginReturnsTooManyRequestsWhenRateLimitIsExceeded() throws Exception {
+    userRepository.save(existingLoginUser);
+    double requestsBefore = counterValue(METRIC_AUTH_LOGIN_REQUESTS);
+    double rateLimitedBefore = counterValue(METRIC_AUTH_LOGIN_RATE_LIMITED);
+
+    LoginRequestDto invalidLoginRequest =
+        new LoginRequestDto(validRequest.getEmail(), INVALID_PASSWORD);
+
+    loginRequest(invalidLoginRequest).andExpect(status().isUnauthorized());
+
+    loginRequest(invalidLoginRequest).andExpect(status().isUnauthorized());
+
+    mockMvc
+        .perform(
+            post(AUTH_LOGIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidLoginRequest)))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.RATE_LIMITED.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.RATE_LIMITED.getType()))
+        .andExpect(jsonPath("$.description").value("Too many login requests"));
+
+    assertEquals(requestsBefore + 3, counterValue(METRIC_AUTH_LOGIN_REQUESTS));
+    assertEquals(rateLimitedBefore + 1, counterValue(METRIC_AUTH_LOGIN_RATE_LIMITED));
   }
 
   @Test
   void secondLoginRevokesPreviousRefreshToken() throws Exception {
     userRepository.save(existingLoginUser);
 
-    String firstLoginBody =
-        mockMvc
-            .perform(
-                post(LOGIN_URL)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(validLoginRequest)))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-    LoginResponseDto firstLoginResponse =
-        objectMapper.readValue(firstLoginBody, LoginResponseDto.class);
-
-    String secondLoginBody =
-        mockMvc
-            .perform(
-                post(LOGIN_URL)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(validLoginRequest)))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-    LoginResponseDto secondLoginResponse =
-        objectMapper.readValue(secondLoginBody, LoginResponseDto.class);
+    LoginResponseDto firstLoginResponse = login(validLoginRequest);
+    LoginResponseDto secondLoginResponse = login(validLoginRequest);
     assertNotEquals(firstLoginResponse.getRefreshToken(), secondLoginResponse.getRefreshToken());
 
-    mockMvc
-        .perform(
-            post(REFRESH_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    objectMapper.writeValueAsString(
-                        new RefreshTokenRequestDto(firstLoginResponse.getRefreshToken()))))
+    refresh(firstLoginResponse.getRefreshToken())
         .andExpect(status().isUnauthorized())
-        .andExpect(jsonPath("$.code").value("TYCHE-103"))
-        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"));
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getType()));
 
-    mockMvc
-        .perform(
-            post(REFRESH_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    objectMapper.writeValueAsString(
-                        new RefreshTokenRequestDto(secondLoginResponse.getRefreshToken()))))
+    refresh(secondLoginResponse.getRefreshToken())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.refreshToken").isString());
   }
@@ -258,18 +322,18 @@ class AuthApiControllerIntegrationTest {
       LoginRequestDto invalidRequest, String expectedMessage) throws Exception {
     mockMvc
         .perform(
-            post(LOGIN_URL)
+            post(AUTH_LOGIN_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(invalidRequest)))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("TYCHE-002"))
-        .andExpect(jsonPath("$.type").value("GENERIC_VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()))
         .andExpect(jsonPath("$.description").value(containsString(expectedMessage)));
   }
 
   @Test
   void refreshRotatesTokensWhenRefreshTokenIsValid() throws Exception {
-    UserEntity user = userRepository.save(buildUser("refresh.user@tychewealth.com", "refreshuser"));
+    UserEntity user = userRepository.save(existingLoginUser);
     String previousTokenValue = "existing-refresh-token";
     RefreshTokenEntity previousToken =
         refreshTokenRepository.save(
@@ -278,15 +342,15 @@ class AuthApiControllerIntegrationTest {
     String responseBody =
         mockMvc
             .perform(
-                post(REFRESH_URL)
+                post(AUTH_REFRESH_URL)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         objectMapper.writeValueAsString(
                             new RefreshTokenRequestDto(previousTokenValue))))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.tokenType").value("Bearer"))
+            .andExpect(jsonPath("$.tokenType").value(TOKEN_TYPE_BEARER))
             .andExpect(jsonPath("$.accessToken").isString())
-            .andExpect(jsonPath("$.expiresAt").exists())
+            .andExpect(jsonPath("$.expiresIn").isNumber())
             .andExpect(jsonPath("$.refreshToken").isString())
             .andReturn()
             .getResponse()
@@ -316,74 +380,165 @@ class AuthApiControllerIntegrationTest {
   void refreshReturnsUnauthorizedWhenRefreshTokenDoesNotExist() throws Exception {
     mockMvc
         .perform(
-            post(REFRESH_URL)
+            post(AUTH_REFRESH_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
-                    objectMapper.writeValueAsString(new RefreshTokenRequestDto("missing-token"))))
+                    objectMapper.writeValueAsString(
+                        new RefreshTokenRequestDto(MISSING_REFRESH_TOKEN))))
         .andExpect(status().isUnauthorized())
-        .andExpect(jsonPath("$.code").value("TYCHE-103"))
-        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"))
-        .andExpect(jsonPath("$.description").value("The provided refresh token is invalid"));
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getType()))
+        .andExpect(
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getDescription()));
   }
 
   @Test
   void refreshReturnsUnauthorizedWhenRefreshTokenIsRevoked() throws Exception {
-    UserEntity user =
-        userRepository.save(buildUser("refresh.revoked@tychewealth.com", "refreshrevoked"));
+    UserEntity user = userRepository.save(existingLoginUser);
     refreshTokenRepository.save(
         buildRefreshToken("revoked-refresh-token", user, Instant.now().plusSeconds(3600), true));
 
     mockMvc
         .perform(
-            post(REFRESH_URL)
+            post(AUTH_REFRESH_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     objectMapper.writeValueAsString(
                         new RefreshTokenRequestDto("revoked-refresh-token"))))
         .andExpect(status().isUnauthorized())
-        .andExpect(jsonPath("$.code").value("TYCHE-103"))
-        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"))
-        .andExpect(jsonPath("$.description").value("The provided refresh token is invalid"));
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getType()))
+        .andExpect(
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getDescription()));
   }
 
   @Test
   void refreshReturnsUnauthorizedWhenRefreshTokenIsExpired() throws Exception {
-    UserEntity user =
-        userRepository.save(buildUser("refresh.expired@tychewealth.com", "refreshexpired"));
+    UserEntity user = userRepository.save(existingLoginUser);
     refreshTokenRepository.save(
         buildRefreshToken("expired-refresh-token", user, Instant.now().minusSeconds(5), false));
 
     mockMvc
         .perform(
-            post(REFRESH_URL)
+            post(AUTH_REFRESH_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     objectMapper.writeValueAsString(
                         new RefreshTokenRequestDto("expired-refresh-token"))))
         .andExpect(status().isUnauthorized())
-        .andExpect(jsonPath("$.code").value("TYCHE-103"))
-        .andExpect(jsonPath("$.type").value("AUTH_REFRESH_TOKEN_INVALID"))
-        .andExpect(jsonPath("$.description").value("The provided refresh token is invalid"));
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getType()))
+        .andExpect(
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getDescription()));
   }
 
   @Test
   void refreshReturnsBadRequestWhenPayloadIsInvalid() throws Exception {
     mockMvc
         .perform(
-            post(REFRESH_URL)
+            post(AUTH_REFRESH_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"refreshToken\":\" \"}"))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("TYCHE-002"))
-        .andExpect(jsonPath("$.type").value("GENERIC_VALIDATION_ERROR"));
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()));
   }
 
   @Test
   void refreshReturnsBadRequestWhenRequestBodyIsEmpty() throws Exception {
     mockMvc
-        .perform(post(REFRESH_URL).contentType(MediaType.APPLICATION_JSON).content(""))
+        .perform(post(AUTH_REFRESH_URL).contentType(MediaType.APPLICATION_JSON).content(""))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("TYCHE-003"))
-        .andExpect(jsonPath("$.type").value("GENERIC_BAD_REQUEST"));
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_BAD_REQUEST.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_BAD_REQUEST.getType()));
+  }
+
+  @Test
+  void refreshRecordsRequestSuccessAndTokenLifecycleMetrics() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    String previousTokenValue = "metrics-refresh-token";
+    refreshTokenRepository.save(
+        buildRefreshToken(previousTokenValue, user, Instant.now().plusSeconds(3600), false));
+
+    double requestsBefore = counterValue(METRIC_AUTH_REFRESH_REQUESTS);
+    double successBefore = counterValue(METRIC_AUTH_REFRESH_SUCCESS);
+    double issuedBefore = counterValue(METRIC_AUTH_REFRESH_TOKEN_ISSUED);
+    double revokedBefore = counterValue(METRIC_AUTH_REFRESH_TOKEN_REVOKED);
+
+    refresh(previousTokenValue).andExpect(status().isOk());
+
+    assertEquals(requestsBefore + 1, counterValue(METRIC_AUTH_REFRESH_REQUESTS));
+    assertEquals(successBefore + 1, counterValue(METRIC_AUTH_REFRESH_SUCCESS));
+    assertEquals(issuedBefore + 1, counterValue(METRIC_AUTH_REFRESH_TOKEN_ISSUED));
+    assertEquals(revokedBefore + 1, counterValue(METRIC_AUTH_REFRESH_TOKEN_REVOKED));
+  }
+
+  @Test
+  void refreshReturnsTooManyRequestsWhenRateLimitIsExceeded() throws Exception {
+    double requestsBefore = counterValue(METRIC_AUTH_REFRESH_REQUESTS);
+    double rateLimitedBefore = counterValue(METRIC_AUTH_REFRESH_RATE_LIMITED);
+
+    refresh(MISSING_REFRESH_TOKEN).andExpect(status().isUnauthorized());
+
+    refresh(MISSING_REFRESH_TOKEN).andExpect(status().isUnauthorized());
+
+    mockMvc
+        .perform(
+            post(AUTH_REFRESH_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new RefreshTokenRequestDto(MISSING_REFRESH_TOKEN))))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.RATE_LIMITED.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.RATE_LIMITED.getType()))
+        .andExpect(jsonPath("$.description").value("Too many refresh token requests"));
+
+    assertEquals(requestsBefore + 3, counterValue(METRIC_AUTH_REFRESH_REQUESTS));
+    assertEquals(rateLimitedBefore + 1, counterValue(METRIC_AUTH_REFRESH_RATE_LIMITED));
+  }
+
+  private double counterValue(String counterName) {
+    return meterRegistry.find(counterName).counter() == null
+        ? 0
+        : meterRegistry.find(counterName).counter().count();
+  }
+
+  private LoginResponseDto login(LoginRequestDto request) throws Exception {
+    String responseBody =
+        loginRequest(request)
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    return objectMapper.readValue(responseBody, LoginResponseDto.class);
+  }
+
+  private org.springframework.test.web.servlet.ResultActions registerRequest(
+      RegisterRequestDto request) throws Exception {
+    return mockMvc.perform(
+        post(AUTH_REGISTER_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions loginRequest(LoginRequestDto request)
+      throws Exception {
+    return mockMvc.perform(
+        post(AUTH_LOGIN_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions refresh(String refreshToken)
+      throws Exception {
+    return mockMvc.perform(
+        post(AUTH_REFRESH_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(new RefreshTokenRequestDto(refreshToken))));
   }
 }

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.tychewealth.controller;
 import static com.tychewealth.constants.ApiConstants.AUTH_LOGIN_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REGISTER_URL;
+import static com.tychewealth.constants.AuthConstants.LOGIN_RATE_LIMIT_MESSAGE;
 import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_FAILURE;
 import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_INVALID_CREDENTIALS;
 import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_RATE_LIMITED;
@@ -18,6 +19,8 @@ import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_FAILU
 import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_RATE_LIMITED;
 import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_REQUESTS;
 import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_SUCCESS;
+import static com.tychewealth.constants.AuthConstants.REFRESH_RATE_LIMIT_MESSAGE;
+import static com.tychewealth.constants.AuthConstants.REGISTER_RATE_LIMIT_MESSAGE;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
 import static com.tychewealth.testdata.EntityBuilder.buildRefreshToken;
 import static org.hamcrest.Matchers.containsString;
@@ -56,6 +59,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 @SpringBootTest(classes = AuthIntegrationTestConfig.class)
 @ContextConfiguration(initializers = AuthIntegrationTestConfig.Initializer.class)
@@ -63,6 +67,10 @@ import org.springframework.test.web.servlet.MockMvc;
 class AuthApiControllerIntegrationTest {
 
   private static final String MISSING_REFRESH_TOKEN = "missing-token";
+  private static final String EXISTING_REFRESH_TOKEN = "existing-refresh-token";
+  private static final String REVOKED_REFRESH_TOKEN = "revoked-refresh-token";
+  private static final String EXPIRED_REFRESH_TOKEN = "expired-refresh-token";
+  private static final String METRICS_REFRESH_TOKEN = "metrics-refresh-token";
   private static final String VALID_PASSWORD = "Secret123!";
   private static final String INVALID_PASSWORD = "Wrong123!";
 
@@ -121,11 +129,7 @@ class AuthApiControllerIntegrationTest {
     double requestsBefore = counterValue(METRIC_AUTH_REGISTER_REQUESTS);
     double successBefore = counterValue(METRIC_AUTH_REGISTER_SUCCESS);
 
-    mockMvc
-        .perform(
-            post(AUTH_REGISTER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validRequest)))
+    registerRequest(validRequest)
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").isNumber())
         .andExpect(jsonPath("$.email").value(validRequest.getEmail()))
@@ -147,11 +151,7 @@ class AuthApiControllerIntegrationTest {
     double failureBefore = counterValue(METRIC_AUTH_REGISTER_FAILURE);
     double conflictBefore = counterValue(METRIC_AUTH_REGISTER_CONFLICT);
 
-    mockMvc
-        .perform(
-            post(AUTH_REGISTER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(conflictByEmailRequest)))
+    registerRequest(conflictByEmailRequest)
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getType()))
@@ -167,11 +167,7 @@ class AuthApiControllerIntegrationTest {
   void registerReturnsConflictWhenUsernameAlreadyExists() throws Exception {
     userRepository.save(existingUsernameUser);
 
-    mockMvc
-        .perform(
-            post(AUTH_REGISTER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(conflictByUsernameRequest)))
+    registerRequest(conflictByUsernameRequest)
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getType()))
@@ -180,7 +176,6 @@ class AuthApiControllerIntegrationTest {
                 .value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getDescription()));
   }
 
-  @Test
   void registerReturnsTooManyRequestsWhenRateLimitIsExceeded() throws Exception {
     RegisterRequestDto invalidRegisterRequest = new RegisterRequestDto("", "", "short");
     double requestsBefore = counterValue(METRIC_AUTH_REGISTER_REQUESTS);
@@ -190,15 +185,11 @@ class AuthApiControllerIntegrationTest {
 
     registerRequest(invalidRegisterRequest).andExpect(status().isBadRequest());
 
-    mockMvc
-        .perform(
-            post(AUTH_REGISTER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidRegisterRequest)))
+    registerRequest(invalidRegisterRequest)
         .andExpect(status().isTooManyRequests())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.RATE_LIMITED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.RATE_LIMITED.getType()))
-        .andExpect(jsonPath("$.description").value("Too many register requests"));
+        .andExpect(jsonPath("$.description").value(REGISTER_RATE_LIMIT_MESSAGE));
 
     assertEquals(requestsBefore + 3, counterValue(METRIC_AUTH_REGISTER_REQUESTS));
     assertEquals(rateLimitedBefore + 1, counterValue(METRIC_AUTH_REGISTER_RATE_LIMITED));
@@ -208,11 +199,7 @@ class AuthApiControllerIntegrationTest {
   @MethodSource("com.tychewealth.testdata.AuthTestData#invalidCreateRequests")
   void registerReturnsBadRequestForInvalidPayload(
       RegisterRequestDto invalidRequest, String expectedMessage) throws Exception {
-    mockMvc
-        .perform(
-            post(AUTH_REGISTER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidRequest)))
+    registerRequest(invalidRequest)
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()))
@@ -225,11 +212,7 @@ class AuthApiControllerIntegrationTest {
     double requestsBefore = counterValue(METRIC_AUTH_LOGIN_REQUESTS);
     double successBefore = counterValue(METRIC_AUTH_LOGIN_SUCCESS);
 
-    mockMvc
-        .perform(
-            post(AUTH_LOGIN_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(validLoginRequest)))
+    loginRequest(validLoginRequest)
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.tokenType").value(TOKEN_TYPE_BEARER))
         .andExpect(jsonPath("$.accessToken").isString())
@@ -253,11 +236,7 @@ class AuthApiControllerIntegrationTest {
     LoginRequestDto invalidLoginRequest =
         new LoginRequestDto(validRequest.getEmail(), INVALID_PASSWORD);
 
-    mockMvc
-        .perform(
-            post(AUTH_LOGIN_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidLoginRequest)))
+    loginRequest(invalidLoginRequest)
         .andExpect(status().isUnauthorized())
         .andExpect(
             jsonPath("$.code").value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getCode()))
@@ -284,15 +263,11 @@ class AuthApiControllerIntegrationTest {
 
     loginRequest(invalidLoginRequest).andExpect(status().isUnauthorized());
 
-    mockMvc
-        .perform(
-            post(AUTH_LOGIN_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidLoginRequest)))
+    loginRequest(invalidLoginRequest)
         .andExpect(status().isTooManyRequests())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.RATE_LIMITED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.RATE_LIMITED.getType()))
-        .andExpect(jsonPath("$.description").value("Too many login requests"));
+        .andExpect(jsonPath("$.description").value(LOGIN_RATE_LIMIT_MESSAGE));
 
     assertEquals(requestsBefore + 3, counterValue(METRIC_AUTH_LOGIN_REQUESTS));
     assertEquals(rateLimitedBefore + 1, counterValue(METRIC_AUTH_LOGIN_RATE_LIMITED));
@@ -320,11 +295,7 @@ class AuthApiControllerIntegrationTest {
   @MethodSource("com.tychewealth.testdata.AuthTestData#invalidLoginRequests")
   void loginReturnsBadRequestForInvalidPayload(
       LoginRequestDto invalidRequest, String expectedMessage) throws Exception {
-    mockMvc
-        .perform(
-            post(AUTH_LOGIN_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidRequest)))
+    loginRequest(invalidRequest)
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()))
@@ -334,19 +305,13 @@ class AuthApiControllerIntegrationTest {
   @Test
   void refreshRotatesTokensWhenRefreshTokenIsValid() throws Exception {
     UserEntity user = userRepository.save(existingLoginUser);
-    String previousTokenValue = "existing-refresh-token";
+    String previousTokenValue = EXISTING_REFRESH_TOKEN;
     RefreshTokenEntity previousToken =
         refreshTokenRepository.save(
             buildRefreshToken(previousTokenValue, user, Instant.now().plusSeconds(3600), false));
 
     String responseBody =
-        mockMvc
-            .perform(
-                post(AUTH_REFRESH_URL)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(
-                        objectMapper.writeValueAsString(
-                            new RefreshTokenRequestDto(previousTokenValue))))
+        refresh(previousTokenValue)
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.tokenType").value(TOKEN_TYPE_BEARER))
             .andExpect(jsonPath("$.accessToken").isString())
@@ -378,13 +343,7 @@ class AuthApiControllerIntegrationTest {
 
   @Test
   void refreshReturnsUnauthorizedWhenRefreshTokenDoesNotExist() throws Exception {
-    mockMvc
-        .perform(
-            post(AUTH_REFRESH_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    objectMapper.writeValueAsString(
-                        new RefreshTokenRequestDto(MISSING_REFRESH_TOKEN))))
+    refresh(MISSING_REFRESH_TOKEN)
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getType()))
@@ -397,15 +356,9 @@ class AuthApiControllerIntegrationTest {
   void refreshReturnsUnauthorizedWhenRefreshTokenIsRevoked() throws Exception {
     UserEntity user = userRepository.save(existingLoginUser);
     refreshTokenRepository.save(
-        buildRefreshToken("revoked-refresh-token", user, Instant.now().plusSeconds(3600), true));
+        buildRefreshToken(REVOKED_REFRESH_TOKEN, user, Instant.now().plusSeconds(3600), true));
 
-    mockMvc
-        .perform(
-            post(AUTH_REFRESH_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    objectMapper.writeValueAsString(
-                        new RefreshTokenRequestDto("revoked-refresh-token"))))
+    refresh(REVOKED_REFRESH_TOKEN)
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getType()))
@@ -418,15 +371,9 @@ class AuthApiControllerIntegrationTest {
   void refreshReturnsUnauthorizedWhenRefreshTokenIsExpired() throws Exception {
     UserEntity user = userRepository.save(existingLoginUser);
     refreshTokenRepository.save(
-        buildRefreshToken("expired-refresh-token", user, Instant.now().minusSeconds(5), false));
+        buildRefreshToken(EXPIRED_REFRESH_TOKEN, user, Instant.now().minusSeconds(5), false));
 
-    mockMvc
-        .perform(
-            post(AUTH_REFRESH_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    objectMapper.writeValueAsString(
-                        new RefreshTokenRequestDto("expired-refresh-token"))))
+    refresh(EXPIRED_REFRESH_TOKEN)
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID.getType()))
@@ -437,11 +384,7 @@ class AuthApiControllerIntegrationTest {
 
   @Test
   void refreshReturnsBadRequestWhenPayloadIsInvalid() throws Exception {
-    mockMvc
-        .perform(
-            post(AUTH_REFRESH_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"refreshToken\":\" \"}"))
+    refresh(" ")
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()));
@@ -459,7 +402,7 @@ class AuthApiControllerIntegrationTest {
   @Test
   void refreshRecordsRequestSuccessAndTokenLifecycleMetrics() throws Exception {
     UserEntity user = userRepository.save(existingLoginUser);
-    String previousTokenValue = "metrics-refresh-token";
+    String previousTokenValue = METRICS_REFRESH_TOKEN;
     refreshTokenRepository.save(
         buildRefreshToken(previousTokenValue, user, Instant.now().plusSeconds(3600), false));
 
@@ -485,26 +428,19 @@ class AuthApiControllerIntegrationTest {
 
     refresh(MISSING_REFRESH_TOKEN).andExpect(status().isUnauthorized());
 
-    mockMvc
-        .perform(
-            post(AUTH_REFRESH_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    objectMapper.writeValueAsString(
-                        new RefreshTokenRequestDto(MISSING_REFRESH_TOKEN))))
+    refresh(MISSING_REFRESH_TOKEN)
         .andExpect(status().isTooManyRequests())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.RATE_LIMITED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.RATE_LIMITED.getType()))
-        .andExpect(jsonPath("$.description").value("Too many refresh token requests"));
+        .andExpect(jsonPath("$.description").value(REFRESH_RATE_LIMIT_MESSAGE));
 
     assertEquals(requestsBefore + 3, counterValue(METRIC_AUTH_REFRESH_REQUESTS));
     assertEquals(rateLimitedBefore + 1, counterValue(METRIC_AUTH_REFRESH_RATE_LIMITED));
   }
 
   private double counterValue(String counterName) {
-    return meterRegistry.find(counterName).counter() == null
-        ? 0
-        : meterRegistry.find(counterName).counter().count();
+    var counter = meterRegistry.find(counterName).counter();
+    return counter == null ? 0 : counter.count();
   }
 
   private LoginResponseDto login(LoginRequestDto request) throws Exception {
@@ -518,24 +454,21 @@ class AuthApiControllerIntegrationTest {
     return objectMapper.readValue(responseBody, LoginResponseDto.class);
   }
 
-  private org.springframework.test.web.servlet.ResultActions registerRequest(
-      RegisterRequestDto request) throws Exception {
+  private ResultActions registerRequest(RegisterRequestDto request) throws Exception {
     return mockMvc.perform(
         post(AUTH_REGISTER_URL)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)));
   }
 
-  private org.springframework.test.web.servlet.ResultActions loginRequest(LoginRequestDto request)
-      throws Exception {
+  private ResultActions loginRequest(LoginRequestDto request) throws Exception {
     return mockMvc.perform(
         post(AUTH_LOGIN_URL)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)));
   }
 
-  private org.springframework.test.web.servlet.ResultActions refresh(String refreshToken)
-      throws Exception {
+  private ResultActions refresh(String refreshToken) throws Exception {
     return mockMvc.perform(
         post(AUTH_REFRESH_URL)
             .contentType(MediaType.APPLICATION_JSON)

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -176,6 +176,7 @@ class AuthApiControllerIntegrationTest {
                 .value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getDescription()));
   }
 
+  @Test
   void registerReturnsTooManyRequestsWhenRateLimitIsExceeded() throws Exception {
     RegisterRequestDto invalidRegisterRequest = new RegisterRequestDto("", "", "short");
     double requestsBefore = counterValue(METRIC_AUTH_REGISTER_REQUESTS);

--- a/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
+++ b/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
@@ -72,18 +72,22 @@ class RefreshTokenRepositoryTest {
   void revokeActiveTokensByUserIdRevokesOnlyActiveTokensForSpecifiedUser() {
     UserEntity targetUser = userRepository.save(buildUser("sofia@tyche.com", "sofia"));
     UserEntity otherUser = userRepository.save(buildUser("diego@tyche.com", "diego"));
+    Instant now = Instant.now();
 
     RefreshTokenEntity activeToken =
         refreshTokenRepository.save(
-            buildRefreshToken(ACTIVE_TOKEN, targetUser, Instant.now().plusSeconds(3600), false));
+            buildRefreshToken(ACTIVE_TOKEN, targetUser, now.plusSeconds(3600), false));
     RefreshTokenEntity alreadyRevokedToken =
         refreshTokenRepository.save(
-            buildRefreshToken(REVOKED_TOKEN, targetUser, Instant.now().plusSeconds(3600), true));
+            buildRefreshToken(REVOKED_TOKEN, targetUser, now.plusSeconds(3600), true));
+    RefreshTokenEntity expiredUnrevokedToken =
+        refreshTokenRepository.save(
+            buildRefreshToken(EXPIRED_REFRESH_TOKEN, targetUser, now.minusSeconds(5), false));
     RefreshTokenEntity otherUserActiveToken =
         refreshTokenRepository.save(
-            buildRefreshToken(OTHER_USER_TOKEN, otherUser, Instant.now().plusSeconds(3600), false));
+            buildRefreshToken(OTHER_USER_TOKEN, otherUser, now.plusSeconds(3600), false));
 
-    int revokedCount = refreshTokenRepository.revokeActiveTokensByUserId(targetUser.getId());
+    int revokedCount = refreshTokenRepository.revokeActiveTokensByUserId(targetUser.getId(), now);
 
     assertEquals(1, revokedCount);
     assertTrue(
@@ -91,6 +95,11 @@ class RefreshTokenRepositoryTest {
     assertTrue(
         refreshTokenRepository
             .findByToken(alreadyRevokedToken.getToken())
+            .orElseThrow()
+            .isRevoked());
+    assertFalse(
+        refreshTokenRepository
+            .findByToken(expiredUnrevokedToken.getToken())
             .orElseThrow()
             .isRevoked());
     assertFalse(

--- a/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
+++ b/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
@@ -56,4 +56,37 @@ class RefreshTokenRepositoryTest {
     assertNotNull(saved.getId());
     assertNotNull(saved.getCreatedAt());
   }
+
+  @Test
+  void revokeActiveTokensByUserIdRevokesOnlyActiveTokensForSpecifiedUser() {
+    UserEntity targetUser = userRepository.save(buildUser("sofia@tyche.com", "sofia"));
+    UserEntity otherUser = userRepository.save(buildUser("diego@tyche.com", "diego"));
+
+    RefreshTokenEntity activeToken =
+        refreshTokenRepository.save(
+            buildRefreshToken("active-token", targetUser, Instant.now().plusSeconds(3600), false));
+    RefreshTokenEntity alreadyRevokedToken =
+        refreshTokenRepository.save(
+            buildRefreshToken("revoked-token", targetUser, Instant.now().plusSeconds(3600), true));
+    RefreshTokenEntity otherUserActiveToken =
+        refreshTokenRepository.save(
+            buildRefreshToken(
+                "other-user-token", otherUser, Instant.now().plusSeconds(3600), false));
+
+    int revokedCount = refreshTokenRepository.revokeActiveTokensByUserId(targetUser.getId());
+
+    assertEquals(1, revokedCount);
+    assertTrue(
+        refreshTokenRepository.findByToken(activeToken.getToken()).orElseThrow().isRevoked());
+    assertTrue(
+        refreshTokenRepository
+            .findByToken(alreadyRevokedToken.getToken())
+            .orElseThrow()
+            .isRevoked());
+    assertFalse(
+        refreshTokenRepository
+            .findByToken(otherUserActiveToken.getToken())
+            .orElseThrow()
+            .isRevoked());
+  }
 }

--- a/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
+++ b/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
@@ -21,6 +21,16 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 class RefreshTokenRepositoryTest {
 
+  private static final String MISSING_TOKEN = "missing-token";
+  private static final String SAVED_REFRESH_TOKEN = "refresh-token-123";
+  private static final String ANOTHER_SAVED_REFRESH_TOKEN = "refresh-token-456";
+  private static final String ACTIVE_TOKEN = "active-token";
+  private static final String REVOKED_TOKEN = "revoked-token";
+  private static final String OTHER_USER_TOKEN = "other-user-token";
+  private static final String ACTIVE_REFRESH_TOKEN = "active-refresh-token";
+  private static final String EXPIRED_REFRESH_TOKEN = "expired-refresh-token";
+  private static final String REVOKED_REFRESH_TOKEN = "revoked-refresh-token";
+
   @Autowired private RefreshTokenRepository refreshTokenRepository;
 
   @Autowired private UserRepository userRepository;
@@ -29,9 +39,9 @@ class RefreshTokenRepositoryTest {
   void findByTokenReturnsSavedToken() {
     UserEntity user = userRepository.save(buildUser("lucia@tyche.com", "lucia"));
     Instant expiresAt = Instant.now().plusSeconds(3600);
-    refreshTokenRepository.save(buildRefreshToken("refresh-token-123", user, expiresAt, false));
+    refreshTokenRepository.save(buildRefreshToken(SAVED_REFRESH_TOKEN, user, expiresAt, false));
 
-    Optional<RefreshTokenEntity> result = refreshTokenRepository.findByToken("refresh-token-123");
+    Optional<RefreshTokenEntity> result = refreshTokenRepository.findByToken(SAVED_REFRESH_TOKEN);
 
     assertTrue(result.isPresent());
     assertEquals(user.getId(), result.get().getUser().getId());
@@ -41,7 +51,7 @@ class RefreshTokenRepositoryTest {
 
   @Test
   void findByTokenReturnsEmptyWhenTokenDoesNotExist() {
-    Optional<RefreshTokenEntity> result = refreshTokenRepository.findByToken("missing-token");
+    Optional<RefreshTokenEntity> result = refreshTokenRepository.findByToken(MISSING_TOKEN);
 
     assertTrue(result.isEmpty());
   }
@@ -51,7 +61,8 @@ class RefreshTokenRepositoryTest {
     UserEntity user = userRepository.save(buildUser("marco@tyche.com", "marco"));
     RefreshTokenEntity saved =
         refreshTokenRepository.save(
-            buildRefreshToken("refresh-token-456", user, Instant.now().plusSeconds(1800), false));
+            buildRefreshToken(
+                ANOTHER_SAVED_REFRESH_TOKEN, user, Instant.now().plusSeconds(1800), false));
 
     assertNotNull(saved.getId());
     assertNotNull(saved.getCreatedAt());
@@ -64,14 +75,13 @@ class RefreshTokenRepositoryTest {
 
     RefreshTokenEntity activeToken =
         refreshTokenRepository.save(
-            buildRefreshToken("active-token", targetUser, Instant.now().plusSeconds(3600), false));
+            buildRefreshToken(ACTIVE_TOKEN, targetUser, Instant.now().plusSeconds(3600), false));
     RefreshTokenEntity alreadyRevokedToken =
         refreshTokenRepository.save(
-            buildRefreshToken("revoked-token", targetUser, Instant.now().plusSeconds(3600), true));
+            buildRefreshToken(REVOKED_TOKEN, targetUser, Instant.now().plusSeconds(3600), true));
     RefreshTokenEntity otherUserActiveToken =
         refreshTokenRepository.save(
-            buildRefreshToken(
-                "other-user-token", otherUser, Instant.now().plusSeconds(3600), false));
+            buildRefreshToken(OTHER_USER_TOKEN, otherUser, Instant.now().plusSeconds(3600), false));
 
     int revokedCount = refreshTokenRepository.revokeActiveTokensByUserId(targetUser.getId());
 
@@ -88,5 +98,32 @@ class RefreshTokenRepositoryTest {
             .findByToken(otherUserActiveToken.getToken())
             .orElseThrow()
             .isRevoked());
+  }
+
+  @Test
+  void revokeTokenIfActiveRevokesOnlyNonExpiredNonRevokedToken() {
+    UserEntity user = userRepository.save(buildUser("nora@tyche.com", "nora"));
+    Instant now = Instant.now();
+
+    RefreshTokenEntity activeToken =
+        refreshTokenRepository.save(
+            buildRefreshToken(ACTIVE_REFRESH_TOKEN, user, now.plusSeconds(3600), false));
+    refreshTokenRepository.save(
+        buildRefreshToken(EXPIRED_REFRESH_TOKEN, user, now.minusSeconds(5), false));
+    refreshTokenRepository.save(
+        buildRefreshToken(REVOKED_REFRESH_TOKEN, user, now.plusSeconds(3600), true));
+
+    int activeRevoked = refreshTokenRepository.revokeTokenIfActive(activeToken.getToken(), now);
+    int expiredRevoked = refreshTokenRepository.revokeTokenIfActive(EXPIRED_REFRESH_TOKEN, now);
+    int alreadyRevoked = refreshTokenRepository.revokeTokenIfActive(REVOKED_REFRESH_TOKEN, now);
+
+    assertEquals(1, activeRevoked);
+    assertEquals(0, expiredRevoked);
+    assertEquals(0, alreadyRevoked);
+    assertTrue(
+        refreshTokenRepository.findByToken(activeToken.getToken()).orElseThrow().isRevoked());
+    assertFalse(
+        refreshTokenRepository.findByToken(EXPIRED_REFRESH_TOKEN).orElseThrow().isRevoked());
+    assertTrue(refreshTokenRepository.findByToken(REVOKED_REFRESH_TOKEN).orElseThrow().isRevoked());
   }
 }

--- a/user-service/src/test/java/com/tychewealth/service/helper/AuthValidationHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/AuthValidationHelperTest.java
@@ -1,0 +1,38 @@
+package com.tychewealth.service.helper;
+
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_LOGIN_FAILURE;
+import static com.tychewealth.constants.AuthConstants.METRIC_AUTH_REGISTER_FAILURE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.monitoring.AuthMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class AuthValidationHelperTest {
+
+  private final UserRepository userRepository = mock(UserRepository.class);
+  private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final AuthMetrics authMetrics = new AuthMetrics(meterRegistry);
+  private final AuthValidationHelper authValidationHelper =
+      new AuthValidationHelper(userRepository, passwordEncoder, authMetrics);
+
+  @Test
+  void validateRegisterPasswordFormatRecordsRegisterFailure() {
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () -> authValidationHelper.validateRegisterPasswordFormat("alllowercase1!"));
+
+    assertEquals(
+        ErrorDefinition.AUTH_REGISTER_PASSWORD_FORMAT_INVALID, exception.getErrorDefinition());
+    assertEquals(1.0, meterRegistry.get(METRIC_AUTH_REGISTER_FAILURE).counter().count());
+    assertEquals(0.0, meterRegistry.get(METRIC_AUTH_LOGIN_FAILURE).counter().count());
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/web/AuthRateLimitInterceptorTest.java
+++ b/user-service/src/test/java/com/tychewealth/web/AuthRateLimitInterceptorTest.java
@@ -1,0 +1,106 @@
+package com.tychewealth.web;
+
+import static com.tychewealth.constants.AuthConstants.LOGIN_RATE_LIMIT_MESSAGE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Deque;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.server.ResponseStatusException;
+
+class AuthRateLimitInterceptorTest {
+
+  @Test
+  void preHandleUsesRemoteAddressInsteadOfForwardedForHeader() {
+    AuthRateLimitInterceptor interceptor =
+        new AuthRateLimitInterceptor(1, 60, LOGIN_RATE_LIMIT_MESSAGE, null, null);
+
+    MockHttpServletRequest firstRequest = buildRequest("198.51.100.10");
+    MockHttpServletRequest secondRequest = buildRequest("203.0.113.20");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Object handler = new Object();
+
+    assertDoesNotThrow(() -> interceptor.preHandle(firstRequest, response, handler));
+    assertThrows(
+        ResponseStatusException.class,
+        () -> interceptor.preHandle(secondRequest, response, handler));
+  }
+
+  @Test
+  void preHandleAllowsRequestsAgainAfterIdleBucketExpires() {
+    MutableTicker ticker = new MutableTicker();
+    MutableClock clock = new MutableClock();
+    Cache<String, Deque<Long>> cache =
+        Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(1)).ticker(ticker).build();
+    AuthRateLimitInterceptor interceptor =
+        new AuthRateLimitInterceptor(1, 1, LOGIN_RATE_LIMIT_MESSAGE, null, null, cache, clock);
+
+    MockHttpServletRequest request = buildRequest(null);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Object handler = new Object();
+
+    assertDoesNotThrow(() -> interceptor.preHandle(request, response, handler));
+    assertThrows(
+        ResponseStatusException.class, () -> interceptor.preHandle(request, response, handler));
+
+    ticker.advance(Duration.ofSeconds(2));
+    clock.advance(Duration.ofSeconds(2));
+
+    assertDoesNotThrow(() -> interceptor.preHandle(request, response, handler));
+  }
+
+  private static MockHttpServletRequest buildRequest(String forwardedFor) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("127.0.0.1");
+    if (forwardedFor != null) {
+      request.addHeader("X-Forwarded-For", forwardedFor);
+    }
+    return request;
+  }
+
+  private static final class MutableTicker implements Ticker {
+    private long nanos;
+
+    @Override
+    public long read() {
+      return nanos;
+    }
+
+    private void advance(Duration duration) {
+      nanos += duration.toNanos();
+    }
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant instant = Instant.parse("2026-03-11T00:00:00Z");
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+
+    private void advance(Duration duration) {
+      instant = instant.plus(duration);
+    }
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/web/RefreshRateLimitInterceptorTest.java
+++ b/user-service/src/test/java/com/tychewealth/web/RefreshRateLimitInterceptorTest.java
@@ -1,0 +1,108 @@
+package com.tychewealth.web;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
+import com.tychewealth.service.monitoring.AuthMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Deque;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.server.ResponseStatusException;
+
+class RefreshRateLimitInterceptorTest {
+
+  @Test
+  void preHandleUsesRemoteAddressInsteadOfForwardedForHeader() {
+    AuthMetrics authMetrics = new AuthMetrics(new SimpleMeterRegistry());
+    RefreshRateLimitInterceptor interceptor = new RefreshRateLimitInterceptor(1, 60, authMetrics);
+
+    MockHttpServletRequest firstRequest = buildRequest("198.51.100.10");
+    MockHttpServletRequest secondRequest = buildRequest("203.0.113.20");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Object handler = new Object();
+
+    assertDoesNotThrow(() -> interceptor.preHandle(firstRequest, response, handler));
+    assertThrows(
+        ResponseStatusException.class,
+        () -> interceptor.preHandle(secondRequest, response, handler));
+  }
+
+  @Test
+  void preHandleAllowsRequestsAgainAfterIdleBucketExpires() {
+    AuthMetrics authMetrics = new AuthMetrics(new SimpleMeterRegistry());
+    MutableTicker ticker = new MutableTicker();
+    MutableClock clock = new MutableClock();
+    Cache<String, Deque<Long>> cache =
+        Caffeine.newBuilder().expireAfterAccess(Duration.ofSeconds(1)).ticker(ticker).build();
+    RefreshRateLimitInterceptor interceptor =
+        new RefreshRateLimitInterceptor(1, 1, authMetrics, cache, clock);
+
+    MockHttpServletRequest request = buildRequest(null);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Object handler = new Object();
+
+    assertDoesNotThrow(() -> interceptor.preHandle(request, response, handler));
+    assertThrows(
+        ResponseStatusException.class, () -> interceptor.preHandle(request, response, handler));
+
+    ticker.advance(Duration.ofSeconds(2));
+    clock.advance(Duration.ofSeconds(2));
+
+    assertDoesNotThrow(() -> interceptor.preHandle(request, response, handler));
+  }
+
+  private static MockHttpServletRequest buildRequest(String forwardedFor) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("127.0.0.1");
+    if (forwardedFor != null) {
+      request.addHeader("X-Forwarded-For", forwardedFor);
+    }
+    return request;
+  }
+
+  private static final class MutableTicker implements Ticker {
+    private long nanos;
+
+    @Override
+    public long read() {
+      return nanos;
+    }
+
+    private void advance(Duration duration) {
+      nanos += duration.toNanos();
+    }
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant instant = Instant.parse("2026-03-11T00:00:00Z");
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+
+    private void advance(Duration duration) {
+      instant = instant.plus(duration);
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-client rate limiting for auth endpoints (register, login, refresh) with configurable thresholds and reset.
  * Auth monitoring added: counters for requests, successes, failures, conflicts, rate-limited events, and token issuance/revocation.

* **Improvements**
  * Refresh response uses expiresIn (seconds); refresh token storage made stricter (non-null revoked flag).
  * Centralized auth endpoint constants and default rate-limit properties added.

* **Bug Fixes**
  * HTTP 429 returned for rate-limited requests.

* **Tests**
  * Expanded unit and integration tests for rate limiting, metrics, token lifecycle, and validation.

Closes #15 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->