### PR TITLE
[TYCHE-23] implement email verification in register endpoint

### DIFF
--- a/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
+++ b/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
@@ -5,7 +5,6 @@ import com.tychewealth.service.helper.email.EmailServiceHelper;
 import com.tychewealth.service.ratelimit.RateLimitStore;
 import java.time.Clock;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +21,6 @@ public class EmailConfig {
   }
 
   @Bean
-  @ConditionalOnProperty(prefix = "app.email.resend", name = "enabled", havingValue = "true")
   public EmailServiceHelper emailServiceHelper(
       RestClient.Builder restClientBuilder,
       ResendEmailPropertiesDto resendEmailProperties,

--- a/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
+++ b/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
@@ -3,6 +3,8 @@ package com.tychewealth.config;
 import com.tychewealth.dto.email.ResendEmailPropertiesDto;
 import com.tychewealth.service.helper.email.EmailServiceHelper;
 import com.tychewealth.service.ratelimit.RateLimitStore;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Clock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -38,5 +40,21 @@ public class EmailConfig {
     RestClient restClient = restClientBuilder.baseUrl(resendEmailProperties.getBaseUrl()).build();
     return new EmailServiceHelper(
         restClient, resendEmailProperties, emailDailyLimit, rateLimitStore, emailClock);
+  }
+
+  @Bean
+  public URI verifyRegistrationUri(
+      @Value("${app.auth.verify-registration-url}") String verifyRegistrationUrl) {
+    Assert.hasText(verifyRegistrationUrl, "app.auth.verify-registration-url must be configured");
+
+    try {
+      URI uri = new URI(verifyRegistrationUrl);
+      Assert.isTrue(uri.isAbsolute(), "app.auth.verify-registration-url must be an absolute URL");
+      Assert.hasText(uri.getScheme(), "app.auth.verify-registration-url must include a scheme");
+      Assert.hasText(uri.getHost(), "app.auth.verify-registration-url must include a host");
+      return uri;
+    } catch (URISyntaxException ex) {
+      throw new IllegalStateException("app.auth.verify-registration-url must be a valid URL", ex);
+    }
   }
 }

--- a/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
@@ -13,7 +13,7 @@ public final class AuthConstants {
   public static final String TOKEN_TYPE_BEARER = "Bearer";
   public static final String TOKEN_TYPE_BEARER_PREFIX = TOKEN_TYPE_BEARER + " ";
   public static final String TOKEN_PURPOSE_CLAIM = "purpose";
-  public static final String VERIFY_EMAIL_TOKEN_PURPOSE = "verify-email";
+  public static final String VERIFY_REGISTRATION_TOKEN_PURPOSE = "verify-registration";
   public static final int REFRESH_TOKEN_BYTE_LENGTH = 32;
   public static final int TOKEN_LINK_MAX_ATTEMPTS = 2;
 

--- a/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
@@ -12,6 +12,8 @@ public final class AuthConstants {
   public static final String AUTHORIZATION_HEADER = "Authorization";
   public static final String TOKEN_TYPE_BEARER = "Bearer";
   public static final String TOKEN_TYPE_BEARER_PREFIX = TOKEN_TYPE_BEARER + " ";
+  public static final String TOKEN_PURPOSE_CLAIM = "purpose";
+  public static final String VERIFY_EMAIL_TOKEN_PURPOSE = "verify-email";
   public static final int REFRESH_TOKEN_BYTE_LENGTH = 32;
   public static final int TOKEN_LINK_MAX_ATTEMPTS = 2;
 

--- a/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -6,10 +6,11 @@ public final class LogConstants {
 
   public static final String AUTH = "[auth]";
   public static final String EMAIL = "[email]";
+  public static final String SYSTEM = "[system]";
   public static final String USER = "[user]";
   public static final String REGISTER_ACTION = "[register]";
   public static final String LOGIN_ACTION = "[login]";
-  public static final String VERIFY_EMAIL_ACTION = "[verify-email]";
+  public static final String VERIFY_REGISTRATION_ACTION = "[verify-registration]";
   public static final String REFRESH_TOKEN_ACTION = "[refresh-token]";
   public static final String RATE_LIMIT_ACTION = "[rate-limit]";
   public static final String LOGOUT_ACTION = "[logout]";
@@ -18,27 +19,29 @@ public final class LogConstants {
   public static final String UPDATE_PASSWORD_ACTION = "[update-password]";
   public static final String DELETE_ACTION = "[delete]";
   public static final String ACCESS_TOKEN_ACTION = "[access-token]";
+  public static final String ERROR_HANDLER_ACTION = "[error-handler]";
   public static final String SEND_ACTION = "[send]";
 
   public static final String REQUEST_START = BASE_LOG + " Request started";
   public static final String REQUEST_SUCCESS = BASE_LOG + " Request succeeded";
   public static final String REQUEST_CONFLICT = BASE_LOG + " Request rejected: {}";
+  public static final String REQUEST_CONFLICT_WITH_URI = REQUEST_CONFLICT + " uri={}";
   public static final String RATE_LIMIT_STORE_UNAVAILABLE_CONTEXT =
       " uri={} namespace={} rejectionMessage={}";
   public static final String REGISTER_REQUEST_FIELDS = " username={}, email={}";
   public static final String LOGIN_REQUEST_FIELDS = " email={}";
   public static final String UPDATE_REQUEST_FIELDS = " username={}";
   public static final String USER_ID = " userId={}";
-  public static final String EMAIL_REQUEST_FIELDS = " to={} subject={}";
 
   public static final String INVALID_LOGIN_CREDENTIALS_MESSAGE = "invalid login credentials";
   public static final String INVALID_PASSWORD_FORMAT_MESSAGE = "invalid password format";
   public static final String INVALID_REFRESH_TOKEN_MESSAGE = "invalid refresh token";
   public static final String INVALID_AUTHORIZATION_HEADER_MESSAGE = "invalid authorization header";
   public static final String INVALID_ACCESS_TOKEN_MESSAGE = "invalid access token";
+  public static final String UNHANDLED_EXCEPTION_MESSAGE =
+      "unhandled exception reached global error handler";
   public static final String RATE_LIMIT_STORE_UNAVAILABLE_MESSAGE = "rate limit store unavailable";
   public static final String RESEND_DELIVERY_FAILED_MESSAGE = "resend delivery failed";
-  public static final String EMAIL_DAILY_QUOTA_EXCEEDED_MESSAGE = "daily email quota exceeded";
   public static final String EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE =
       "daily email quota exceeded; skipping send";
 

--- a/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -9,6 +9,7 @@ public final class LogConstants {
   public static final String USER = "[user]";
   public static final String REGISTER_ACTION = "[register]";
   public static final String LOGIN_ACTION = "[login]";
+  public static final String VERIFY_EMAIL_ACTION = "[verify-email]";
   public static final String REFRESH_TOKEN_ACTION = "[refresh-token]";
   public static final String RATE_LIMIT_ACTION = "[rate-limit]";
   public static final String LOGOUT_ACTION = "[logout]";

--- a/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
+++ b/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
@@ -13,14 +13,19 @@ import com.tychewealth.dto.user.UserResponseDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequestMapping(value = URL_FOLDER_V1 + "/auth")
 @Tag(name = "Auth")
 public interface AuthApi {
+
+  @GetMapping(value = "/verify-email", produces = REQUEST_PRODUCES)
+  ResponseEntity<Void> verifyEmail(@RequestParam("token") String token);
 
   @PostMapping(value = "/register", consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
   ResponseEntity<UserResponseDto> register(@Valid @RequestBody RegisterRequestDto register);

--- a/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
+++ b/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
@@ -24,8 +24,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "Auth")
 public interface AuthApi {
 
-  @GetMapping(value = "/verify-email", produces = REQUEST_PRODUCES)
-  ResponseEntity<Void> verifyEmail(@RequestParam("token") String token);
+  @GetMapping(value = "/verify-registration", produces = REQUEST_PRODUCES)
+  ResponseEntity<Void> verifyRegistration(@RequestParam("token") String token);
 
   @PostMapping(value = "/register", consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
   ResponseEntity<UserResponseDto> register(@Valid @RequestBody RegisterRequestDto register);

--- a/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
+++ b/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
@@ -1,10 +1,22 @@
 package com.tychewealth.controller.impl;
 
 import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
+import static com.tychewealth.constants.LogConstants.AUTH;
+import static com.tychewealth.constants.LogConstants.LOGIN_ACTION;
+import static com.tychewealth.constants.LogConstants.LOGIN_REQUEST_FIELDS;
+import static com.tychewealth.constants.LogConstants.LOGOUT_ACTION;
+import static com.tychewealth.constants.LogConstants.REFRESH_TOKEN_ACTION;
+import static com.tychewealth.constants.LogConstants.REGISTER_ACTION;
+import static com.tychewealth.constants.LogConstants.REGISTER_REQUEST_FIELDS;
+import static com.tychewealth.constants.LogConstants.REQUEST_START;
+import static com.tychewealth.constants.LogConstants.VERIFY_EMAIL_ACTION;
 import static com.tychewealth.constants.SecurityConstants.CACHE_CONTROL_NO_STORE_HEADER_VALUE;
 import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER_VALUE;
+import static com.tychewealth.utils.LogContextFactory.mask;
+import static org.springframework.http.HttpHeaders.CACHE_CONTROL;
+import static org.springframework.http.HttpHeaders.PRAGMA;
+import static org.springframework.http.ResponseEntity.status;
 
-import com.tychewealth.constants.LogConstants;
 import com.tychewealth.controller.AuthApi;
 import com.tychewealth.dto.auth.LoginResponseDto;
 import com.tychewealth.dto.auth.RefreshTokenResponseDto;
@@ -13,15 +25,14 @@ import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.service.AuthService;
-import com.tychewealth.utils.LogContextFactory;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -32,55 +43,62 @@ public class AuthApiController implements AuthApi {
   private final AuthService authService;
 
   @Override
+  public ResponseEntity<Void> verifyEmail(@RequestParam("token") String token) {
+    log.info(REQUEST_START, AUTH, VERIFY_EMAIL_ACTION);
+
+    authService.verifyEmail(token);
+    return ResponseEntity.noContent()
+        .header(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
+        .header(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE)
+        .build();
+  }
+
+  @Override
   public ResponseEntity<UserResponseDto> register(@Valid @RequestBody RegisterRequestDto register) {
     log.info(
-        LogConstants.REQUEST_START + LogConstants.REGISTER_REQUEST_FIELDS,
-        LogConstants.AUTH,
-        LogConstants.REGISTER_ACTION,
-        LogContextFactory.mask(register.getUsername()),
-        LogContextFactory.mask(register.getEmail()));
+        REQUEST_START + REGISTER_REQUEST_FIELDS,
+        AUTH,
+        REGISTER_ACTION,
+        mask(register.getUsername()),
+        mask(register.getEmail()));
 
     UserResponseDto response = authService.register(register);
-    return withNoStoreHeaders(ResponseEntity.status(HttpStatus.CREATED)).body(response);
+    return withNoStoreHeaders(status(HttpStatus.CREATED)).body(response);
   }
 
   @Override
   public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto login) {
-    log.info(
-        LogConstants.REQUEST_START + LogConstants.LOGIN_REQUEST_FIELDS,
-        LogConstants.AUTH,
-        LogConstants.LOGIN_ACTION,
-        LogContextFactory.mask(login.getEmail()));
+    log.info(REQUEST_START + LOGIN_REQUEST_FIELDS, AUTH, LOGIN_ACTION, mask(login.getEmail()));
 
     LoginResponseDto response = authService.login(login);
-    return withNoStoreHeaders(ResponseEntity.status(HttpStatus.OK)).body(response);
+    return withNoStoreHeaders(status(HttpStatus.OK)).body(response);
   }
 
   @Override
   public ResponseEntity<RefreshTokenResponseDto> refresh(
       @Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto) {
-    log.info(LogConstants.REQUEST_START, LogConstants.AUTH, LogConstants.REFRESH_TOKEN_ACTION);
+    log.info(REQUEST_START, AUTH, REFRESH_TOKEN_ACTION);
 
     RefreshTokenResponseDto response = authService.refresh(refreshTokenRequestDto);
-    return withNoStoreHeaders(ResponseEntity.status(HttpStatus.OK)).body(response);
+    return withNoStoreHeaders(status(HttpStatus.OK)).body(response);
   }
 
   @Override
   public ResponseEntity<Void> logout(
       @RequestHeader(value = AUTHORIZATION_HEADER, required = false) String authorizationHeader,
       @Valid @RequestBody RefreshTokenRequestDto refreshTokenRequestDto) {
-    log.info(LogConstants.REQUEST_START, LogConstants.AUTH, LogConstants.LOGOUT_ACTION);
+    log.info(REQUEST_START, AUTH, LOGOUT_ACTION);
 
     authService.logout(authorizationHeader, refreshTokenRequestDto);
     return ResponseEntity.noContent()
-        .header(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
-        .header(HttpHeaders.PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE)
+        .header(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
+        .header(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE)
         .build();
   }
 
   private ResponseEntity.BodyBuilder withNoStoreHeaders(ResponseEntity.BodyBuilder builder) {
     return builder
-        .header(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
-        .header(HttpHeaders.PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE);
+        .header(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
+        .header(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
+++ b/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
@@ -9,7 +9,7 @@ import static com.tychewealth.constants.LogConstants.REFRESH_TOKEN_ACTION;
 import static com.tychewealth.constants.LogConstants.REGISTER_ACTION;
 import static com.tychewealth.constants.LogConstants.REGISTER_REQUEST_FIELDS;
 import static com.tychewealth.constants.LogConstants.REQUEST_START;
-import static com.tychewealth.constants.LogConstants.VERIFY_EMAIL_ACTION;
+import static com.tychewealth.constants.LogConstants.VERIFY_REGISTRATION_ACTION;
 import static com.tychewealth.constants.SecurityConstants.CACHE_CONTROL_NO_STORE_HEADER_VALUE;
 import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER_VALUE;
 import static com.tychewealth.utils.LogContextFactory.mask;
@@ -43,8 +43,8 @@ public class AuthApiController implements AuthApi {
   private final AuthService authService;
 
   @Override
-  public ResponseEntity<Void> verifyEmail(@RequestParam("token") String token) {
-    log.info(REQUEST_START, AUTH, VERIFY_EMAIL_ACTION);
+  public ResponseEntity<Void> verifyRegistration(@RequestParam("token") String token) {
+    log.info(REQUEST_START, AUTH, VERIFY_REGISTRATION_ACTION);
 
     authService.verifyEmail(token);
     return ResponseEntity.noContent()

--- a/user-service/src/main/java/com/tychewealth/dto/auth/RegisteredUserResultDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/auth/RegisteredUserResultDto.java
@@ -1,0 +1,8 @@
+package com.tychewealth.dto.auth;
+
+import com.tychewealth.dto.user.UserResponseDto;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.service.token.AuthTokenPayload;
+
+public record RegisteredUserResultDto(
+    UserEntity user, UserResponseDto response, AuthTokenPayload verificationToken) {}

--- a/user-service/src/main/java/com/tychewealth/dto/auth/RegisteredUserResultDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/auth/RegisteredUserResultDto.java
@@ -1,8 +1,7 @@
 package com.tychewealth.dto.auth;
 
 import com.tychewealth.dto.user.UserResponseDto;
-import com.tychewealth.entity.UserEntity;
 import com.tychewealth.service.token.AuthTokenPayload;
 
 public record RegisteredUserResultDto(
-    UserEntity user, UserResponseDto response, AuthTokenPayload verificationToken) {}
+    UserResponseDto response, AuthTokenPayload verificationToken) {}

--- a/user-service/src/main/java/com/tychewealth/entity/UserEntity.java
+++ b/user-service/src/main/java/com/tychewealth/entity/UserEntity.java
@@ -54,6 +54,9 @@ public class UserEntity {
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 
+  @Column(name = "is_verified", nullable = false)
+  private boolean isVerified = false;
+
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorHandler.java
@@ -1,6 +1,10 @@
 package com.tychewealth.error.handler;
 
 import static com.tychewealth.constants.ApiConstants.USER_BASE_URL;
+import static com.tychewealth.constants.LogConstants.ERROR_HANDLER_ACTION;
+import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT_WITH_URI;
+import static com.tychewealth.constants.LogConstants.SYSTEM;
+import static com.tychewealth.constants.LogConstants.UNHANDLED_EXCEPTION_MESSAGE;
 import static com.tychewealth.constants.SecurityConstants.CACHE_CONTROL_NO_STORE_HEADER_VALUE;
 import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER_VALUE;
 
@@ -12,6 +16,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -23,6 +28,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
+@Slf4j
 @RestControllerAdvice
 @AllArgsConstructor
 public class ErrorHandler {
@@ -90,7 +96,15 @@ public class ErrorHandler {
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+  public ResponseEntity<ErrorResponse> handleGenericException(
+      Exception ex, HttpServletRequest request) {
+    log.error(
+        REQUEST_CONFLICT_WITH_URI,
+        SYSTEM,
+        ERROR_HANDLER_ACTION,
+        UNHANDLED_EXCEPTION_MESSAGE,
+        request == null ? "unknown" : request.getRequestURI(),
+        ex);
     return build(
         ErrorDefinition.GENERIC_INTERNAL_ERROR,
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/user-service/src/main/java/com/tychewealth/service/AuthService.java
+++ b/user-service/src/main/java/com/tychewealth/service/AuthService.java
@@ -9,6 +9,8 @@ import com.tychewealth.dto.user.UserResponseDto;
 
 public interface AuthService {
 
+  void verifyEmail(String token);
+
   UserResponseDto register(RegisterRequestDto register);
 
   LoginResponseDto login(LoginRequestDto login);

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
@@ -1,12 +1,15 @@
 package com.tychewealth.service.helper.auth;
 
 import com.tychewealth.constants.LogConstants;
+import com.tychewealth.dto.auth.RegisteredUserResultDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.mapper.user.UserMapper;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.monitoring.AuthMetrics;
+import com.tychewealth.service.token.AuthTokenPayload;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,12 +23,14 @@ public class AuthRegisterHelper {
   private final UserRepository userRepository;
   private final UserMapper userMapper;
   private final PasswordEncoder passwordEncoder;
+  private final AccessTokenHelper accessTokenHelper;
   private final AuthMetrics authMetrics;
 
-  public UserResponseDto createUser(RegisterRequestDto register) {
+  public RegisteredUserResultDto createUser(RegisterRequestDto register) {
     UserEntity toCreate = userMapper.create(register);
     toCreate.setPassword(passwordEncoder.encode(register.getPassword()));
     UserEntity created = userRepository.save(toCreate);
+    AuthTokenPayload verificationToken = accessTokenHelper.generateVerifyEmailToken(created);
     UserResponseDto response = userMapper.toDto(created);
     authMetrics.recordRegisterSuccess();
 
@@ -34,6 +39,6 @@ public class AuthRegisterHelper {
         LogConstants.AUTH,
         LogConstants.REGISTER_ACTION,
         created.getId());
-    return response;
+    return new RegisteredUserResultDto(created, response, verificationToken);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
@@ -1,6 +1,5 @@
 package com.tychewealth.service.helper.auth;
 
-import com.tychewealth.constants.LogConstants;
 import com.tychewealth.dto.auth.RegisteredUserResultDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
@@ -8,14 +7,11 @@ import com.tychewealth.entity.UserEntity;
 import com.tychewealth.mapper.user.UserMapper;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
-import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @AllArgsConstructor
 public class AuthRegisterHelper {
@@ -24,7 +20,6 @@ public class AuthRegisterHelper {
   private final UserMapper userMapper;
   private final PasswordEncoder passwordEncoder;
   private final AccessTokenHelper accessTokenHelper;
-  private final AuthMetrics authMetrics;
 
   public RegisteredUserResultDto createUser(RegisterRequestDto register) {
     UserEntity toCreate = userMapper.create(register);
@@ -32,13 +27,6 @@ public class AuthRegisterHelper {
     UserEntity created = userRepository.save(toCreate);
     AuthTokenPayload verificationToken = accessTokenHelper.generateVerifyEmailToken(created);
     UserResponseDto response = userMapper.toDto(created);
-    authMetrics.recordRegisterSuccess();
-
-    log.info(
-        LogConstants.REQUEST_SUCCESS + LogConstants.USER_ID,
-        LogConstants.AUTH,
-        LogConstants.REGISTER_ACTION,
-        created.getId());
     return new RegisteredUserResultDto(response, verificationToken);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
@@ -39,6 +39,6 @@ public class AuthRegisterHelper {
         LogConstants.AUTH,
         LogConstants.REGISTER_ACTION,
         created.getId());
-    return new RegisteredUserResultDto(created, response, verificationToken);
+    return new RegisteredUserResultDto(response, verificationToken);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
@@ -42,8 +42,25 @@ public class AuthValidationHelper {
 
   public UserEntity validateLoginRequest(LoginRequestDto login) {
     UserEntity user = validateLoginEmail(login.getEmail());
+    validateUserIsVerified(user);
     validateLoginPassword(login.getPassword(), user.getPassword());
     return user;
+  }
+
+  public void validateUserIsVerified(UserEntity user) {
+    if (user.isVerified()) {
+      return;
+    }
+
+    log.warn(
+        LogConstants.REQUEST_CONFLICT,
+        LogConstants.AUTH,
+        LogConstants.LOGIN_ACTION,
+        LogConstants.INVALID_LOGIN_CREDENTIALS_MESSAGE);
+    authMetrics.recordLoginFailure();
+    authMetrics.recordLoginInvalidCredentials();
+    throw new AuthException(
+        ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, null, HttpStatus.UNAUTHORIZED);
   }
 
   public AuthException validateRegisterPersistenceConflict(DataIntegrityViolationException ex) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
@@ -1,6 +1,8 @@
 package com.tychewealth.service.helper.auth;
 
+import static com.tychewealth.constants.AuthConstants.EMAIL_CONSTRAINT;
 import static com.tychewealth.constants.AuthConstants.LOGIN_PASSWORD_POLICY;
+import static com.tychewealth.constants.AuthConstants.USERNAME_CONSTRAINT;
 
 import com.tychewealth.constants.LogConstants;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
@@ -11,9 +13,12 @@ import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.utils.Utils;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -39,6 +44,22 @@ public class AuthValidationHelper {
     UserEntity user = validateLoginEmail(login.getEmail());
     validateLoginPassword(login.getPassword(), user.getPassword());
     return user;
+  }
+
+  public AuthException validateRegisterPersistenceConflict(DataIntegrityViolationException ex) {
+    if (!validateUserUniqueConstraintViolation(ex)) {
+      throw ex;
+    }
+
+    log.warn(
+        LogConstants.REQUEST_CONFLICT,
+        LogConstants.AUTH,
+        LogConstants.REGISTER_ACTION,
+        "registration conflict detected at persistence layer");
+    authMetrics.recordRegisterFailure();
+    authMetrics.recordRegisterConflict();
+
+    return new AuthException(ErrorDefinition.AUTH_REGISTRATION_CONFLICT, null, HttpStatus.CONFLICT);
   }
 
   public void validateEmailIsAvailable(String email) {
@@ -137,5 +158,34 @@ public class AuthValidationHelper {
       throw new AuthException(
           ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, null, HttpStatus.UNAUTHORIZED);
     }
+  }
+
+  private boolean validateUserUniqueConstraintViolation(Throwable throwable) {
+    Throwable current = throwable;
+
+    while (current != null) {
+      if (current instanceof ConstraintViolationException cve) {
+        String constraintName = cve.getConstraintName();
+        if (validateUserUniqueConstraint(constraintName)) {
+          return true;
+        }
+      }
+
+      String message = current.getMessage();
+      if (validateUserUniqueConstraint(message)) {
+        return true;
+      }
+
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private boolean validateUserUniqueConstraint(String source) {
+    if (source == null || source.isBlank()) {
+      return false;
+    }
+    String normalized = source.toLowerCase(Locale.ROOT);
+    return normalized.contains(EMAIL_CONSTRAINT) || normalized.contains(USERNAME_CONSTRAINT);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/EmailServiceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/EmailServiceHelper.java
@@ -17,7 +17,6 @@ import com.tychewealth.dto.email.ResendEmailPropertiesDto;
 import com.tychewealth.dto.email.request.ResendSendEmailRequestDto;
 import com.tychewealth.error.exception.EmailException;
 import com.tychewealth.error.handler.ErrorDefinition;
-import com.tychewealth.service.EmailService;
 import com.tychewealth.service.email.EmailMessage;
 import com.tychewealth.service.ratelimit.RateLimitStore;
 import java.time.Clock;
@@ -30,7 +29,7 @@ import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @RequiredArgsConstructor
-public class EmailServiceHelper implements EmailService {
+public class EmailServiceHelper {
 
   private final RestClient restClient;
   private final ResendEmailPropertiesDto resendEmailProperties;
@@ -38,7 +37,6 @@ public class EmailServiceHelper implements EmailService {
   private final RateLimitStore rateLimitStore;
   private final Clock clock;
 
-  @Override
   public void send(EmailMessage emailMessage) {
     if (!canSendWithinDailyQuota()) {
       return;

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
@@ -1,6 +1,5 @@
 package com.tychewealth.service.helper.email;
 
-import com.tychewealth.entity.UserEntity;
 import com.tychewealth.service.email.EmailMessage;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -29,10 +28,10 @@ public class RegisterEmailHelper {
   }
 
   public EmailMessage buildVerifyEmailMessage(
-      UserEntity user, String verificationToken, long expiresInSeconds) {
+      String email, String verificationToken, long expiresInSeconds) {
     String verificationLink = buildVerificationLink(verificationToken);
     return new EmailMessage(
-        user.getEmail(),
+        email,
         VERIFY_EMAIL_SUBJECT,
         renderHtml(verificationLink),
         buildText(verificationLink, expiresInSeconds));

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
@@ -2,6 +2,7 @@ package com.tychewealth.service.helper.email;
 
 import com.tychewealth.service.email.EmailMessage;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -16,15 +17,18 @@ public class RegisterEmailHelper {
   private static final String VERIFY_EMAIL_LINK_PLACEHOLDER = "{{verification_link}}";
 
   private final String verifyEmailUrl;
-  private final Resource verifyEmailTemplate;
+  private final String cachedVerifyEmailTemplate;
 
   public RegisterEmailHelper(
-      @Value(
-              "${app.auth.verify-registration-url:http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration}")
-          String verifyEmailUrl,
+      URI verifyRegistrationUri,
       @Value("classpath:templates/email/verify-email.html") Resource verifyEmailTemplate) {
-    this.verifyEmailUrl = verifyEmailUrl;
-    this.verifyEmailTemplate = verifyEmailTemplate;
+    this.verifyEmailUrl = verifyRegistrationUri.toString();
+    try {
+      this.cachedVerifyEmailTemplate =
+          StreamUtils.copyToString(verifyEmailTemplate.getInputStream(), StandardCharsets.UTF_8);
+    } catch (IOException ex) {
+      throw new IllegalStateException("Unable to load verify email template", ex);
+    }
   }
 
   public EmailMessage buildVerifyEmailMessage(
@@ -45,17 +49,11 @@ public class RegisterEmailHelper {
   }
 
   private String renderHtml(String verificationLink) {
-    try {
-      String template =
-          StreamUtils.copyToString(verifyEmailTemplate.getInputStream(), StandardCharsets.UTF_8);
-      return template.replace(VERIFY_EMAIL_LINK_PLACEHOLDER, verificationLink);
-    } catch (IOException ex) {
-      throw new IllegalStateException("Unable to load verify email template", ex);
-    }
+    return cachedVerifyEmailTemplate.replace(VERIFY_EMAIL_LINK_PLACEHOLDER, verificationLink);
   }
 
   private String buildText(String verificationLink, long expiresInSeconds) {
-    long expiresInMinutes = expiresInSeconds / 60;
+    long expiresInMinutes = (expiresInSeconds + 59) / 60;
     return "Verify your email by visiting "
         + verificationLink
         + ". This link will expire in "

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
@@ -1,0 +1,66 @@
+package com.tychewealth.service.helper.email;
+
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.service.email.EmailMessage;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class RegisterEmailHelper {
+
+  private static final String VERIFY_EMAIL_SUBJECT = "Verify your email";
+  private static final String VERIFY_EMAIL_LINK_PLACEHOLDER = "{{verification_link}}";
+
+  private final String verifyEmailUrl;
+  private final Resource verifyEmailTemplate;
+
+  public RegisterEmailHelper(
+      @Value(
+              "${app.auth.verify-registration-url:http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration}")
+          String verifyEmailUrl,
+      @Value("classpath:templates/email/verify-email.html") Resource verifyEmailTemplate) {
+    this.verifyEmailUrl = verifyEmailUrl;
+    this.verifyEmailTemplate = verifyEmailTemplate;
+  }
+
+  public EmailMessage buildVerifyEmailMessage(
+      UserEntity user, String verificationToken, long expiresInSeconds) {
+    String verificationLink = buildVerificationLink(verificationToken);
+    return new EmailMessage(
+        user.getEmail(),
+        VERIFY_EMAIL_SUBJECT,
+        renderHtml(verificationLink),
+        buildText(verificationLink, expiresInSeconds));
+  }
+
+  private String buildVerificationLink(String token) {
+    return UriComponentsBuilder.fromUriString(verifyEmailUrl)
+        .queryParam("token", token)
+        .build(true)
+        .toUriString();
+  }
+
+  private String renderHtml(String verificationLink) {
+    try {
+      String template =
+          StreamUtils.copyToString(verifyEmailTemplate.getInputStream(), StandardCharsets.UTF_8);
+      return template.replace(VERIFY_EMAIL_LINK_PLACEHOLDER, verificationLink);
+    } catch (IOException ex) {
+      throw new IllegalStateException("Unable to load verify email template", ex);
+    }
+  }
+
+  private String buildText(String verificationLink, long expiresInSeconds) {
+    long expiresInMinutes = expiresInSeconds / 60;
+    return "Verify your email by visiting "
+        + verificationLink
+        + ". This link will expire in "
+        + expiresInMinutes
+        + " minutes.";
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -106,7 +106,14 @@ public class AccessTokenHelper {
 
   public Long extractUserId(String token) {
     try {
-      return Long.valueOf(parseClaims(token).getSubject());
+      Claims claims = parseClaims(token);
+      String purpose = claims.get(TOKEN_PURPOSE_CLAIM, String.class);
+
+      if (StringUtils.hasText(purpose)) {
+        throw new IllegalArgumentException("Token with purpose is not valid for bearer auth");
+      }
+
+      return Long.valueOf(claims.getSubject());
     } catch (JwtException | IllegalArgumentException ex) {
       log.warn(REQUEST_CONFLICT, AUTH, ACCESS_TOKEN_ACTION, INVALID_ACCESS_TOKEN_MESSAGE);
       throw new AuthException(ErrorDefinition.UNAUTHORIZED, null, HttpStatus.UNAUTHORIZED);

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -2,7 +2,7 @@ package com.tychewealth.service.helper.token;
 
 import static com.tychewealth.constants.AuthConstants.TOKEN_PURPOSE_CLAIM;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
-import static com.tychewealth.constants.AuthConstants.VERIFY_EMAIL_TOKEN_PURPOSE;
+import static com.tychewealth.constants.AuthConstants.VERIFY_REGISTRATION_TOKEN_PURPOSE;
 import static com.tychewealth.constants.LogConstants.ACCESS_TOKEN_ACTION;
 import static com.tychewealth.constants.LogConstants.AUTH;
 import static com.tychewealth.constants.LogConstants.INVALID_ACCESS_TOKEN_MESSAGE;
@@ -61,14 +61,14 @@ public class AccessTokenHelper {
   }
 
   public AuthTokenPayload generateVerifyEmailToken(UserEntity user) {
-    return generateToken(user, verifyEmailTokenTtlSeconds, VERIFY_EMAIL_TOKEN_PURPOSE);
+    return generateToken(user, verifyEmailTokenTtlSeconds, VERIFY_REGISTRATION_TOKEN_PURPOSE);
   }
 
   public Long extractVerifyEmailUserId(String token) {
     try {
       Claims claims = parseClaims(token);
       String purpose = claims.get(TOKEN_PURPOSE_CLAIM, String.class);
-      if (!VERIFY_EMAIL_TOKEN_PURPOSE.equals(purpose)) {
+      if (!VERIFY_REGISTRATION_TOKEN_PURPOSE.equals(purpose)) {
         throw new IllegalArgumentException("Token is not intended for email verification");
       }
       return Long.valueOf(claims.getSubject());

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -1,6 +1,8 @@
 package com.tychewealth.service.helper.token;
 
+import static com.tychewealth.constants.AuthConstants.TOKEN_PURPOSE_CLAIM;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.AuthConstants.VERIFY_EMAIL_TOKEN_PURPOSE;
 import static com.tychewealth.constants.LogConstants.ACCESS_TOKEN_ACTION;
 import static com.tychewealth.constants.LogConstants.AUTH;
 import static com.tychewealth.constants.LogConstants.INVALID_ACCESS_TOKEN_MESSAGE;
@@ -32,26 +34,56 @@ public class AccessTokenHelper {
 
   private final SecretKey signingKey;
   private final long accessTokenTtlSeconds;
+  private final long verifyEmailTokenTtlSeconds;
 
   public AccessTokenHelper(
       @Value("${app.auth.jwt.secret}") String jwtSecret,
-      @Value("${app.auth.jwt.access-token-ttl-seconds:900}") long accessTokenTtlSeconds) {
+      @Value("${app.auth.jwt.access-token-ttl-seconds:900}") long accessTokenTtlSeconds,
+      @Value("${app.auth.jwt.verify-email-token-ttl-seconds:900}")
+          long verifyEmailTokenTtlSeconds) {
 
     if (accessTokenTtlSeconds <= 0) {
       throw new IllegalArgumentException(
           "app.auth.jwt.access-token-ttl-seconds must be greater than 0");
     }
+    if (verifyEmailTokenTtlSeconds <= 0) {
+      throw new IllegalArgumentException(
+          "app.auth.jwt.verify-email-token-ttl-seconds must be greater than 0");
+    }
 
     this.signingKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
     this.accessTokenTtlSeconds = accessTokenTtlSeconds;
+    this.verifyEmailTokenTtlSeconds = verifyEmailTokenTtlSeconds;
   }
 
   public AuthTokenPayload generateAccessToken(UserEntity user) {
+    return generateToken(user, accessTokenTtlSeconds, null);
+  }
+
+  public AuthTokenPayload generateVerifyEmailToken(UserEntity user) {
+    return generateToken(user, verifyEmailTokenTtlSeconds, VERIFY_EMAIL_TOKEN_PURPOSE);
+  }
+
+  public Long extractVerifyEmailUserId(String token) {
+    try {
+      Claims claims = parseClaims(token);
+      String purpose = claims.get(TOKEN_PURPOSE_CLAIM, String.class);
+      if (!VERIFY_EMAIL_TOKEN_PURPOSE.equals(purpose)) {
+        throw new IllegalArgumentException("Token is not intended for email verification");
+      }
+      return Long.valueOf(claims.getSubject());
+    } catch (JwtException | IllegalArgumentException ex) {
+      log.warn(REQUEST_CONFLICT, AUTH, ACCESS_TOKEN_ACTION, INVALID_ACCESS_TOKEN_MESSAGE);
+      throw new AuthException(ErrorDefinition.UNAUTHORIZED, null, HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  private AuthTokenPayload generateToken(UserEntity user, long ttlSeconds, String purpose) {
     Instant issuedAt = Instant.now();
-    Instant expiresAt = issuedAt.plusSeconds(accessTokenTtlSeconds);
+    Instant expiresAt = issuedAt.plusSeconds(ttlSeconds);
     String jti = UUID.randomUUID().toString();
 
-    String token =
+    var builder =
         Jwts.builder()
             .header()
             .type("JWT")
@@ -61,11 +93,15 @@ public class AccessTokenHelper {
             .claim("email", user.getEmail())
             .claim("username", user.getUsername())
             .issuedAt(Date.from(issuedAt))
-            .expiration(Date.from(expiresAt))
-            .signWith(signingKey, Jwts.SIG.HS256)
-            .compact();
+            .expiration(Date.from(expiresAt));
 
-    return new AuthTokenPayload(TOKEN_TYPE_BEARER, token, accessTokenTtlSeconds, jti);
+    if (StringUtils.hasText(purpose)) {
+      builder.claim(TOKEN_PURPOSE_CLAIM, purpose);
+    }
+
+    String token = builder.signWith(signingKey, Jwts.SIG.HS256).compact();
+
+    return new AuthTokenPayload(TOKEN_TYPE_BEARER, token, ttlSeconds, jti);
   }
 
   public Long extractUserId(String token) {

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -30,6 +30,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -76,12 +78,25 @@ public class AuthServiceImpl implements AuthService {
 
     try {
       var registeredUser = authRegisterHelper.createUser(register);
-
-      emailService.send(
+      var verificationEmailMessage =
           registerEmailHelper.buildVerifyEmailMessage(
               registeredUser.response().getEmail(),
               registeredUser.verificationToken().accessToken(),
-              registeredUser.verificationToken().expiresIn()));
+              registeredUser.verificationToken().expiresIn());
+
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              emailService.send(verificationEmailMessage);
+              authMetrics.recordRegisterSuccess();
+              log.info(
+                  LogConstants.REQUEST_SUCCESS + LogConstants.USER_ID,
+                  LogConstants.AUTH,
+                  LogConstants.REGISTER_ACTION,
+                  registeredUser.response().getId());
+            }
+          });
 
       return registeredUser.response();
     } catch (DataIntegrityViolationException ex) {

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -1,8 +1,5 @@
 package com.tychewealth.service.impl;
 
-import static com.tychewealth.constants.AuthConstants.EMAIL_CONSTRAINT;
-import static com.tychewealth.constants.AuthConstants.USERNAME_CONSTRAINT;
-
 import com.tychewealth.constants.LogConstants;
 import com.tychewealth.dto.auth.LoginResponseDto;
 import com.tychewealth.dto.auth.RefreshTokenResponseDto;
@@ -24,10 +21,8 @@ import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
-import java.util.Locale;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -48,26 +43,22 @@ public class AuthServiceImpl implements AuthService {
   private final AuthMetrics authMetrics;
 
   @Override
+  public void verifyEmail(String token) {
+    if (token == null || token.isBlank()) {
+      throw new AuthException(ErrorDefinition.GENERIC_BAD_REQUEST, null, HttpStatus.BAD_REQUEST);
+    }
+
+    accessTokenHelper.extractVerifyEmailUserId(token);
+  }
+
+  @Override
   public UserResponseDto register(RegisterRequestDto register) {
     authValidationHelper.validateRegisterRequest(register);
 
     try {
       return authRegisterHelper.createUser(register);
     } catch (DataIntegrityViolationException ex) {
-      if (!isUserUniqueConstraintViolation(ex)) {
-        throw ex;
-      }
-
-      log.warn(
-          LogConstants.REQUEST_CONFLICT,
-          LogConstants.AUTH,
-          LogConstants.REGISTER_ACTION,
-          "registration conflict detected at persistence layer");
-      authMetrics.recordRegisterFailure();
-      authMetrics.recordRegisterConflict();
-
-      throw new AuthException(
-          ErrorDefinition.AUTH_REGISTRATION_CONFLICT, null, HttpStatus.CONFLICT);
+      throw authValidationHelper.validateRegisterPersistenceConflict(ex);
     }
   }
 
@@ -120,34 +111,5 @@ public class AuthServiceImpl implements AuthService {
         LogConstants.AUTH,
         LogConstants.LOGOUT_ACTION,
         refreshToken.getUser().getId());
-  }
-
-  private boolean isUserUniqueConstraintViolation(Throwable throwable) {
-    Throwable current = throwable;
-
-    while (current != null) {
-      if (current instanceof ConstraintViolationException cve) {
-        String constraintName = cve.getConstraintName();
-        if (isUserUniqueConstraint(constraintName)) {
-          return true;
-        }
-      }
-
-      String message = current.getMessage();
-      if (isUserUniqueConstraint(message)) {
-        return true;
-      }
-
-      current = current.getCause();
-    }
-    return false;
-  }
-
-  private boolean isUserUniqueConstraint(String source) {
-    if (source == null || source.isBlank()) {
-      return false;
-    }
-    String normalized = source.toLowerCase(Locale.ROOT);
-    return normalized.contains(EMAIL_CONSTRAINT) || normalized.contains(USERNAME_CONSTRAINT);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -11,10 +11,13 @@ import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.AuthService;
+import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.email.RegisterEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -36,27 +39,51 @@ public class AuthServiceImpl implements AuthService {
   private final AuthValidationHelper authValidationHelper;
   private final AuthRegisterHelper authRegisterHelper;
   private final AuthLoginHelper authLoginHelper;
+  private final RegisterEmailHelper registerEmailHelper;
+  private final EmailService emailService;
   private final TokenStateHelper tokenStateHelper;
   private final AuthRefreshTokenHelper authRefreshTokenHelper;
   private final AccessTokenHelper accessTokenHelper;
   private final TokenValidationHelper tokenValidationHelper;
   private final AuthMetrics authMetrics;
+  private final UserRepository userRepository;
 
   @Override
+  @Transactional
   public void verifyEmail(String token) {
     if (token == null || token.isBlank()) {
       throw new AuthException(ErrorDefinition.GENERIC_BAD_REQUEST, null, HttpStatus.BAD_REQUEST);
     }
 
-    accessTokenHelper.extractVerifyEmailUserId(token);
+    Long userId = accessTokenHelper.extractVerifyEmailUserId(token);
+    UserEntity user =
+        userRepository
+            .findByIdAndDeletedAtIsNull(userId)
+            .orElseThrow(
+                () ->
+                    new AuthException(ErrorDefinition.UNAUTHORIZED, null, HttpStatus.UNAUTHORIZED));
+    if (user.isVerified()) {
+      return;
+    }
+    user.setVerified(true);
+    userRepository.save(user);
   }
 
   @Override
+  @Transactional
   public UserResponseDto register(RegisterRequestDto register) {
     authValidationHelper.validateRegisterRequest(register);
 
     try {
-      return authRegisterHelper.createUser(register);
+      var registeredUser = authRegisterHelper.createUser(register);
+
+      emailService.send(
+          registerEmailHelper.buildVerifyEmailMessage(
+              registeredUser.user(),
+              registeredUser.verificationToken().accessToken(),
+              registeredUser.verificationToken().expiresIn()));
+
+      return registeredUser.response();
     } catch (DataIntegrityViolationException ex) {
       throw authValidationHelper.validateRegisterPersistenceConflict(ex);
     }

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -79,7 +79,7 @@ public class AuthServiceImpl implements AuthService {
 
       emailService.send(
           registerEmailHelper.buildVerifyEmailMessage(
-              registeredUser.user(),
+              registeredUser.response().getEmail(),
               registeredUser.verificationToken().accessToken(),
               registeredUser.verificationToken().expiresIn()));
 

--- a/user-service/src/main/java/com/tychewealth/service/impl/EmailServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/EmailServiceImpl.java
@@ -4,12 +4,10 @@ import com.tychewealth.service.EmailService;
 import com.tychewealth.service.email.EmailMessage;
 import com.tychewealth.service.helper.email.EmailServiceHelper;
 import lombok.AllArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
-@ConditionalOnProperty(prefix = "app.email.resend", name = "enabled", havingValue = "true")
 public class EmailServiceImpl implements EmailService {
 
   private final EmailServiceHelper emailServiceHelper;

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -21,6 +21,7 @@ spring.jpa.hibernate.ddl-auto=none
 # JWT login token config
 app.auth.jwt.secret=${JWT_SECRET}
 app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
+app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
 app.auth.jwt.refresh-token-pepper=${JWT_REFRESH_TOKEN_PEPPER}
 

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -25,7 +25,7 @@ app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
 app.auth.jwt.refresh-token-pepper=${JWT_REFRESH_TOKEN_PEPPER}
-app.auth.verify-registration-url=${VERIFY_REGISTRATION_URL:http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration}
+app.auth.verify-registration-url=${VERIFY_REGISTRATION_URL}
 
 # Register endpoint protections
 app.auth.register-rate-limit.max-requests=${AUTH_REGISTER_RATE_LIMIT_MAX_REQUESTS:15}

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -17,6 +17,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Let Liquibase manage schema creation and updates
 spring.jpa.hibernate.ddl-auto=none
+spring.jpa.open-in-view=false
 
 # JWT login token config
 app.auth.jwt.secret=${JWT_SECRET}
@@ -24,6 +25,7 @@ app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
 app.auth.jwt.refresh-token-pepper=${JWT_REFRESH_TOKEN_PEPPER}
+app.auth.verify-registration-url=${VERIFY_REGISTRATION_URL:http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration}
 
 # Register endpoint protections
 app.auth.register-rate-limit.max-requests=${AUTH_REGISTER_RATE_LIMIT_MAX_REQUESTS:15}

--- a/user-service/src/main/resources/db.changelog/user-changelog/user-changelog-email-verification.xml
+++ b/user-service/src/main/resources/db.changelog/user-changelog/user-changelog-email-verification.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-users-is-verified-column" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <columnExists tableName="users" columnName="is_verified"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="users">
+            <column name="is_verified" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="users" columnName="is_verified"/>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/user-service/src/main/resources/db.changelog/user-changelog/user-changelog-master.xml
+++ b/user-service/src/main/resources/db.changelog/user-changelog/user-changelog-master.xml
@@ -7,5 +7,6 @@
 
     <include file="user-changelog-dll.xml" relativeToChangelogFile="true"/>
     <include file="user-changelog-soft-delete.xml" relativeToChangelogFile="true"/>
+    <include file="user-changelog-email-verification.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/user-service/src/main/resources/templates/email/verify-email.html
+++ b/user-service/src/main/resources/templates/email/verify-email.html
@@ -1,35 +1,40 @@
-<div
-  style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; color: #111; line-height: 1.5;"
->
-  <h1 style="margin-bottom: 24px;">Tyche Wealth</h1>
-
-  <h2 style="margin-bottom: 16px;">Verify your email</h2>
-
-  <p>Hi,</p>
-
-  <p>Thanks for signing up for <strong>Tyche Wealth</strong>.</p>
-
-  <p>Please confirm your email address by clicking the button below:</p>
-
-  <div style="text-align: center; margin: 32px 0;">
-    <a
-      href="{{verification_link}}"
-      style="
-        display: inline-block;
-        background-color: #111;
-        color: #fff;
-        padding: 12px 20px;
-        text-decoration: none;
-        border-radius: 6px;
-      "
+<!DOCTYPE html>
+<html>
+  <body>
+    <div
+      style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; color: #111; line-height: 1.5;"
     >
-      Verify email
-    </a>
-  </div>
+      <h1 style="margin-bottom: 24px;">Tyche Wealth</h1>
 
-  <p>If you didn't create an account, you can safely ignore this email.</p>
+      <h2 style="margin-bottom: 16px;">Verify your email</h2>
 
-  <p style="margin-top: 32px; font-size: 12px; color: #666;">
-    This link will expire in 15 minutes.
-  </p>
-</div>
+      <p>Hi,</p>
+
+      <p>Thanks for signing up for <strong>Tyche Wealth</strong>.</p>
+
+      <p>Please confirm your email address by clicking the button below:</p>
+
+      <div style="text-align: center; margin: 32px 0;">
+        <a
+          href="{{verification_link}}"
+          style="
+            display: inline-block;
+            background-color: #111;
+            color: #fff;
+            padding: 12px 20px;
+            text-decoration: none;
+            border-radius: 6px;
+          "
+        >
+          Verify email
+        </a>
+      </div>
+
+      <p>If you didn't create an account, you can safely ignore this email.</p>
+
+      <p style="margin-top: 32px; font-size: 12px; color: #666;">
+        This link will expire in 15 minutes.
+      </p>
+    </div>
+  </body>
+</html>

--- a/user-service/src/main/resources/templates/email/verify-email.html
+++ b/user-service/src/main/resources/templates/email/verify-email.html
@@ -1,0 +1,35 @@
+<div
+  style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; color: #111; line-height: 1.5;"
+>
+  <h1 style="margin-bottom: 24px;">Tyche Wealth</h1>
+
+  <h2 style="margin-bottom: 16px;">Verify your email</h2>
+
+  <p>Hi,</p>
+
+  <p>Thanks for signing up for <strong>Tyche Wealth</strong>.</p>
+
+  <p>Please confirm your email address by clicking the button below:</p>
+
+  <div style="text-align: center; margin: 32px 0;">
+    <a
+      href="{{verification_link}}"
+      style="
+        display: inline-block;
+        background-color: #111;
+        color: #fff;
+        padding: 12px 20px;
+        text-decoration: none;
+        border-radius: 6px;
+      "
+    >
+      Verify email
+    </a>
+  </div>
+
+  <p>If you didn't create an account, you can safely ignore this email.</p>
+
+  <p style="margin-top: 32px; font-size: 12px; color: #666;">
+    This link will expire in 15 minutes.
+  </p>
+</div>

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -36,6 +36,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableAutoConfiguration(exclude = UserDetailsServiceAutoConfiguration.class)
 @Import({
   IntegrationTestConfig.class,
+  EmailConfig.class,
   RefreshRateLimitConfig.class,
   AuthApiController.class,
   AuthServiceImpl.class,
@@ -70,6 +71,9 @@ public class AuthIntegrationTestConfig {
               "spring.liquibase.change-log=classpath:db.changelog/changelog-master.xml",
               "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
               "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER,
+              "app.auth.verify-registration-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration",
+              "app.email.resend.api-key=test-resend-api-key",
+              "app.email.resend.from=Tyche Wealth <auth@tyche-wealth.test>",
               "app.auth.register-rate-limit.max-requests=2",
               "app.auth.register-rate-limit.window-seconds=300",
               "app.auth.login-rate-limit.max-requests=2",

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -9,9 +9,11 @@ import com.tychewealth.error.handler.ErrorHandler;
 import com.tychewealth.mapper.user.UserMapperImpl;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.email.RegisterEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -19,6 +21,7 @@ import com.tychewealth.service.helper.token.TokenValidationHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.monitoring.UserMetrics;
+import org.mockito.Mockito;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -39,6 +42,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthValidationHelper.class,
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
+  RegisterEmailHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
@@ -51,6 +55,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
 @EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
 public class AuthIntegrationTestConfig {
+
+  @org.springframework.context.annotation.Bean
+  public EmailService emailService() {
+    return Mockito.mock(EmailService.class);
+  }
 
   public static class Initializer
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
@@ -49,6 +49,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 @Import({
   SecurityTestConfig.class,
   TestDatabaseConfig.class,
+  EmailConfig.class,
   RefreshRateLimitConfig.class,
   AuthApiController.class,
   UserApiController.class,
@@ -102,6 +103,9 @@ public class RedisIntegrationTestConfig {
               "spring.liquibase.change-log=classpath:db.changelog/changelog-master.xml",
               "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
               "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER,
+              "app.auth.verify-registration-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration",
+              "app.email.resend.api-key=test-resend-api-key",
+              "app.email.resend.from=Tyche Wealth <auth@tyche-wealth.test>",
               "app.auth.register-rate-limit.max-requests=2",
               "app.auth.register-rate-limit.window-seconds=300",
               "app.auth.login-rate-limit.max-requests=20",

--- a/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
@@ -13,9 +13,11 @@ import com.tychewealth.error.handler.ErrorHandler;
 import com.tychewealth.mapper.user.UserMapperImpl;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.email.RegisterEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -28,6 +30,7 @@ import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.monitoring.UserMetrics;
 import com.tychewealth.service.ratelimit.RateLimitStore;
 import com.tychewealth.service.ratelimit.RedisRateLimitStore;
+import org.mockito.Mockito;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -54,6 +57,7 @@ import org.springframework.data.redis.core.RedisTemplate;
   AuthValidationHelper.class,
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
+  RegisterEmailHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
@@ -68,6 +72,11 @@ import org.springframework.data.redis.core.RedisTemplate;
 @EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
 @EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
 public class RedisIntegrationTestConfig {
+
+  @Bean
+  public EmailService emailService() {
+    return Mockito.mock(EmailService.class);
+  }
 
   @Bean
   @Primary

--- a/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
@@ -12,9 +12,11 @@ import com.tychewealth.error.handler.ErrorHandler;
 import com.tychewealth.mapper.user.UserMapperImpl;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.email.RegisterEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -25,6 +27,7 @@ import com.tychewealth.service.impl.AuthServiceImpl;
 import com.tychewealth.service.impl.UserServiceImpl;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.monitoring.UserMetrics;
+import org.mockito.Mockito;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -32,6 +35,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
@@ -47,6 +51,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthValidationHelper.class,
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
+  RegisterEmailHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
@@ -61,6 +66,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
 @EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
 public class SecurityIntegrationTestConfig {
+
+  @Bean
+  public EmailService emailService() {
+    return Mockito.mock(EmailService.class);
+  }
 
   public static class Initializer
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
@@ -43,6 +43,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableAutoConfiguration(exclude = UserDetailsServiceAutoConfiguration.class)
 @Import({
   IntegrationTestConfig.class,
+  EmailConfig.class,
   RefreshRateLimitConfig.class,
   AuthApiController.class,
   UserApiController.class,
@@ -81,6 +82,9 @@ public class SecurityIntegrationTestConfig {
               "spring.liquibase.change-log=classpath:db.changelog/changelog-master.xml",
               "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
               "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER,
+              "app.auth.verify-registration-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration",
+              "app.email.resend.api-key=test-resend-api-key",
+              "app.email.resend.from=Tyche Wealth <auth@tyche-wealth.test>",
               "app.security.prometheus.username=" + TEST_PROMETHEUS_USERNAME,
               "PROMETHEUS_PASSWORD=" + TEST_PROMETHEUS_PASSWORD,
               "app.auth.register-rate-limit.max-requests=2",

--- a/user-service/src/test/java/com/tychewealth/config/UserIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/UserIntegrationTestConfig.java
@@ -62,7 +62,8 @@ public class UserIntegrationTestConfig {
       TestPropertyValues.of(
               "spring.liquibase.change-log=classpath:db.changelog/changelog-master.xml",
               "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
-              "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER)
+              "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER,
+              "app.auth.verify-registration-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration")
           .applyTo(applicationContext.getEnvironment());
     }
   }

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.tychewealth.controller;
 
+import static com.tychewealth.constants.ApiConstants.AUTH_BASE_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
 import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_LOGIN_FAILURE;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -57,6 +59,8 @@ import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.helper.token.AccessTokenHelper;
+import com.tychewealth.service.token.AuthTokenPayload;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,6 +90,7 @@ class AuthApiControllerIntegrationTest {
   @Autowired private RefreshRateLimitConfig rateLimitConfig;
 
   @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private AccessTokenHelper accessTokenHelper;
 
   private RegisterRequestDto validRequest;
   private LoginRequestDto validLoginRequest;
@@ -146,6 +151,30 @@ class AuthApiControllerIntegrationTest {
     assertTrue(passwordEncoder.matches(validRequest.getPassword(), created.getPassword()));
     assertEquals(requestsBefore + 1, counterValue(meterRegistry, METRIC_AUTH_REGISTER_REQUESTS));
     assertEquals(successBefore + 1, counterValue(meterRegistry, METRIC_AUTH_REGISTER_SUCCESS));
+  }
+
+  @Test
+  void verifyEmailReturnsNoContentWhenTokenIsValid() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload verifyEmailToken = accessTokenHelper.generateVerifyEmailToken(user);
+
+    mockMvc
+        .perform(
+            get(AUTH_BASE_URL + "/verify-email").param("token", verifyEmailToken.accessToken()))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void verifyEmailReturnsUnauthorizedWhenTokenIsRegularAccessToken() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload accessToken = accessTokenHelper.generateAccessToken(user);
+
+    mockMvc
+        .perform(get(AUTH_BASE_URL + "/verify-email").param("token", accessToken.accessToken()))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
+        .andExpect(jsonPath("$.description").value(ErrorDefinition.UNAUTHORIZED.getDescription()));
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -42,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -59,14 +61,19 @@ import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.EmailService;
+import com.tychewealth.service.email.EmailMessage;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.token.AuthTokenPayload;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -80,6 +87,9 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 class AuthApiControllerIntegrationTest {
 
+  private static final Pattern VERIFY_REGISTRATION_TOKEN_PATTERN =
+      Pattern.compile("token=([^\"&]+)");
+
   @Autowired private MockMvc mockMvc;
 
   @Autowired private ObjectMapper objectMapper;
@@ -91,6 +101,7 @@ class AuthApiControllerIntegrationTest {
 
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private AccessTokenHelper accessTokenHelper;
+  @Autowired private EmailService emailService;
 
   private RegisterRequestDto validRequest;
   private LoginRequestDto validLoginRequest;
@@ -105,6 +116,7 @@ class AuthApiControllerIntegrationTest {
     refreshTokenRepository.deleteAll();
     userRepository.deleteAll();
     rateLimitConfig.resetAll();
+    reset(emailService);
     validRequest =
         new RegisterRequestDto(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_PASSWORD_VALID);
     conflictByEmailRequest =
@@ -127,6 +139,7 @@ class AuthApiControllerIntegrationTest {
     existingLoginUser.setEmail(validRequest.getEmail());
     existingLoginUser.setUsername(validRequest.getUsername());
     existingLoginUser.setPassword(passwordEncoder.encode(validRequest.getPassword()));
+    existingLoginUser.setVerified(true);
 
     validLoginRequest = new LoginRequestDto(validRequest.getEmail(), validRequest.getPassword());
   }
@@ -154,23 +167,73 @@ class AuthApiControllerIntegrationTest {
   }
 
   @Test
-  void verifyEmailReturnsNoContentWhenTokenIsValid() throws Exception {
+  void registerSendsVerificationEmailWithWorkingVerifyLink() throws Exception {
+    registerRequest(mockMvc, objectMapper, validRequest).andExpect(status().isCreated());
+
+    ArgumentCaptor<EmailMessage> emailCaptor = ArgumentCaptor.forClass(EmailMessage.class);
+    verify(emailService).send(emailCaptor.capture());
+
+    EmailMessage sentEmail = emailCaptor.getValue();
+    assertEquals(validRequest.getEmail(), sentEmail.to());
+    assertEquals("Verify your email", sentEmail.subject());
+    assertTrue(sentEmail.html().contains("/auth/verify-registration"));
+    assertTrue(sentEmail.text().contains("15 minutes"));
+
+    String token = extractVerificationToken(sentEmail.html());
+
+    mockMvc
+        .perform(get(AUTH_BASE_URL + "/verify-registration").param("token", token))
+        .andExpect(status().isNoContent());
+
+    UserEntity verifiedUser =
+        userRepository.findByEmailIncludingDeleted(validRequest.getEmail()).orElseThrow();
+    assertTrue(verifiedUser.isVerified());
+  }
+
+  @Test
+  void verifyRegistrationReturnsNoContentAndMarksUserVerifiedWhenTokenIsValid() throws Exception {
     UserEntity user = userRepository.save(existingLoginUser);
     AuthTokenPayload verifyEmailToken = accessTokenHelper.generateVerifyEmailToken(user);
 
     mockMvc
         .perform(
-            get(AUTH_BASE_URL + "/verify-email").param("token", verifyEmailToken.accessToken()))
+            get(AUTH_BASE_URL + "/verify-registration")
+                .param("token", verifyEmailToken.accessToken()))
         .andExpect(status().isNoContent());
+
+    UserEntity verifiedUser = userRepository.findById(user.getId()).orElseThrow();
+    assertTrue(verifiedUser.isVerified());
   }
 
   @Test
-  void verifyEmailReturnsUnauthorizedWhenTokenIsRegularAccessToken() throws Exception {
+  void verifyRegistrationIsIdempotentWhenUserWasAlreadyVerified() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload verifyEmailToken = accessTokenHelper.generateVerifyEmailToken(user);
+
+    mockMvc
+        .perform(
+            get(AUTH_BASE_URL + "/verify-registration")
+                .param("token", verifyEmailToken.accessToken()))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            get(AUTH_BASE_URL + "/verify-registration")
+                .param("token", verifyEmailToken.accessToken()))
+        .andExpect(status().isNoContent());
+
+    UserEntity verifiedUser = userRepository.findById(user.getId()).orElseThrow();
+    assertTrue(verifiedUser.isVerified());
+  }
+
+  @Test
+  void verifyRegistrationReturnsUnauthorizedWhenTokenIsRegularAccessToken() throws Exception {
     UserEntity user = userRepository.save(existingLoginUser);
     AuthTokenPayload accessToken = accessTokenHelper.generateAccessToken(user);
 
     mockMvc
-        .perform(get(AUTH_BASE_URL + "/verify-email").param("token", accessToken.accessToken()))
+        .perform(
+            get(AUTH_BASE_URL + "/verify-registration").param("token", accessToken.accessToken()))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
@@ -292,6 +355,22 @@ class AuthApiControllerIntegrationTest {
   @Test
   void loginReturnsUnauthorizedWhenUserWasSoftDeleted() throws Exception {
     existingLoginUser.setDeletedAt(java.time.LocalDateTime.now());
+    userRepository.save(existingLoginUser);
+
+    loginRequest(mockMvc, objectMapper, validLoginRequest)
+        .andExpect(status().isUnauthorized())
+        .andExpect(
+            jsonPath("$.code").value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getCode()))
+        .andExpect(
+            jsonPath("$.type").value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getType()))
+        .andExpect(
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getDescription()));
+  }
+
+  @Test
+  void loginReturnsUnauthorizedWhenUserIsNotVerified() throws Exception {
+    existingLoginUser.setVerified(false);
     userRepository.save(existingLoginUser);
 
     loginRequest(mockMvc, objectMapper, validLoginRequest)
@@ -526,5 +605,11 @@ class AuthApiControllerIntegrationTest {
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()));
+  }
+
+  private String extractVerificationToken(String html) {
+    Matcher matcher = VERIFY_REGISTRATION_TOKEN_PATTERN.matcher(html);
+    assertTrue(matcher.find());
+    return matcher.group(1);
   }
 }

--- a/user-service/src/test/java/com/tychewealth/controller/RedisIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/RedisIntegrationTest.java
@@ -66,6 +66,7 @@ class RedisIntegrationTest {
     existingLoginUser.setEmail(TEST_EMAIL_LAURA);
     existingLoginUser.setUsername(TEST_USERNAME_LAURA);
     existingLoginUser.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
+    existingLoginUser.setVerified(true);
     userRepository.save(existingLoginUser);
 
     validLoginRequest = new LoginRequestDto(TEST_EMAIL_LAURA, TEST_PASSWORD_VALID);

--- a/user-service/src/test/java/com/tychewealth/controller/UserApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/UserApiControllerIntegrationTest.java
@@ -90,6 +90,7 @@ class UserApiControllerIntegrationTest {
     existingUser =
         buildUser(
             TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, passwordEncoder.encode(TEST_PASSWORD_VALID));
+    existingUser.setVerified(true);
   }
 
   @Test
@@ -212,6 +213,7 @@ class UserApiControllerIntegrationTest {
     UserEntity anotherUser =
         buildUser(
             TEST_OTHER_EMAIL, TEST_OCCUPIED_USERNAME, passwordEncoder.encode(TEST_PASSWORD_VALID));
+    anotherUser.setVerified(true);
     userRepository.saveAndFlush(anotherUser);
     String accessToken = accessTokenHelper.generateAccessToken(saved).accessToken();
     double conflictBefore = counterValue(meterRegistry, METRIC_USER_USERNAME_CONFLICT);

--- a/user-service/src/test/java/com/tychewealth/security/SecurityIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/security/SecurityIntegrationTest.java
@@ -89,6 +89,7 @@ class SecurityIntegrationTest {
     existingUser.setEmail(TEST_EMAIL_LAURA);
     existingUser.setUsername(TEST_USERNAME_LAURA);
     existingUser.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
+    existingUser.setVerified(true);
     userRepository.save(existingUser);
 
     validLoginRequest = new LoginRequestDto(TEST_EMAIL_LAURA, TEST_PASSWORD_VALID);

--- a/user-service/src/test/java/com/tychewealth/service/helper/token/AccessTokenHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/token/AccessTokenHelperTest.java
@@ -1,0 +1,45 @@
+package com.tychewealth.service.helper.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.testdata.EntityBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AccessTokenHelperTest {
+
+  private static final String TEST_JWT_SECRET =
+      "0123456789012345678901234567890123456789012345678901234567890123";
+
+  private AccessTokenHelper accessTokenHelper;
+
+  @BeforeEach
+  void setUp() {
+    accessTokenHelper = new AccessTokenHelper(TEST_JWT_SECRET, 900, 900);
+  }
+
+  @Test
+  void extractUserIdReturnsSubjectForNormalAccessToken() {
+    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
+    user.setId(42L);
+
+    Long userId =
+        accessTokenHelper.extractUserId(accessTokenHelper.generateAccessToken(user).accessToken());
+
+    assertEquals(42L, userId);
+  }
+
+  @Test
+  void extractUserIdRejectsVerifyRegistrationToken() {
+    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
+    user.setId(42L);
+
+    String verifyRegistrationToken = accessTokenHelper.generateVerifyEmailToken(user).accessToken();
+
+    assertThrows(
+        AuthException.class, () -> accessTokenHelper.extractUserId(verifyRegistrationToken));
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/testhelper/LiquibaseTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/LiquibaseTestHelper.java
@@ -60,15 +60,16 @@ public class LiquibaseTestHelper {
   public void insertUser(Long id, String email, String username) {
     jdbcTemplate.update(
         """
-        INSERT INTO users (id, email, username, password, created_at, deleted_at)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO users (id, email, username, password, created_at, deleted_at, is_verified)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
         id,
         email,
         username,
         DEFAULT_STORED_PASSWORD,
         Timestamp.from(Instant.now()),
-        null);
+        null,
+        false);
   }
 
   public void insertRefreshToken(Long id, String token, Long userId) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email verification on signup with time-limited (~15min) verification links, a new verification endpoint, idempotent confirmation, and enforcement of verified status (blocks login until verified). Verification emails are sent after successful registration commit.
* **Tests**
  * Added integration and unit tests covering registration, email delivery, token verification, idempotency, and unauthorized cases.

Closes #48 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->