### PR TITLE
[TYCHE-22] implement resend email service and email limit with Redis

### DIFF
--- a/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
+++ b/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
@@ -35,6 +35,7 @@ public class EmailConfig {
     Assert.hasText(
         resendEmailProperties.getFrom(),
         "app.email.resend.from must be configured when Resend is enabled");
+    Assert.isTrue(emailDailyLimit > 0, "app.email.daily-limit must be a positive integer");
 
     RestClient restClient = restClientBuilder.baseUrl(resendEmailProperties.getBaseUrl()).build();
     return new EmailServiceHelper(

--- a/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
+++ b/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
@@ -1,0 +1,43 @@
+package com.tychewealth.config;
+
+import com.tychewealth.dto.email.ResendEmailPropertiesDto;
+import com.tychewealth.service.helper.email.EmailServiceHelper;
+import com.tychewealth.service.ratelimit.RateLimitStore;
+import java.time.Clock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(ResendEmailPropertiesDto.class)
+public class EmailConfig {
+
+  @Bean
+  public Clock emailClock() {
+    return Clock.systemUTC();
+  }
+
+  @Bean
+  @ConditionalOnProperty(prefix = "app.email.resend", name = "enabled", havingValue = "true")
+  public EmailServiceHelper emailServiceHelper(
+      RestClient.Builder restClientBuilder,
+      ResendEmailPropertiesDto resendEmailProperties,
+      @Value("${app.email.daily-limit:80}") int emailDailyLimit,
+      RateLimitStore rateLimitStore,
+      Clock emailClock) {
+    Assert.hasText(
+        resendEmailProperties.getApiKey(),
+        "app.email.resend.api-key must be configured when Resend is enabled");
+    Assert.hasText(
+        resendEmailProperties.getFrom(),
+        "app.email.resend.from must be configured when Resend is enabled");
+
+    RestClient restClient = restClientBuilder.baseUrl(resendEmailProperties.getBaseUrl()).build();
+    return new EmailServiceHelper(
+        restClient, resendEmailProperties, emailDailyLimit, rateLimitStore, emailClock);
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/constants/ApiConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/ApiConstants.java
@@ -19,6 +19,7 @@ public class ApiConstants {
 
   public static final String REQUEST_PRODUCES = MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8";
   public static final String REQUEST_CONSUMES = MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8";
+  public static final String RESEND_EMAILS_PATH = "/emails";
 
   ApiConstants() {}
 }

--- a/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -5,6 +5,7 @@ public final class LogConstants {
   public static final String BASE_LOG = "{} {}";
 
   public static final String AUTH = "[auth]";
+  public static final String EMAIL = "[email]";
   public static final String USER = "[user]";
   public static final String REGISTER_ACTION = "[register]";
   public static final String LOGIN_ACTION = "[login]";
@@ -16,6 +17,7 @@ public final class LogConstants {
   public static final String UPDATE_PASSWORD_ACTION = "[update-password]";
   public static final String DELETE_ACTION = "[delete]";
   public static final String ACCESS_TOKEN_ACTION = "[access-token]";
+  public static final String SEND_ACTION = "[send]";
 
   public static final String REQUEST_START = BASE_LOG + " Request started";
   public static final String REQUEST_SUCCESS = BASE_LOG + " Request succeeded";
@@ -26,6 +28,7 @@ public final class LogConstants {
   public static final String LOGIN_REQUEST_FIELDS = " email={}";
   public static final String UPDATE_REQUEST_FIELDS = " username={}";
   public static final String USER_ID = " userId={}";
+  public static final String EMAIL_REQUEST_FIELDS = " to={} subject={}";
 
   public static final String INVALID_LOGIN_CREDENTIALS_MESSAGE = "invalid login credentials";
   public static final String INVALID_PASSWORD_FORMAT_MESSAGE = "invalid password format";
@@ -33,6 +36,10 @@ public final class LogConstants {
   public static final String INVALID_AUTHORIZATION_HEADER_MESSAGE = "invalid authorization header";
   public static final String INVALID_ACCESS_TOKEN_MESSAGE = "invalid access token";
   public static final String RATE_LIMIT_STORE_UNAVAILABLE_MESSAGE = "rate limit store unavailable";
+  public static final String RESEND_DELIVERY_FAILED_MESSAGE = "resend delivery failed";
+  public static final String EMAIL_DAILY_QUOTA_EXCEEDED_MESSAGE = "daily email quota exceeded";
+  public static final String EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE =
+      "daily email quota exceeded; skipping send";
 
   private LogConstants() {}
 }

--- a/user-service/src/main/java/com/tychewealth/constants/RedisConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/RedisConstants.java
@@ -4,6 +4,9 @@ import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 public final class RedisConstants {
 
+  public static final String EMAIL_DAILY_LIMIT_NAMESPACE = "rate-limit:email:daily";
+  public static final String EMAIL_DAILY_LIMIT_CLIENT_KEY = "global";
+
   public static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT =
       new DefaultRedisScript<>(
           """

--- a/user-service/src/main/java/com/tychewealth/dto/email/ResendEmailPropertiesDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/email/ResendEmailPropertiesDto.java
@@ -1,0 +1,16 @@
+package com.tychewealth.dto.email;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.email.resend")
+public class ResendEmailPropertiesDto {
+
+  private boolean enabled = false;
+  private String apiKey;
+  private String from;
+  private String baseUrl = "https://api.resend.com";
+}

--- a/user-service/src/main/java/com/tychewealth/dto/email/request/ResendSendEmailRequestDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/email/request/ResendSendEmailRequestDto.java
@@ -1,0 +1,4 @@
+package com.tychewealth.dto.email.request;
+
+public record ResendSendEmailRequestDto(
+    String from, String to, String subject, String html, String text) {}

--- a/user-service/src/main/java/com/tychewealth/error/exception/EmailException.java
+++ b/user-service/src/main/java/com/tychewealth/error/exception/EmailException.java
@@ -1,0 +1,40 @@
+package com.tychewealth.error.exception;
+
+import com.tychewealth.error.handler.ErrorDefinition;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class EmailException extends RuntimeException {
+
+  private final ErrorDefinition errorDefinition;
+  private final Map<String, String> metadata;
+  private final HttpStatus httpStatus;
+
+  public EmailException(
+      ErrorDefinition errorDefinition, Map<String, String> metadata, HttpStatus httpStatus) {
+    this(resolve(errorDefinition), metadata, httpStatus);
+  }
+
+  public static EmailException of(
+      ErrorDefinition errorDefinition, Map<String, String> metadata, HttpStatus httpStatus) {
+    return new EmailException(errorDefinition, metadata, httpStatus);
+  }
+
+  private EmailException(
+      ResolvedError resolvedError, Map<String, String> metadata, HttpStatus httpStatus) {
+    super(resolvedError.errorDefinition().getDescription());
+
+    this.errorDefinition = resolvedError.errorDefinition();
+    this.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    this.httpStatus = httpStatus == null ? HttpStatus.INTERNAL_SERVER_ERROR : httpStatus;
+  }
+
+  private static ResolvedError resolve(ErrorDefinition errorDefinition) {
+    return new ResolvedError(
+        errorDefinition == null ? ErrorDefinition.EMAIL_DELIVERY_FAILED : errorDefinition);
+  }
+
+  private record ResolvedError(ErrorDefinition errorDefinition) {}
+}

--- a/user-service/src/main/java/com/tychewealth/error/exception/EmailException.java
+++ b/user-service/src/main/java/com/tychewealth/error/exception/EmailException.java
@@ -1,6 +1,7 @@
 package com.tychewealth.error.exception;
 
 import com.tychewealth.error.handler.ErrorDefinition;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -27,13 +28,28 @@ public class EmailException extends RuntimeException {
     super(resolvedError.errorDefinition().getDescription());
 
     this.errorDefinition = resolvedError.errorDefinition();
-    this.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    this.metadata = sanitizeMetadata(metadata);
     this.httpStatus = httpStatus == null ? HttpStatus.INTERNAL_SERVER_ERROR : httpStatus;
   }
 
   private static ResolvedError resolve(ErrorDefinition errorDefinition) {
     return new ResolvedError(
         errorDefinition == null ? ErrorDefinition.EMAIL_DELIVERY_FAILED : errorDefinition);
+  }
+
+  private Map<String, String> sanitizeMetadata(Map<String, String> metadata) {
+    if (metadata == null || metadata.isEmpty()) {
+      return Map.of();
+    }
+
+    Map<String, String> sanitizedMetadata = new HashMap<>();
+    metadata.forEach(
+        (key, value) -> {
+          if (key != null && value != null) {
+            sanitizedMetadata.put(key, value);
+          }
+        });
+    return sanitizedMetadata.isEmpty() ? Map.of() : Map.copyOf(sanitizedMetadata);
   }
 
   private record ResolvedError(ErrorDefinition errorDefinition) {}

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
@@ -42,7 +42,10 @@ public enum ErrorDefinition {
   USER_NEW_PASSWORD_MUST_BE_DIFFERENT(
       "TYCHE-203",
       "USER_NEW_PASSWORD_MUST_BE_DIFFERENT",
-      "The new password must be different from the current password");
+      "The new password must be different from the current password"),
+
+  // EMAIL
+  EMAIL_DELIVERY_FAILED("TYCHE-300", "EMAIL_DELIVERY_FAILED", "Failed to deliver email");
 
   private final String code;
   private final String type;

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
@@ -5,6 +5,7 @@ import static com.tychewealth.constants.SecurityConstants.CACHE_CONTROL_NO_STORE
 import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER_VALUE;
 
 import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.exception.EmailException;
 import com.tychewealth.error.exception.UserException;
 import com.tychewealth.service.monitoring.UserMetrics;
 import jakarta.servlet.http.HttpServletRequest;
@@ -39,6 +40,11 @@ public class ErrorHandler {
 
   @ExceptionHandler(UserException.class)
   public ResponseEntity<ErrorResponse> handleUserException(UserException ex) {
+    return buildFromException(ex.getErrorDefinition(), ex.getHttpStatus());
+  }
+
+  @ExceptionHandler(EmailException.class)
+  public ResponseEntity<ErrorResponse> handleEmailException(EmailException ex) {
     return buildFromException(ex.getErrorDefinition(), ex.getHttpStatus());
   }
 

--- a/user-service/src/main/java/com/tychewealth/service/EmailService.java
+++ b/user-service/src/main/java/com/tychewealth/service/EmailService.java
@@ -1,0 +1,8 @@
+package com.tychewealth.service;
+
+import com.tychewealth.service.email.EmailMessage;
+
+public interface EmailService {
+
+  void send(EmailMessage emailMessage);
+}

--- a/user-service/src/main/java/com/tychewealth/service/email/EmailMessage.java
+++ b/user-service/src/main/java/com/tychewealth/service/email/EmailMessage.java
@@ -1,0 +1,3 @@
+package com.tychewealth.service.email;
+
+public record EmailMessage(String to, String subject, String html, String text) {}

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/EmailServiceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/EmailServiceHelper.java
@@ -1,0 +1,100 @@
+package com.tychewealth.service.helper.email;
+
+import static com.tychewealth.constants.ApiConstants.RESEND_EMAILS_PATH;
+import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER_PREFIX;
+import static com.tychewealth.constants.LogConstants.EMAIL;
+import static com.tychewealth.constants.LogConstants.EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE;
+import static com.tychewealth.constants.LogConstants.EMAIL_REQUEST_FIELDS;
+import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
+import static com.tychewealth.constants.LogConstants.RESEND_DELIVERY_FAILED_MESSAGE;
+import static com.tychewealth.constants.LogConstants.SEND_ACTION;
+import static com.tychewealth.constants.RedisConstants.EMAIL_DAILY_LIMIT_CLIENT_KEY;
+import static com.tychewealth.constants.RedisConstants.EMAIL_DAILY_LIMIT_NAMESPACE;
+import static com.tychewealth.utils.Utils.currentUtcDate;
+import static com.tychewealth.utils.Utils.durationUntilNextUtcMidnight;
+
+import com.tychewealth.dto.email.ResendEmailPropertiesDto;
+import com.tychewealth.dto.email.request.ResendSendEmailRequestDto;
+import com.tychewealth.error.exception.EmailException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.service.EmailService;
+import com.tychewealth.service.email.EmailMessage;
+import com.tychewealth.service.ratelimit.RateLimitStore;
+import java.time.Clock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class EmailServiceHelper implements EmailService {
+
+  private final RestClient restClient;
+  private final ResendEmailPropertiesDto resendEmailProperties;
+  private final int emailDailyLimit;
+  private final RateLimitStore rateLimitStore;
+  private final Clock clock;
+
+  @Override
+  public void send(EmailMessage emailMessage) {
+    if (!canSendWithinDailyQuota(emailMessage)) {
+      return;
+    }
+
+    try {
+      restClient
+          .post()
+          .uri(RESEND_EMAILS_PATH)
+          .contentType(MediaType.APPLICATION_JSON)
+          .header(
+              AUTHORIZATION_HEADER, TOKEN_TYPE_BEARER_PREFIX + resendEmailProperties.getApiKey())
+          .body(toResendRequest(emailMessage))
+          .retrieve()
+          .toBodilessEntity();
+    } catch (RestClientException ex) {
+      log.error(
+          REQUEST_CONFLICT + EMAIL_REQUEST_FIELDS,
+          EMAIL,
+          SEND_ACTION,
+          RESEND_DELIVERY_FAILED_MESSAGE,
+          emailMessage.to(),
+          emailMessage.subject(),
+          ex);
+      throw EmailException.of(
+          ErrorDefinition.EMAIL_DELIVERY_FAILED, null, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private boolean canSendWithinDailyQuota(EmailMessage emailMessage) {
+    long currentCount =
+        rateLimitStore.increment(
+            EMAIL_DAILY_LIMIT_NAMESPACE + ":" + currentUtcDate(clock),
+            EMAIL_DAILY_LIMIT_CLIENT_KEY,
+            durationUntilNextUtcMidnight(clock));
+
+    if (currentCount > emailDailyLimit) {
+      log.info(
+          REQUEST_CONFLICT + EMAIL_REQUEST_FIELDS,
+          EMAIL,
+          SEND_ACTION,
+          EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE,
+          emailMessage.to(),
+          emailMessage.subject());
+      return false;
+    }
+    return true;
+  }
+
+  private ResendSendEmailRequestDto toResendRequest(EmailMessage emailMessage) {
+    return new ResendSendEmailRequestDto(
+        resendEmailProperties.getFrom(),
+        emailMessage.to(),
+        emailMessage.subject(),
+        emailMessage.html(),
+        emailMessage.text());
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/EmailServiceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/EmailServiceHelper.java
@@ -5,7 +5,6 @@ import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER_PREFIX;
 import static com.tychewealth.constants.LogConstants.EMAIL;
 import static com.tychewealth.constants.LogConstants.EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE;
-import static com.tychewealth.constants.LogConstants.EMAIL_REQUEST_FIELDS;
 import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
 import static com.tychewealth.constants.LogConstants.RESEND_DELIVERY_FAILED_MESSAGE;
 import static com.tychewealth.constants.LogConstants.SEND_ACTION;
@@ -41,7 +40,7 @@ public class EmailServiceHelper implements EmailService {
 
   @Override
   public void send(EmailMessage emailMessage) {
-    if (!canSendWithinDailyQuota(emailMessage)) {
+    if (!canSendWithinDailyQuota()) {
       return;
     }
 
@@ -56,20 +55,13 @@ public class EmailServiceHelper implements EmailService {
           .retrieve()
           .toBodilessEntity();
     } catch (RestClientException ex) {
-      log.error(
-          REQUEST_CONFLICT + EMAIL_REQUEST_FIELDS,
-          EMAIL,
-          SEND_ACTION,
-          RESEND_DELIVERY_FAILED_MESSAGE,
-          emailMessage.to(),
-          emailMessage.subject(),
-          ex);
+      log.error(REQUEST_CONFLICT, EMAIL, SEND_ACTION, RESEND_DELIVERY_FAILED_MESSAGE, ex);
       throw EmailException.of(
           ErrorDefinition.EMAIL_DELIVERY_FAILED, null, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
-  private boolean canSendWithinDailyQuota(EmailMessage emailMessage) {
+  private boolean canSendWithinDailyQuota() {
     long currentCount =
         rateLimitStore.increment(
             EMAIL_DAILY_LIMIT_NAMESPACE + ":" + currentUtcDate(clock),
@@ -77,13 +69,7 @@ public class EmailServiceHelper implements EmailService {
             durationUntilNextUtcMidnight(clock));
 
     if (currentCount > emailDailyLimit) {
-      log.info(
-          REQUEST_CONFLICT + EMAIL_REQUEST_FIELDS,
-          EMAIL,
-          SEND_ACTION,
-          EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE,
-          emailMessage.to(),
-          emailMessage.subject());
+      log.info(REQUEST_CONFLICT, EMAIL, SEND_ACTION, EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE);
       return false;
     }
     return true;

--- a/user-service/src/main/java/com/tychewealth/service/impl/EmailServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/EmailServiceImpl.java
@@ -1,0 +1,21 @@
+package com.tychewealth.service.impl;
+
+import com.tychewealth.service.EmailService;
+import com.tychewealth.service.email.EmailMessage;
+import com.tychewealth.service.helper.email.EmailServiceHelper;
+import lombok.AllArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@ConditionalOnProperty(prefix = "app.email.resend", name = "enabled", havingValue = "true")
+public class EmailServiceImpl implements EmailService {
+
+  private final EmailServiceHelper emailServiceHelper;
+
+  @Override
+  public void send(EmailMessage emailMessage) {
+    emailServiceHelper.send(emailMessage);
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/utils/Utils.java
+++ b/user-service/src/main/java/com/tychewealth/utils/Utils.java
@@ -4,6 +4,10 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.HexFormat;
 import java.util.Locale;
 import javax.crypto.Mac;
@@ -37,5 +41,14 @@ public final class Utils {
     } catch (GeneralSecurityException ex) {
       throw new IllegalStateException("HmacSHA256 algorithm not available", ex);
     }
+  }
+
+  public static String currentUtcDate(Clock clock) {
+    return LocalDate.now(clock.withZone(ZoneOffset.UTC)).toString();
+  }
+
+  public static Duration durationUntilNextUtcMidnight(Clock clock) {
+    LocalDate tomorrow = LocalDate.now(clock.withZone(ZoneOffset.UTC)).plusDays(1);
+    return Duration.between(clock.instant(), tomorrow.atStartOfDay().toInstant(ZoneOffset.UTC));
   }
 }

--- a/user-service/src/main/java/com/tychewealth/utils/Utils.java
+++ b/user-service/src/main/java/com/tychewealth/utils/Utils.java
@@ -6,6 +6,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.HexFormat;
@@ -48,7 +49,8 @@ public final class Utils {
   }
 
   public static Duration durationUntilNextUtcMidnight(Clock clock) {
-    LocalDate tomorrow = LocalDate.now(clock.withZone(ZoneOffset.UTC)).plusDays(1);
-    return Duration.between(clock.instant(), tomorrow.atStartOfDay().toInstant(ZoneOffset.UTC));
+    Instant now = clock.instant();
+    LocalDate tomorrow = now.atZone(ZoneOffset.UTC).toLocalDate().plusDays(1);
+    return Duration.between(now, tomorrow.atStartOfDay().toInstant(ZoneOffset.UTC));
   }
 }

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -53,3 +53,10 @@ app.security.prometheus.password=${PROMETHEUS_PASSWORD}
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
 spring.data.redis.timeout=${REDIS_TIMEOUT:2s}
+
+# Email / Resend
+app.email.daily-limit=${EMAIL_DAILY_LIMIT:80}
+app.email.resend.enabled=${EMAIL_RESEND_ENABLED:false}
+app.email.resend.api-key=${RESEND_API_KEY:}
+app.email.resend.from=${EMAIL_FROM:}
+app.email.resend.base-url=${EMAIL_RESEND_BASE_URL:https://api.resend.com}

--- a/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -30,6 +30,13 @@ public final class TestConstants {
   public static final String TEST_REFRESH_TOKEN_EXPIRED = "expired-refresh-token";
   public static final String TEST_REFRESH_TOKEN_METRICS = "metrics-refresh-token";
   public static final String TEST_REFRESH_TOKEN_PEPPER = "test-refresh-token-pepper";
+  public static final String TEST_RESEND_BASE_URL = "https://api.resend.com";
+  public static final String TEST_RESEND_API_KEY = "re_test_key";
+  public static final String TEST_RESEND_FROM = "Tyche Wealth <auth@tyche-wealth.com>";
+  public static final String TEST_EMAIL_SUBJECT_VERIFY = "Verify your email";
+  public static final String TEST_EMAIL_HTML_BODY = "<p>Hello</p>";
+  public static final String TEST_EMAIL_TEXT_BODY = "Hello";
+  public static final int TEST_EMAIL_DAILY_LIMIT = 2;
 
   public static final String TEST_PROMETHEUS_USERNAME = "prometheus";
   public static final String TEST_PROMETHEUS_PASSWORD = "secret";

--- a/user-service/src/test/java/com/tychewealth/email/EmailServiceHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/email/EmailServiceHelperTest.java
@@ -1,0 +1,132 @@
+package com.tychewealth.email;
+
+import static com.tychewealth.constants.ApiConstants.RESEND_EMAILS_PATH;
+import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER_PREFIX;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_DAILY_LIMIT;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_HTML_BODY;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_SUBJECT_VERIFY;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_TEXT_BODY;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_RESEND_API_KEY;
+import static com.tychewealth.constants.TestConstants.TEST_RESEND_BASE_URL;
+import static com.tychewealth.constants.TestConstants.TEST_RESEND_FROM;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import com.tychewealth.dto.email.ResendEmailPropertiesDto;
+import com.tychewealth.error.exception.EmailException;
+import com.tychewealth.service.email.EmailMessage;
+import com.tychewealth.service.helper.email.EmailServiceHelper;
+import com.tychewealth.testhelper.InMemoryRateLimitStore;
+import com.tychewealth.testhelper.RateLimitWebTestHelper.MutableClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class EmailServiceHelperTest {
+
+  private MockRestServiceServer mockRestServiceServer;
+  private EmailServiceHelper emailServiceHelper;
+  private MutableClock clock;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder restClientBuilder = RestClient.builder();
+    mockRestServiceServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+
+    ResendEmailPropertiesDto resendEmailProperties = new ResendEmailPropertiesDto();
+    resendEmailProperties.setApiKey(TEST_RESEND_API_KEY);
+    resendEmailProperties.setFrom(TEST_RESEND_FROM);
+    resendEmailProperties.setBaseUrl(TEST_RESEND_BASE_URL);
+    clock = new MutableClock();
+
+    RestClient restClient = restClientBuilder.baseUrl(TEST_RESEND_BASE_URL).build();
+    emailServiceHelper =
+        new EmailServiceHelper(
+            restClient,
+            resendEmailProperties,
+            TEST_EMAIL_DAILY_LIMIT,
+            new InMemoryRateLimitStore(clock),
+            clock);
+  }
+
+  @Test
+  void sendPostsEmailToResend() {
+    mockRestServiceServer
+        .expect(requestTo(TEST_RESEND_BASE_URL + RESEND_EMAILS_PATH))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(header(AUTHORIZATION_HEADER, TOKEN_TYPE_BEARER_PREFIX + TEST_RESEND_API_KEY))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    """
+                    {
+                      "from": "Tyche Wealth <auth@tyche-wealth.com>",
+                      "to": "valid@tychewealth.com",
+                      "subject": "Verify your email",
+                      "html": "<p>Hello</p>",
+                      "text": "Hello"
+                    }
+                    """))
+        .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body("{}"));
+
+    emailServiceHelper.send(
+        new EmailMessage(
+            TEST_EMAIL_VALID,
+            TEST_EMAIL_SUBJECT_VERIFY,
+            TEST_EMAIL_HTML_BODY,
+            TEST_EMAIL_TEXT_BODY));
+
+    mockRestServiceServer.verify();
+  }
+
+  @Test
+  void sendWrapsProviderFailures() {
+    mockRestServiceServer
+        .expect(requestTo(TEST_RESEND_BASE_URL + RESEND_EMAILS_PATH))
+        .andRespond(withStatus(HttpStatus.TOO_MANY_REQUESTS));
+    EmailMessage emailMessage =
+        new EmailMessage(TEST_EMAIL_VALID, TEST_EMAIL_SUBJECT_VERIFY, TEST_EMAIL_HTML_BODY, null);
+
+    assertThrows(EmailException.class, () -> emailServiceHelper.send(emailMessage));
+  }
+
+  @Test
+  void sendSkipsDeliveryWhenDailyQuotaIsExceeded() {
+    mockRestServiceServer
+        .expect(requestTo(TEST_RESEND_BASE_URL + RESEND_EMAILS_PATH))
+        .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body("{}"));
+    mockRestServiceServer
+        .expect(requestTo(TEST_RESEND_BASE_URL + RESEND_EMAILS_PATH))
+        .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body("{}"));
+
+    assertDoesNotThrow(
+        () ->
+            emailServiceHelper.send(
+                new EmailMessage(
+                    TEST_EMAIL_VALID, TEST_EMAIL_SUBJECT_VERIFY, TEST_EMAIL_HTML_BODY, null)));
+    assertDoesNotThrow(
+        () ->
+            emailServiceHelper.send(
+                new EmailMessage(
+                    TEST_EMAIL_VALID, TEST_EMAIL_SUBJECT_VERIFY, TEST_EMAIL_HTML_BODY, null)));
+    assertDoesNotThrow(
+        () ->
+            emailServiceHelper.send(
+                new EmailMessage(
+                    TEST_EMAIL_VALID, TEST_EMAIL_SUBJECT_VERIFY, TEST_EMAIL_HTML_BODY, null)));
+
+    mockRestServiceServer.verify();
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound email delivery with a configurable daily sending quota (default 80/day) and optional provider integration.

* **Configuration**
  * New properties to enable the email integration, set provider API key, sender address, base URL, and daily limit.

* **Bug Fixes**
  * Improved error handling for delivery failures with clearer error responses.

* **Tests**
  * Added unit tests covering send success, provider rate responses, and daily-quota enforcement.

Closes #46 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->