### PR TITLE
[TYCHE-24] endpoint to resend verification email

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./application-local.properties:/app/application-local.properties:ro
     environment:
-      DB_URL: ${DB_URL:-jdbc:postgresql://host.docker.internal:5432/tyche_wealth_user}
+      DB_URL: ${DB_URL:-jdbc:postgresql://host.docker.internal:5433/tyche_wealth_user}
       REDIS_HOST: ${REDIS_HOST:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
     depends_on:
@@ -26,7 +26,7 @@ services:
       - /bin/sh
       - /etc/postgres/entrypoint.sh
     ports:
-      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5433}:5432"
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-tyche_wealth_user}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}

--- a/user-service/src/main/java/com/tychewealth/constants/CommonConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/CommonConstants.java
@@ -1,0 +1,11 @@
+package com.tychewealth.constants;
+
+public final class CommonConstants {
+
+  public static final String FIELD_EMAIL = "email";
+  public static final String FIELD_USERNAME = "username";
+  public static final String FIELD_ID = "id";
+  public static final String FIELD_ERROR = "error";
+
+  private CommonConstants() {}
+}

--- a/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
+++ b/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
@@ -9,6 +9,7 @@ import com.tychewealth.dto.auth.RefreshTokenResponseDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -32,6 +33,10 @@ public interface AuthApi {
 
   @PostMapping(value = "/login", consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
   ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto login);
+
+  @PostMapping(value = "/resend-verification", consumes = REQUEST_CONSUMES)
+  ResponseEntity<Void> resendVerificationEmail(
+      @Valid @RequestBody ResendVerificationEmailRequestDto resendVerificationEmailRequestDto);
 
   @PostMapping(value = "/refresh", consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
   ResponseEntity<RefreshTokenResponseDto> refresh(

--- a/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
+++ b/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
@@ -23,6 +23,7 @@ import com.tychewealth.dto.auth.RefreshTokenResponseDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.service.AuthService;
 import jakarta.validation.Valid;
@@ -72,6 +73,22 @@ public class AuthApiController implements AuthApi {
 
     LoginResponseDto response = authService.login(login);
     return withNoStoreHeaders(status(HttpStatus.OK)).body(response);
+  }
+
+  @Override
+  public ResponseEntity<Void> resendVerificationEmail(
+      @Valid @RequestBody ResendVerificationEmailRequestDto resendVerificationEmailRequestDto) {
+    log.info(
+        REQUEST_START,
+        AUTH,
+        VERIFY_REGISTRATION_ACTION,
+        mask(resendVerificationEmailRequestDto.getEmail()));
+
+    authService.resendVerificationEmail(resendVerificationEmailRequestDto);
+    return ResponseEntity.noContent()
+        .header(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
+        .header(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE)
+        .build();
   }
 
   @Override

--- a/user-service/src/main/java/com/tychewealth/dto/auth/request/ResendVerificationEmailRequestDto.java
+++ b/user-service/src/main/java/com/tychewealth/dto/auth/request/ResendVerificationEmailRequestDto.java
@@ -1,0 +1,22 @@
+package com.tychewealth.dto.auth.request;
+
+import static com.tychewealth.constants.ValidationConstants.MUST_BE_A_VALID_EMAIL_ADDRESS;
+import static com.tychewealth.constants.ValidationConstants.MUST_NOT_BE_BLANK;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResendVerificationEmailRequestDto {
+
+  @NotBlank(message = MUST_NOT_BE_BLANK)
+  @Email(message = MUST_BE_A_VALID_EMAIL_ADDRESS)
+  private String email;
+}

--- a/user-service/src/main/java/com/tychewealth/entity/UserEntity.java
+++ b/user-service/src/main/java/com/tychewealth/entity/UserEntity.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +57,9 @@ public class UserEntity {
 
   @Column(name = "is_verified", nullable = false)
   private boolean isVerified = false;
+
+  @Column(name = "verification_token_expires_at")
+  private Instant verificationTokenExpiresAt;
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
@@ -32,6 +32,10 @@ public enum ErrorDefinition {
       "TYCHE-104",
       "AUTH_REGISTER_PASSWORD_FORMAT_INVALID",
       "Password must be 8-72 characters and include at least one uppercase letter, one lowercase letter, one number, and one symbol"),
+  AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE(
+      "TYCHE-105",
+      "AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE",
+      "The previous verification email is still available"),
 
   // USER
   USER_NOT_FOUND("TYCHE-200", "USER_NOT_FOUND", "The requested user was not found"),

--- a/user-service/src/main/java/com/tychewealth/repository/UserRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package com.tychewealth.repository;
 
 import com.tychewealth.entity.UserEntity;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,6 +21,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
 
   Optional<UserEntity> findByEmailAndDeletedAtIsNull(String email);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT u FROM UserEntity u WHERE u.email = :email AND u.deletedAt IS NULL")
+  Optional<UserEntity> findByEmailAndDeletedAtIsNullForUpdate(@Param("email") String email);
 
   Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username);
 }

--- a/user-service/src/main/java/com/tychewealth/service/AuthService.java
+++ b/user-service/src/main/java/com/tychewealth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.tychewealth.dto.auth.RefreshTokenResponseDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
 
 public interface AuthService {
@@ -12,6 +13,8 @@ public interface AuthService {
   void verifyEmail(String token);
 
   UserResponseDto register(RegisterRequestDto register);
+
+  void resendVerificationEmail(ResendVerificationEmailRequestDto resendVerificationEmailRequestDto);
 
   LoginResponseDto login(LoginRequestDto login);
 

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthRegisterHelper.java
@@ -8,6 +8,7 @@ import com.tychewealth.mapper.user.UserMapper;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.token.AuthTokenPayload;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -25,7 +26,12 @@ public class AuthRegisterHelper {
     UserEntity toCreate = userMapper.create(register);
     toCreate.setPassword(passwordEncoder.encode(register.getPassword()));
     UserEntity created = userRepository.save(toCreate);
+
     AuthTokenPayload verificationToken = accessTokenHelper.generateVerifyEmailToken(created);
+    Instant verificationTokenExpiresAt =
+        accessTokenHelper.extractExpiration(verificationToken.accessToken());
+    created.setVerificationTokenExpiresAt(verificationTokenExpiresAt);
+
     UserResponseDto response = userMapper.toDto(created);
     return new RegisteredUserResultDto(response, verificationToken);
   }

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
@@ -64,10 +64,20 @@ public class AuthValidationHelper {
         ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, null, HttpStatus.UNAUTHORIZED);
   }
 
-  public void validateVerificationEmailCanBeResent(UserEntity user) {
+  public boolean canResendVerificationEmail(UserEntity user) {
+
+    if (user.isVerified()) {
+      log.warn(
+          LogConstants.REQUEST_CONFLICT,
+          LogConstants.AUTH,
+          LogConstants.VERIFY_REGISTRATION_ACTION,
+          "user is already verified");
+      return false;
+    }
+
     Instant verificationTokenExpiresAt = user.getVerificationTokenExpiresAt();
     if (verificationTokenExpiresAt == null || !verificationTokenExpiresAt.isAfter(Instant.now())) {
-      return;
+      return true;
     }
 
     log.warn(
@@ -75,8 +85,7 @@ public class AuthValidationHelper {
         LogConstants.AUTH,
         LogConstants.VERIFY_REGISTRATION_ACTION,
         "previous verification email is still available");
-    throw new AuthException(
-        ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE, null, HttpStatus.BAD_REQUEST);
+    return false;
   }
 
   public AuthException validateRegisterPersistenceConflict(DataIntegrityViolationException ex) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthValidationHelper.java
@@ -13,6 +13,7 @@ import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.utils.Utils;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
@@ -61,6 +62,21 @@ public class AuthValidationHelper {
     authMetrics.recordLoginInvalidCredentials();
     throw new AuthException(
         ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, null, HttpStatus.UNAUTHORIZED);
+  }
+
+  public void validateVerificationEmailCanBeResent(UserEntity user) {
+    Instant verificationTokenExpiresAt = user.getVerificationTokenExpiresAt();
+    if (verificationTokenExpiresAt == null || !verificationTokenExpiresAt.isAfter(Instant.now())) {
+      return;
+    }
+
+    log.warn(
+        LogConstants.REQUEST_CONFLICT,
+        LogConstants.AUTH,
+        LogConstants.VERIFY_REGISTRATION_ACTION,
+        "previous verification email is still available");
+    throw new AuthException(
+        ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE, null, HttpStatus.BAD_REQUEST);
   }
 
   public AuthException validateRegisterPersistenceConflict(DataIntegrityViolationException ex) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
@@ -67,10 +67,10 @@ public class RegisterEmailHelper {
   private String formatExpirationText(long expiresInSeconds) {
     if (expiresInSeconds % 3600 == 0) {
       long hours = expiresInSeconds / 3600;
-      return hours + " hours";
+      return hours + (hours == 1 ? " hour" : " hours");
     }
 
     long expiresInMinutes = (expiresInSeconds + 59) / 60;
-    return expiresInMinutes + " minutes";
+    return expiresInMinutes + (expiresInMinutes == 1 ? " minute" : " minutes");
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
@@ -15,6 +15,7 @@ public class RegisterEmailHelper {
 
   private static final String VERIFY_EMAIL_SUBJECT = "Verify your email";
   private static final String VERIFY_EMAIL_LINK_PLACEHOLDER = "{{verification_link}}";
+  private static final String VERIFY_EMAIL_EXPIRATION_PLACEHOLDER = "{{expiration_text}}";
 
   private final String verifyEmailUrl;
   private final String cachedVerifyEmailTemplate;
@@ -34,11 +35,12 @@ public class RegisterEmailHelper {
   public EmailMessage buildVerifyEmailMessage(
       String email, String verificationToken, long expiresInSeconds) {
     String verificationLink = buildVerificationLink(verificationToken);
+    String expirationText = formatExpirationText(expiresInSeconds);
     return new EmailMessage(
         email,
         VERIFY_EMAIL_SUBJECT,
-        renderHtml(verificationLink),
-        buildText(verificationLink, expiresInSeconds));
+        renderHtml(verificationLink, expirationText),
+        buildText(verificationLink, expirationText));
   }
 
   private String buildVerificationLink(String token) {
@@ -48,16 +50,27 @@ public class RegisterEmailHelper {
         .toUriString();
   }
 
-  private String renderHtml(String verificationLink) {
-    return cachedVerifyEmailTemplate.replace(VERIFY_EMAIL_LINK_PLACEHOLDER, verificationLink);
+  private String renderHtml(String verificationLink, String expirationText) {
+    return cachedVerifyEmailTemplate
+        .replace(VERIFY_EMAIL_LINK_PLACEHOLDER, verificationLink)
+        .replace(VERIFY_EMAIL_EXPIRATION_PLACEHOLDER, expirationText);
   }
 
-  private String buildText(String verificationLink, long expiresInSeconds) {
-    long expiresInMinutes = (expiresInSeconds + 59) / 60;
+  private String buildText(String verificationLink, String expirationText) {
     return "Verify your email by visiting "
         + verificationLink
         + ". This link will expire in "
-        + expiresInMinutes
-        + " minutes.";
+        + expirationText
+        + ".";
+  }
+
+  private String formatExpirationText(long expiresInSeconds) {
+    if (expiresInSeconds % 3600 == 0) {
+      long hours = expiresInSeconds / 3600;
+      return hours + " hours";
+    }
+
+    long expiresInMinutes = (expiresInSeconds + 59) / 60;
+    return expiresInMinutes + " minutes";
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/VerificationEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/VerificationEmailHelper.java
@@ -47,11 +47,12 @@ public class VerificationEmailHelper {
       Runnable onSuccess) {
     try {
       emailService.send(verificationEmailMessage);
-      onSuccess.run();
     } catch (RuntimeException ex) {
       verificationTokenRecoveryHelper.restoreVerificationTokenExpiryWithErrorHandling(
           userId, previousVerificationTokenExpiresAt);
       throw ex;
     }
+
+    onSuccess.run();
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/VerificationEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/VerificationEmailHelper.java
@@ -1,13 +1,15 @@
 package com.tychewealth.service.helper.email;
 
-import com.tychewealth.repository.UserRepository;
+import static org.springframework.transaction.support.TransactionSynchronizationManager.registerSynchronization;
+
 import com.tychewealth.service.EmailService;
+import com.tychewealth.service.email.EmailMessage;
+import com.tychewealth.service.helper.token.VerificationTokenRecoveryHelper;
 import com.tychewealth.service.token.AuthTokenPayload;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @AllArgsConstructor
@@ -15,7 +17,7 @@ public class VerificationEmailHelper {
 
   private final RegisterEmailHelper registerEmailHelper;
   private final EmailService emailService;
-  private final UserRepository userRepository;
+  private final VerificationTokenRecoveryHelper verificationTokenRecoveryHelper;
 
   public void scheduleVerificationEmail(
       Long userId,
@@ -28,29 +30,28 @@ public class VerificationEmailHelper {
         registerEmailHelper.buildVerifyEmailMessage(
             email, verificationToken.accessToken(), verificationToken.expiresIn());
 
-    TransactionSynchronizationManager.registerSynchronization(
+    registerSynchronization(
         new TransactionSynchronization() {
           @Override
           public void afterCommit() {
-            try {
-              emailService.send(verificationEmailMessage);
-              onSuccess.run();
-            } catch (RuntimeException ex) {
-              restoreVerificationTokenExpiry(userId, previousVerificationTokenExpiresAt);
-              throw ex;
-            }
+            handleVerificationEmailAfterCommit(
+                userId, previousVerificationTokenExpiresAt, verificationEmailMessage, onSuccess);
           }
         });
   }
 
-  private void restoreVerificationTokenExpiry(
-      Long userId, Instant previousVerificationTokenExpiresAt) {
-    userRepository
-        .findById(userId)
-        .ifPresent(
-            user -> {
-              user.setVerificationTokenExpiresAt(previousVerificationTokenExpiresAt);
-              userRepository.save(user);
-            });
+  private void handleVerificationEmailAfterCommit(
+      Long userId,
+      Instant previousVerificationTokenExpiresAt,
+      EmailMessage verificationEmailMessage,
+      Runnable onSuccess) {
+    try {
+      emailService.send(verificationEmailMessage);
+      onSuccess.run();
+    } catch (RuntimeException ex) {
+      verificationTokenRecoveryHelper.restoreVerificationTokenExpiryWithErrorHandling(
+          userId, previousVerificationTokenExpiresAt);
+      throw ex;
+    }
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/VerificationEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/VerificationEmailHelper.java
@@ -1,0 +1,56 @@
+package com.tychewealth.service.helper.email;
+
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.EmailService;
+import com.tychewealth.service.token.AuthTokenPayload;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+@AllArgsConstructor
+public class VerificationEmailHelper {
+
+  private final RegisterEmailHelper registerEmailHelper;
+  private final EmailService emailService;
+  private final UserRepository userRepository;
+
+  public void scheduleVerificationEmail(
+      Long userId,
+      String email,
+      AuthTokenPayload verificationToken,
+      Instant previousVerificationTokenExpiresAt,
+      Runnable onSuccess) {
+
+    var verificationEmailMessage =
+        registerEmailHelper.buildVerifyEmailMessage(
+            email, verificationToken.accessToken(), verificationToken.expiresIn());
+
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            try {
+              emailService.send(verificationEmailMessage);
+              onSuccess.run();
+            } catch (RuntimeException ex) {
+              restoreVerificationTokenExpiry(userId, previousVerificationTokenExpiresAt);
+              throw ex;
+            }
+          }
+        });
+  }
+
+  private void restoreVerificationTokenExpiry(
+      Long userId, Instant previousVerificationTokenExpiresAt) {
+    userRepository
+        .findById(userId)
+        .ifPresent(
+            user -> {
+              user.setVerificationTokenExpiresAt(previousVerificationTokenExpiresAt);
+              userRepository.save(user);
+            });
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -3,6 +3,8 @@ package com.tychewealth.service.helper.token;
 import static com.tychewealth.constants.AuthConstants.TOKEN_PURPOSE_CLAIM;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
 import static com.tychewealth.constants.AuthConstants.VERIFY_REGISTRATION_TOKEN_PURPOSE;
+import static com.tychewealth.constants.CommonConstants.FIELD_EMAIL;
+import static com.tychewealth.constants.CommonConstants.FIELD_USERNAME;
 import static com.tychewealth.constants.LogConstants.ACCESS_TOKEN_ACTION;
 import static com.tychewealth.constants.LogConstants.AUTH;
 import static com.tychewealth.constants.LogConstants.INVALID_ACCESS_TOKEN_MESSAGE;
@@ -90,8 +92,8 @@ public class AccessTokenHelper {
             .and()
             .subject(String.valueOf(user.getId()))
             .id(jti)
-            .claim("email", user.getEmail())
-            .claim("username", user.getUsername())
+            .claim(FIELD_EMAIL, user.getEmail())
+            .claim(FIELD_USERNAME, user.getUsername())
             .issuedAt(Date.from(issuedAt))
             .expiration(Date.from(expiresAt));
 

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -39,7 +39,7 @@ public class AccessTokenHelper {
   public AccessTokenHelper(
       @Value("${app.auth.jwt.secret}") String jwtSecret,
       @Value("${app.auth.jwt.access-token-ttl-seconds:900}") long accessTokenTtlSeconds,
-      @Value("${app.auth.jwt.verify-email-token-ttl-seconds:900}")
+      @Value("${app.auth.jwt.verify-email-token-ttl-seconds:86400}")
           long verifyEmailTokenTtlSeconds) {
 
     if (accessTokenTtlSeconds <= 0) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/VerificationTokenRecoveryHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/VerificationTokenRecoveryHelper.java
@@ -1,0 +1,40 @@
+package com.tychewealth.service.helper.token;
+
+import com.tychewealth.constants.LogConstants;
+import com.tychewealth.repository.UserRepository;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class VerificationTokenRecoveryHelper {
+
+  private final UserRepository userRepository;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void restoreVerificationTokenExpiryWithErrorHandling(
+      Long userId, Instant previousVerificationTokenExpiresAt) {
+    try {
+      userRepository
+          .findById(userId)
+          .ifPresent(
+              user -> {
+                user.setVerificationTokenExpiresAt(previousVerificationTokenExpiresAt);
+                userRepository.save(user);
+              });
+    } catch (RuntimeException ex) {
+      log.error(
+          LogConstants.REQUEST_CONFLICT + LogConstants.USER_ID,
+          LogConstants.EMAIL,
+          LogConstants.SEND_ACTION,
+          "failed to restore verification token expiry",
+          userId,
+          ex);
+    }
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -67,7 +67,9 @@ public class AuthServiceImpl implements AuthService {
     if (user.isVerified()) {
       return;
     }
+
     user.setVerified(true);
+    user.setVerificationTokenExpiresAt(null);
     userRepository.save(user);
   }
 

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -14,11 +14,10 @@ import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.AuthService;
-import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
-import com.tychewealth.service.helper.email.RegisterEmailHelper;
+import com.tychewealth.service.helper.email.VerificationEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -26,14 +25,13 @@ import com.tychewealth.service.helper.token.TokenValidationHelper;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
 import com.tychewealth.utils.Utils;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -43,8 +41,7 @@ public class AuthServiceImpl implements AuthService {
   private final AuthValidationHelper authValidationHelper;
   private final AuthRegisterHelper authRegisterHelper;
   private final AuthLoginHelper authLoginHelper;
-  private final RegisterEmailHelper registerEmailHelper;
-  private final EmailService emailService;
+  private final VerificationEmailHelper verificationEmailHelper;
   private final TokenStateHelper tokenStateHelper;
   private final AuthRefreshTokenHelper authRefreshTokenHelper;
   private final AccessTokenHelper accessTokenHelper;
@@ -82,19 +79,18 @@ public class AuthServiceImpl implements AuthService {
 
     try {
       var registeredUser = authRegisterHelper.createUser(register);
-      scheduleVerificationEmail(
-          registeredUser.response().getEmail(), registeredUser.verificationToken());
-      TransactionSynchronizationManager.registerSynchronization(
-          new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-              authMetrics.recordRegisterSuccess();
-              log.info(
-                  LogConstants.REQUEST_SUCCESS + LogConstants.USER_ID,
-                  LogConstants.AUTH,
-                  LogConstants.REGISTER_ACTION,
-                  registeredUser.response().getId());
-            }
+      verificationEmailHelper.scheduleVerificationEmail(
+          registeredUser.response().getId(),
+          registeredUser.response().getEmail(),
+          registeredUser.verificationToken(),
+          null,
+          () -> {
+            authMetrics.recordRegisterSuccess();
+            log.info(
+                LogConstants.REQUEST_SUCCESS + LogConstants.USER_ID,
+                LogConstants.AUTH,
+                LogConstants.REGISTER_ACTION,
+                registeredUser.response().getId());
           });
 
       return registeredUser.response();
@@ -107,18 +103,24 @@ public class AuthServiceImpl implements AuthService {
   @Transactional
   public void resendVerificationEmail(
       ResendVerificationEmailRequestDto resendVerificationEmailRequestDto) {
+    String normalizedEmail = Utils.normalizeIdentity(resendVerificationEmailRequestDto.getEmail());
     UserEntity user =
-        userRepository
-            .findByEmailAndDeletedAtIsNull(
-                Utils.normalizeIdentity(resendVerificationEmailRequestDto.getEmail()))
-            .orElseThrow(
-                () ->
-                    new AuthException(ErrorDefinition.USER_NOT_FOUND, null, HttpStatus.NOT_FOUND));
-    authValidationHelper.validateVerificationEmailCanBeResent(user);
+        userRepository.findByEmailAndDeletedAtIsNullForUpdate(normalizedEmail).orElse(null);
+
+    if (user == null || !authValidationHelper.canResendVerificationEmail(user)) {
+      return;
+    }
+
+    Instant previousVerificationTokenExpiresAt = user.getVerificationTokenExpiresAt();
     AuthTokenPayload verificationToken = accessTokenHelper.generateVerifyEmailToken(user);
     user.setVerificationTokenExpiresAt(
         accessTokenHelper.extractExpiration(verificationToken.accessToken()));
-    scheduleVerificationEmail(user.getEmail(), verificationToken);
+    verificationEmailHelper.scheduleVerificationEmail(
+        user.getId(),
+        user.getEmail(),
+        verificationToken,
+        previousVerificationTokenExpiresAt,
+        () -> {});
   }
 
   @Override
@@ -170,19 +172,5 @@ public class AuthServiceImpl implements AuthService {
         LogConstants.AUTH,
         LogConstants.LOGOUT_ACTION,
         refreshToken.getUser().getId());
-  }
-
-  private void scheduleVerificationEmail(String email, AuthTokenPayload verificationToken) {
-    var verificationEmailMessage =
-        registerEmailHelper.buildVerifyEmailMessage(
-            email, verificationToken.accessToken(), verificationToken.expiresIn());
-
-    TransactionSynchronizationManager.registerSynchronization(
-        new TransactionSynchronization() {
-          @Override
-          public void afterCommit() {
-            emailService.send(verificationEmailMessage);
-          }
-        });
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -6,6 +6,7 @@ import com.tychewealth.dto.auth.RefreshTokenResponseDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
@@ -24,6 +25,7 @@ import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
+import com.tychewealth.utils.Utils;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -80,17 +82,12 @@ public class AuthServiceImpl implements AuthService {
 
     try {
       var registeredUser = authRegisterHelper.createUser(register);
-      var verificationEmailMessage =
-          registerEmailHelper.buildVerifyEmailMessage(
-              registeredUser.response().getEmail(),
-              registeredUser.verificationToken().accessToken(),
-              registeredUser.verificationToken().expiresIn());
-
+      scheduleVerificationEmail(
+          registeredUser.response().getEmail(), registeredUser.verificationToken());
       TransactionSynchronizationManager.registerSynchronization(
           new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-              emailService.send(verificationEmailMessage);
               authMetrics.recordRegisterSuccess();
               log.info(
                   LogConstants.REQUEST_SUCCESS + LogConstants.USER_ID,
@@ -104,6 +101,24 @@ public class AuthServiceImpl implements AuthService {
     } catch (DataIntegrityViolationException ex) {
       throw authValidationHelper.validateRegisterPersistenceConflict(ex);
     }
+  }
+
+  @Override
+  @Transactional
+  public void resendVerificationEmail(
+      ResendVerificationEmailRequestDto resendVerificationEmailRequestDto) {
+    UserEntity user =
+        userRepository
+            .findByEmailAndDeletedAtIsNull(
+                Utils.normalizeIdentity(resendVerificationEmailRequestDto.getEmail()))
+            .orElseThrow(
+                () ->
+                    new AuthException(ErrorDefinition.USER_NOT_FOUND, null, HttpStatus.NOT_FOUND));
+    authValidationHelper.validateVerificationEmailCanBeResent(user);
+    AuthTokenPayload verificationToken = accessTokenHelper.generateVerifyEmailToken(user);
+    user.setVerificationTokenExpiresAt(
+        accessTokenHelper.extractExpiration(verificationToken.accessToken()));
+    scheduleVerificationEmail(user.getEmail(), verificationToken);
   }
 
   @Override
@@ -155,5 +170,19 @@ public class AuthServiceImpl implements AuthService {
         LogConstants.AUTH,
         LogConstants.LOGOUT_ACTION,
         refreshToken.getUser().getId());
+  }
+
+  private void scheduleVerificationEmail(String email, AuthTokenPayload verificationToken) {
+    var verificationEmailMessage =
+        registerEmailHelper.buildVerifyEmailMessage(
+            email, verificationToken.accessToken(), verificationToken.expiresIn());
+
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            emailService.send(verificationEmailMessage);
+          }
+        });
   }
 }

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -22,7 +22,7 @@ spring.jpa.open-in-view=false
 # JWT login token config
 app.auth.jwt.secret=${JWT_SECRET}
 app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
-app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS:900}
+app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS:86400}
 app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
 app.auth.jwt.refresh-token-pepper=${JWT_REFRESH_TOKEN_PEPPER}
 app.auth.verify-registration-url=${VERIFY_REGISTRATION_URL}

--- a/user-service/src/main/resources/db.changelog/user-changelog/user-changelog-email-verification.xml
+++ b/user-service/src/main/resources/db.changelog/user-changelog/user-changelog-email-verification.xml
@@ -25,4 +25,22 @@
 
     </changeSet>
 
+    <changeSet id="add-users-verification-token-expires-at-column" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <columnExists tableName="users" columnName="verification_token_expires_at"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="users">
+            <column name="verification_token_expires_at" type="TIMESTAMP"/>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="users" columnName="verification_token_expires_at"/>
+        </rollback>
+
+    </changeSet>
+
 </databaseChangeLog>

--- a/user-service/src/main/resources/templates/email/verify-email.html
+++ b/user-service/src/main/resources/templates/email/verify-email.html
@@ -33,7 +33,7 @@
       <p>If you didn't create an account, you can safely ignore this email.</p>
 
       <p style="margin-top: 32px; font-size: 12px; color: #666;">
-        This link will expire in 15 minutes.
+        This link will expire in {{expiration_text}}.
       </p>
     </div>
   </body>

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -19,6 +19,7 @@ import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
+import com.tychewealth.service.helper.token.VerificationTokenRecoveryHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.monitoring.UserMetrics;
@@ -49,6 +50,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
+  VerificationTokenRecoveryHelper.class,
   AuthRefreshTokenHelper.class,
   AuthMetrics.class,
   UserMetrics.class,

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -14,6 +14,7 @@ import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
 import com.tychewealth.service.helper.email.RegisterEmailHelper;
+import com.tychewealth.service.helper.email.VerificationEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -44,6 +45,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
   RegisterEmailHelper.class,
+  VerificationEmailHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,

--- a/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
@@ -18,6 +18,7 @@ import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
 import com.tychewealth.service.helper.email.RegisterEmailHelper;
+import com.tychewealth.service.helper.email.VerificationEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -59,6 +60,7 @@ import org.springframework.data.redis.core.RedisTemplate;
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
   RegisterEmailHelper.class,
+  VerificationEmailHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,

--- a/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
@@ -23,6 +23,7 @@ import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
+import com.tychewealth.service.helper.token.VerificationTokenRecoveryHelper;
 import com.tychewealth.service.helper.user.UserHelper;
 import com.tychewealth.service.helper.user.UserValidationHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
@@ -64,6 +65,7 @@ import org.springframework.data.redis.core.RedisTemplate;
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
+  VerificationTokenRecoveryHelper.class,
   AuthRefreshTokenHelper.class,
   UserHelper.class,
   UserValidationHelper.class,

--- a/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
@@ -17,6 +17,7 @@ import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
 import com.tychewealth.service.helper.email.RegisterEmailHelper;
+import com.tychewealth.service.helper.email.VerificationEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
@@ -53,6 +54,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
   RegisterEmailHelper.class,
+  VerificationEmailHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,

--- a/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
@@ -22,6 +22,7 @@ import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
+import com.tychewealth.service.helper.token.VerificationTokenRecoveryHelper;
 import com.tychewealth.service.helper.user.UserHelper;
 import com.tychewealth.service.helper.user.UserValidationHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
@@ -58,6 +59,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
+  VerificationTokenRecoveryHelper.class,
   AuthRefreshTokenHelper.class,
   AuthMetrics.class,
   UserMetrics.class,

--- a/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -17,7 +17,6 @@ public final class TestConstants {
   public static final String TEST_FIELD_CURRENT_PASSWORD = "currentPassword";
   public static final String TEST_FIELD_NEW_PASSWORD = "newPassword";
   public static final String TEST_FIELD_CONFIRM_NEW_PASSWORD = "confirmNewPassword";
-  public static final String TEST_FIELD_USERNAME = "username";
 
   public static final String TEST_UPDATE_USERNAME_REQUEST = "AfterUpdate";
   public static final String TEST_UPDATE_USERNAME_NORMALIZED = "afterupdate";

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -57,6 +57,7 @@ import com.tychewealth.dto.auth.LoginResponseDto;
 import com.tychewealth.dto.auth.RefreshTokenResponseDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
 import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorDefinition;
@@ -276,6 +277,60 @@ class AuthApiControllerIntegrationTest {
         .andExpect(
             jsonPath("$.description")
                 .value(ErrorDefinition.AUTH_REGISTRATION_CONFLICT.getDescription()));
+  }
+
+  @Test
+  void resendVerificationEmailReturnsBadRequestWhenPreviousVerificationEmailIsStillAvailable()
+      throws Exception {
+    existingLoginUser.setVerified(false);
+    existingLoginUser.setVerificationTokenExpiresAt(Instant.now().plusSeconds(300));
+    userRepository.save(existingLoginUser);
+
+    mockMvc
+        .perform(
+            post(AUTH_BASE_URL + "/resend-verification")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new ResendVerificationEmailRequestDto(existingLoginUser.getEmail()))))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath("$.code")
+                .value(ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE.getCode()))
+        .andExpect(
+            jsonPath("$.type")
+                .value(ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE.getType()))
+        .andExpect(
+            jsonPath("$.description")
+                .value(ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE.getDescription()));
+  }
+
+  @Test
+  void resendVerificationEmailSendsNewEmailWhenPreviousVerificationTokenHasExpired()
+      throws Exception {
+    existingLoginUser.setVerified(false);
+    existingLoginUser.setVerificationTokenExpiresAt(Instant.now().minusSeconds(5));
+    UserEntity user = userRepository.save(existingLoginUser);
+
+    mockMvc
+        .perform(
+            post(AUTH_BASE_URL + "/resend-verification")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new ResendVerificationEmailRequestDto(existingLoginUser.getEmail()))))
+        .andExpect(status().isNoContent());
+
+    ArgumentCaptor<EmailMessage> emailCaptor = ArgumentCaptor.forClass(EmailMessage.class);
+    verify(emailService).send(emailCaptor.capture());
+
+    EmailMessage sentEmail = emailCaptor.getValue();
+    assertEquals(existingLoginUser.getEmail(), sentEmail.to());
+    assertTrue(sentEmail.html().contains("/auth/verify-registration"));
+
+    UserEntity updatedUser = userRepository.findById(user.getId()).orElseThrow();
+    assertNotNull(updatedUser.getVerificationTokenExpiresAt());
+    assertTrue(updatedUser.getVerificationTokenExpiresAt().isAfter(Instant.now()));
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -3,6 +3,9 @@ package com.tychewealth.controller;
 import static com.tychewealth.constants.ApiConstants.AUTH_BASE_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.CommonConstants.FIELD_EMAIL;
+import static com.tychewealth.constants.CommonConstants.FIELD_ID;
+import static com.tychewealth.constants.CommonConstants.FIELD_USERNAME;
 import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_LOGIN_FAILURE;
 import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_LOGIN_INVALID_CREDENTIALS;
 import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_LOGIN_RATE_LIMITED;
@@ -153,9 +156,9 @@ class AuthApiControllerIntegrationTest {
 
     registerRequest(mockMvc, objectMapper, validRequest)
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.id").isNumber())
-        .andExpect(jsonPath("$.email").value(validRequest.getEmail()))
-        .andExpect(jsonPath("$.username").value(validRequest.getUsername()))
+        .andExpect(jsonPath("$." + FIELD_ID).isNumber())
+        .andExpect(jsonPath("$." + FIELD_EMAIL).value(validRequest.getEmail()))
+        .andExpect(jsonPath("$." + FIELD_USERNAME).value(validRequest.getUsername()))
         .andExpect(jsonPath("$.createdAt").exists())
         .andExpect(jsonPath("$.password").doesNotExist());
 
@@ -280,7 +283,7 @@ class AuthApiControllerIntegrationTest {
   }
 
   @Test
-  void resendVerificationEmailReturnsBadRequestWhenPreviousVerificationEmailIsStillAvailable()
+  void resendVerificationEmailReturnsNoContentWhenPreviousVerificationEmailIsStillAvailable()
       throws Exception {
     existingLoginUser.setVerified(false);
     existingLoginUser.setVerificationTokenExpiresAt(Instant.now().plusSeconds(300));
@@ -293,16 +296,7 @@ class AuthApiControllerIntegrationTest {
                 .content(
                     objectMapper.writeValueAsString(
                         new ResendVerificationEmailRequestDto(existingLoginUser.getEmail()))))
-        .andExpect(status().isBadRequest())
-        .andExpect(
-            jsonPath("$.code")
-                .value(ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE.getCode()))
-        .andExpect(
-            jsonPath("$.type")
-                .value(ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE.getType()))
-        .andExpect(
-            jsonPath("$.description")
-                .value(ErrorDefinition.AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE.getDescription()));
+        .andExpect(status().isNoContent());
   }
 
   @Test
@@ -379,9 +373,9 @@ class AuthApiControllerIntegrationTest {
         .andExpect(jsonPath("$.accessToken").isString())
         .andExpect(jsonPath("$.refreshToken").isString())
         .andExpect(jsonPath("$.expiresIn").isNumber())
-        .andExpect(jsonPath("$.user.id").isNumber())
-        .andExpect(jsonPath("$.user.email").value(validRequest.getEmail()))
-        .andExpect(jsonPath("$.user.username").value(validRequest.getUsername()))
+        .andExpect(jsonPath("$.user." + FIELD_ID).isNumber())
+        .andExpect(jsonPath("$.user." + FIELD_EMAIL).value(validRequest.getEmail()))
+        .andExpect(jsonPath("$.user." + FIELD_USERNAME).value(validRequest.getUsername()))
         .andExpect(jsonPath("$.user.password").doesNotExist());
 
     assertEquals(requestsBefore + 1, counterValue(meterRegistry, METRIC_AUTH_LOGIN_REQUESTS));

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -177,7 +177,8 @@ class AuthApiControllerIntegrationTest {
     assertEquals(validRequest.getEmail(), sentEmail.to());
     assertEquals("Verify your email", sentEmail.subject());
     assertTrue(sentEmail.html().contains("/auth/verify-registration"));
-    assertTrue(sentEmail.text().contains("15 minutes"));
+    assertTrue(sentEmail.html().contains("24 hours"));
+    assertTrue(sentEmail.text().contains("24 hours"));
 
     String token = extractVerificationToken(sentEmail.html());
 

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -162,6 +163,8 @@ class AuthApiControllerIntegrationTest {
     assertNotNull(created.getId());
     assertNotEquals(validRequest.getPassword(), created.getPassword());
     assertTrue(passwordEncoder.matches(validRequest.getPassword(), created.getPassword()));
+    assertNotNull(created.getVerificationTokenExpiresAt());
+    assertTrue(created.getVerificationTokenExpiresAt().isAfter(Instant.now()));
     assertEquals(requestsBefore + 1, counterValue(meterRegistry, METRIC_AUTH_REGISTER_REQUESTS));
     assertEquals(successBefore + 1, counterValue(meterRegistry, METRIC_AUTH_REGISTER_SUCCESS));
   }
@@ -189,6 +192,7 @@ class AuthApiControllerIntegrationTest {
     UserEntity verifiedUser =
         userRepository.findByEmailIncludingDeleted(validRequest.getEmail()).orElseThrow();
     assertTrue(verifiedUser.isVerified());
+    assertNull(verifiedUser.getVerificationTokenExpiresAt());
   }
 
   @Test
@@ -204,6 +208,7 @@ class AuthApiControllerIntegrationTest {
 
     UserEntity verifiedUser = userRepository.findById(user.getId()).orElseThrow();
     assertTrue(verifiedUser.isVerified());
+    assertNull(verifiedUser.getVerificationTokenExpiresAt());
   }
 
   @Test
@@ -225,6 +230,7 @@ class AuthApiControllerIntegrationTest {
 
     UserEntity verifiedUser = userRepository.findById(user.getId()).orElseThrow();
     assertTrue(verifiedUser.isVerified());
+    assertNull(verifiedUser.getVerificationTokenExpiresAt());
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/controller/UserApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/UserApiControllerIntegrationTest.java
@@ -4,6 +4,9 @@ import static com.tychewealth.constants.ApiConstants.USER_ME_PASSWORD_URL;
 import static com.tychewealth.constants.ApiConstants.USER_ME_URL;
 import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER_PREFIX;
+import static com.tychewealth.constants.CommonConstants.FIELD_EMAIL;
+import static com.tychewealth.constants.CommonConstants.FIELD_ID;
+import static com.tychewealth.constants.CommonConstants.FIELD_USERNAME;
 import static com.tychewealth.constants.MetricConstants.METRIC_USER_CURRENT_PASSWORD_INVALID;
 import static com.tychewealth.constants.MetricConstants.METRIC_USER_DELETE_REQUESTS;
 import static com.tychewealth.constants.MetricConstants.METRIC_USER_DELETE_SUCCESS;
@@ -102,9 +105,9 @@ class UserApiControllerIntegrationTest {
 
     retrieveRequest(mockMvc, accessToken)
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(saved.getId()))
-        .andExpect(jsonPath("$.email").value(saved.getEmail()))
-        .andExpect(jsonPath("$.username").value(saved.getUsername()))
+        .andExpect(jsonPath("$." + FIELD_ID).value(saved.getId()))
+        .andExpect(jsonPath("$." + FIELD_EMAIL).value(saved.getEmail()))
+        .andExpect(jsonPath("$." + FIELD_USERNAME).value(saved.getUsername()))
         .andExpect(jsonPath("$.createdAt").exists())
         .andExpect(jsonPath("$.password").doesNotExist());
 
@@ -129,7 +132,7 @@ class UserApiControllerIntegrationTest {
     mockMvc
         .perform(get(USER_ME_URL).header(AUTHORIZATION_HEADER, "bearer " + accessToken))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(saved.getId()));
+        .andExpect(jsonPath("$." + FIELD_ID).value(saved.getId()));
   }
 
   @Test
@@ -149,9 +152,9 @@ class UserApiControllerIntegrationTest {
 
     updateRequest(mockMvc, objectMapper, accessToken, TEST_UPDATE_USERNAME_REQUEST)
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(saved.getId()))
-        .andExpect(jsonPath("$.email").value(saved.getEmail()))
-        .andExpect(jsonPath("$.username").value(TEST_UPDATE_USERNAME_NORMALIZED));
+        .andExpect(jsonPath("$." + FIELD_ID).value(saved.getId()))
+        .andExpect(jsonPath("$." + FIELD_EMAIL).value(saved.getEmail()))
+        .andExpect(jsonPath("$." + FIELD_USERNAME).value(TEST_UPDATE_USERNAME_NORMALIZED));
 
     UserEntity updatedUser = userRepository.findById(saved.getId()).orElseThrow();
     assertEquals(TEST_UPDATE_USERNAME_NORMALIZED, updatedUser.getUsername());

--- a/user-service/src/test/java/com/tychewealth/service/helper/token/AccessTokenHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/token/AccessTokenHelperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.service.token.AuthTokenPayload;
 import com.tychewealth.testdata.EntityBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,12 +14,16 @@ class AccessTokenHelperTest {
 
   private static final String TEST_JWT_SECRET =
       "0123456789012345678901234567890123456789012345678901234567890123";
+  private static final long TEST_ACCESS_TOKEN_TTL_SECONDS = 900;
+  private static final long TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS = 86400;
 
   private AccessTokenHelper accessTokenHelper;
 
   @BeforeEach
   void setUp() {
-    accessTokenHelper = new AccessTokenHelper(TEST_JWT_SECRET, 900, 900);
+    accessTokenHelper =
+        new AccessTokenHelper(
+            TEST_JWT_SECRET, TEST_ACCESS_TOKEN_TTL_SECONDS, TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS);
   }
 
   @Test
@@ -41,5 +46,15 @@ class AccessTokenHelperTest {
 
     assertThrows(
         AuthException.class, () -> accessTokenHelper.extractUserId(verifyRegistrationToken));
+  }
+
+  @Test
+  void generateVerifyEmailTokenUsesTwentyFourHourTtl() {
+    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
+    user.setId(42L);
+
+    AuthTokenPayload verifyRegistrationToken = accessTokenHelper.generateVerifyEmailToken(user);
+
+    assertEquals(TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS, verifyRegistrationToken.expiresIn());
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testhelper/UserTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/UserTestHelper.java
@@ -4,10 +4,10 @@ import static com.tychewealth.constants.ApiConstants.USER_ME_PASSWORD_URL;
 import static com.tychewealth.constants.ApiConstants.USER_ME_URL;
 import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER_PREFIX;
+import static com.tychewealth.constants.CommonConstants.FIELD_USERNAME;
 import static com.tychewealth.constants.TestConstants.TEST_FIELD_CONFIRM_NEW_PASSWORD;
 import static com.tychewealth.constants.TestConstants.TEST_FIELD_CURRENT_PASSWORD;
 import static com.tychewealth.constants.TestConstants.TEST_FIELD_NEW_PASSWORD;
-import static com.tychewealth.constants.TestConstants.TEST_FIELD_USERNAME;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -46,7 +46,7 @@ public final class UserTestHelper {
         patch(USER_ME_URL)
             .header(AUTHORIZATION_HEADER, authorizationHeader(accessToken))
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(Map.of(TEST_FIELD_USERNAME, username))));
+            .content(objectMapper.writeValueAsString(Map.of(FIELD_USERNAME, username))));
   }
 
   public static ResultActions updateRequestUnauthorized(
@@ -54,7 +54,7 @@ public final class UserTestHelper {
     return mockMvc.perform(
         patch(USER_ME_URL)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(Map.of(TEST_FIELD_USERNAME, username))));
+            .content(objectMapper.writeValueAsString(Map.of(FIELD_USERNAME, username))));
   }
 
   public static ResultActions updatePasswordRequest(
@@ -104,7 +104,7 @@ public final class UserTestHelper {
 
   public static String updateRequestBody(String username) {
     try {
-      return OBJECT_MAPPER.writeValueAsString(Map.of(TEST_FIELD_USERNAME, username));
+      return OBJECT_MAPPER.writeValueAsString(Map.of(FIELD_USERNAME, username));
     } catch (JsonProcessingException ex) {
       throw new IllegalStateException("Failed to serialize update request body", ex);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New endpoint to request resending verification emails; will only send a new email when the previous link has expired.
  * Verification tokens now default to 24-hour validity and each account stores its token expiration.
  * Verification emails (HTML and plain text) show a dynamic expiration message.

* **Chores**
  * Database migration added to persist verification token expiration timestamps.

Closes #50 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->