### PR TITLE
[tyche-25] create entity trusted devices

### DIFF
--- a/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
+++ b/user-service/src/main/java/com/tychewealth/config/EmailConfig.java
@@ -46,15 +46,25 @@ public class EmailConfig {
   public URI verifyRegistrationUri(
       @Value("${app.auth.verify-registration-url}") String verifyRegistrationUrl) {
     Assert.hasText(verifyRegistrationUrl, "app.auth.verify-registration-url must be configured");
+    return parseAbsoluteUri(verifyRegistrationUrl, "app.auth.verify-registration-url");
+  }
 
+  @Bean
+  public URI verifyLoginDeviceUri(
+      @Value("${app.auth.verify-login-device-url}") String verifyLoginDeviceUrl) {
+    Assert.hasText(verifyLoginDeviceUrl, "app.auth.verify-login-device-url must be configured");
+    return parseAbsoluteUri(verifyLoginDeviceUrl, "app.auth.verify-login-device-url");
+  }
+
+  private URI parseAbsoluteUri(String value, String propertyName) {
     try {
-      URI uri = new URI(verifyRegistrationUrl);
-      Assert.isTrue(uri.isAbsolute(), "app.auth.verify-registration-url must be an absolute URL");
-      Assert.hasText(uri.getScheme(), "app.auth.verify-registration-url must include a scheme");
-      Assert.hasText(uri.getHost(), "app.auth.verify-registration-url must include a host");
+      URI uri = new URI(value);
+      Assert.isTrue(uri.isAbsolute(), propertyName + " must be an absolute URL");
+      Assert.hasText(uri.getScheme(), propertyName + " must include a scheme");
+      Assert.hasText(uri.getHost(), propertyName + " must include a host");
       return uri;
     } catch (URISyntaxException ex) {
-      throw new IllegalStateException("app.auth.verify-registration-url must be a valid URL", ex);
+      throw new IllegalStateException(propertyName + " must be a valid URL", ex);
     }
   }
 }

--- a/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/AuthConstants.java
@@ -14,6 +14,7 @@ public final class AuthConstants {
   public static final String TOKEN_TYPE_BEARER_PREFIX = TOKEN_TYPE_BEARER + " ";
   public static final String TOKEN_PURPOSE_CLAIM = "purpose";
   public static final String VERIFY_REGISTRATION_TOKEN_PURPOSE = "verify-registration";
+  public static final String VERIFY_LOGIN_DEVICE_TOKEN_PURPOSE = "verify-login-device";
   public static final int REFRESH_TOKEN_BYTE_LENGTH = 32;
   public static final int TOKEN_LINK_MAX_ATTEMPTS = 2;
 

--- a/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -11,6 +11,7 @@ public final class LogConstants {
   public static final String REGISTER_ACTION = "[register]";
   public static final String LOGIN_ACTION = "[login]";
   public static final String VERIFY_REGISTRATION_ACTION = "[verify-registration]";
+  public static final String VERIFY_LOGIN_DEVICE_ACTION = "[verify-login-device]";
   public static final String REFRESH_TOKEN_ACTION = "[refresh-token]";
   public static final String RATE_LIMIT_ACTION = "[rate-limit]";
   public static final String LOGOUT_ACTION = "[logout]";

--- a/user-service/src/main/java/com/tychewealth/constants/RedisConstants.java
+++ b/user-service/src/main/java/com/tychewealth/constants/RedisConstants.java
@@ -6,6 +6,8 @@ public final class RedisConstants {
 
   public static final String EMAIL_DAILY_LIMIT_NAMESPACE = "rate-limit:email:daily";
   public static final String EMAIL_DAILY_LIMIT_CLIENT_KEY = "global";
+  public static final String AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE =
+      "cooldown:auth:login-device-email";
 
   public static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT =
       new DefaultRedisScript<>(

--- a/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
+++ b/user-service/src/main/java/com/tychewealth/controller/AuthApi.java
@@ -28,6 +28,9 @@ public interface AuthApi {
   @GetMapping(value = "/verify-registration", produces = REQUEST_PRODUCES)
   ResponseEntity<Void> verifyRegistration(@RequestParam("token") String token);
 
+  @GetMapping(value = "/verify-login-device", produces = REQUEST_PRODUCES)
+  ResponseEntity<Void> verifyLoginDevice(@RequestParam("token") String token);
+
   @PostMapping(value = "/register", consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
   ResponseEntity<UserResponseDto> register(@Valid @RequestBody RegisterRequestDto register);
 

--- a/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
+++ b/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
@@ -9,6 +9,7 @@ import static com.tychewealth.constants.LogConstants.REFRESH_TOKEN_ACTION;
 import static com.tychewealth.constants.LogConstants.REGISTER_ACTION;
 import static com.tychewealth.constants.LogConstants.REGISTER_REQUEST_FIELDS;
 import static com.tychewealth.constants.LogConstants.REQUEST_START;
+import static com.tychewealth.constants.LogConstants.VERIFY_LOGIN_DEVICE_ACTION;
 import static com.tychewealth.constants.LogConstants.VERIFY_REGISTRATION_ACTION;
 import static com.tychewealth.constants.SecurityConstants.CACHE_CONTROL_NO_STORE_HEADER_VALUE;
 import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER_VALUE;
@@ -58,7 +59,7 @@ public class AuthApiController implements AuthApi {
 
   @Override
   public ResponseEntity<Void> verifyLoginDevice(@RequestParam("token") String token) {
-    log.info(REQUEST_START, AUTH, LOGIN_ACTION);
+    log.info(REQUEST_START, AUTH, VERIFY_LOGIN_DEVICE_ACTION);
 
     var trustedDeviceCookie = authService.verifyLoginDevice(token);
     return ResponseEntity.noContent()

--- a/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
+++ b/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
@@ -15,6 +15,7 @@ import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER
 import static com.tychewealth.utils.LogContextFactory.mask;
 import static org.springframework.http.HttpHeaders.CACHE_CONTROL;
 import static org.springframework.http.HttpHeaders.PRAGMA;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.http.ResponseEntity.status;
 
 import com.tychewealth.controller.AuthApi;
@@ -47,10 +48,11 @@ public class AuthApiController implements AuthApi {
   public ResponseEntity<Void> verifyRegistration(@RequestParam("token") String token) {
     log.info(REQUEST_START, AUTH, VERIFY_REGISTRATION_ACTION);
 
-    authService.verifyEmail(token);
+    var trustedDeviceCookie = authService.verifyEmail(token);
     return ResponseEntity.noContent()
         .header(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
         .header(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE)
+        .header(SET_COOKIE, trustedDeviceCookie.toString())
         .build();
   }
 

--- a/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
+++ b/user-service/src/main/java/com/tychewealth/controller/impl/AuthApiController.java
@@ -57,6 +57,18 @@ public class AuthApiController implements AuthApi {
   }
 
   @Override
+  public ResponseEntity<Void> verifyLoginDevice(@RequestParam("token") String token) {
+    log.info(REQUEST_START, AUTH, LOGIN_ACTION);
+
+    var trustedDeviceCookie = authService.verifyLoginDevice(token);
+    return ResponseEntity.noContent()
+        .header(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE)
+        .header(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE)
+        .header(SET_COOKIE, trustedDeviceCookie.toString())
+        .build();
+  }
+
+  @Override
   public ResponseEntity<UserResponseDto> register(@Valid @RequestBody RegisterRequestDto register) {
     log.info(
         REQUEST_START + REGISTER_REQUEST_FIELDS,

--- a/user-service/src/main/java/com/tychewealth/entity/TrustedDeviceEntity.java
+++ b/user-service/src/main/java/com/tychewealth/entity/TrustedDeviceEntity.java
@@ -1,0 +1,53 @@
+package com.tychewealth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "trusted_devices")
+public class TrustedDeviceEntity {
+
+  @Id
+  @SequenceGenerator(
+      name = "trusted_device_seq_gen",
+      sequenceName = "trusted_device_seq",
+      allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "trusted_device_seq_gen")
+  private Long id;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private UserEntity user;
+
+  @Column(name = "token_hash", nullable = false, unique = true, length = 128)
+  private String tokenHash;
+
+  @Column(name = "expires_at", nullable = false)
+  private Instant expiresAt;
+
+  @Column(name = "last_used_at")
+  private Instant lastUsedAt;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @PrePersist
+  void onCreate() {
+    createdAt = Instant.now();
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
+++ b/user-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
@@ -36,6 +36,12 @@ public enum ErrorDefinition {
       "TYCHE-105",
       "AUTH_VERIFICATION_EMAIL_STILL_AVAILABLE",
       "The previous verification email is still available"),
+  AUTH_TRUSTED_DEVICE_LIMIT_REACHED(
+      "TYCHE-106", "AUTH_TRUSTED_DEVICE_LIMIT_REACHED", "Trusted device limit reached"),
+  AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED(
+      "TYCHE-107",
+      "AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED",
+      "Login verification required for this device"),
 
   // USER
   USER_NOT_FOUND("TYCHE-200", "USER_NOT_FOUND", "The requested user was not found"),

--- a/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
@@ -13,5 +13,7 @@ public interface TrustedDeviceRepository extends JpaRepository<TrustedDeviceEnti
 
   Optional<TrustedDeviceEntity> findByTokenHash(String tokenHash);
 
+  Optional<TrustedDeviceEntity> findByUserIdAndTokenHash(Long userId, String tokenHash);
+
   List<TrustedDeviceEntity> findByUserIdOrderByCreatedAtAsc(Long userId);
 }

--- a/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
@@ -1,0 +1,17 @@
+package com.tychewealth.repository;
+
+import com.tychewealth.entity.TrustedDeviceEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TrustedDeviceRepository extends JpaRepository<TrustedDeviceEntity, Long> {
+
+  long countByUserId(Long userId);
+
+  Optional<TrustedDeviceEntity> findByTokenHash(String tokenHash);
+
+  List<TrustedDeviceEntity> findByUserIdOrderByCreatedAtAsc(Long userId);
+}

--- a/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
@@ -13,5 +13,6 @@ public interface TrustedDeviceRepository extends JpaRepository<TrustedDeviceEnti
 
   void deleteByUserIdAndExpiresAtBefore(Long userId, Instant expiresAt);
 
-  Optional<TrustedDeviceEntity> findByUserIdAndTokenHash(Long userId, String tokenHash);
+  Optional<TrustedDeviceEntity> findByUserIdAndTokenHashAndExpiresAtAfter(
+      Long userId, String tokenHash, Instant expiresAt);
 }

--- a/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/TrustedDeviceRepository.java
@@ -1,7 +1,7 @@
 package com.tychewealth.repository;
 
 import com.tychewealth.entity.TrustedDeviceEntity;
-import java.util.List;
+import java.time.Instant;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,11 +9,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TrustedDeviceRepository extends JpaRepository<TrustedDeviceEntity, Long> {
 
-  long countByUserId(Long userId);
+  long countByUserIdAndExpiresAtAfter(Long userId, Instant expiresAt);
 
-  Optional<TrustedDeviceEntity> findByTokenHash(String tokenHash);
+  void deleteByUserIdAndExpiresAtBefore(Long userId, Instant expiresAt);
 
   Optional<TrustedDeviceEntity> findByUserIdAndTokenHash(Long userId, String tokenHash);
-
-  List<TrustedDeviceEntity> findByUserIdOrderByCreatedAtAsc(Long userId);
 }

--- a/user-service/src/main/java/com/tychewealth/repository/UserRepository.java
+++ b/user-service/src/main/java/com/tychewealth/repository/UserRepository.java
@@ -20,6 +20,10 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
   Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT u FROM UserEntity u WHERE u.id = :id")
+  Optional<UserEntity> findByIdForUpdate(@Param("id") Long id);
+
   Optional<UserEntity> findByEmailAndDeletedAtIsNull(String email);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/user-service/src/main/java/com/tychewealth/service/AuthService.java
+++ b/user-service/src/main/java/com/tychewealth/service/AuthService.java
@@ -7,10 +7,11 @@ import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
 import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
 import com.tychewealth.dto.user.UserResponseDto;
+import org.springframework.http.ResponseCookie;
 
 public interface AuthService {
 
-  void verifyEmail(String token);
+  ResponseCookie verifyEmail(String token);
 
   UserResponseDto register(RegisterRequestDto register);
 

--- a/user-service/src/main/java/com/tychewealth/service/AuthService.java
+++ b/user-service/src/main/java/com/tychewealth/service/AuthService.java
@@ -13,6 +13,8 @@ public interface AuthService {
 
   ResponseCookie verifyEmail(String token);
 
+  ResponseCookie verifyLoginDevice(String token);
+
   UserResponseDto register(RegisterRequestDto register);
 
   void resendVerificationEmail(ResendVerificationEmailRequestDto resendVerificationEmailRequestDto);

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
@@ -85,6 +85,7 @@ public class AuthLoginHelper {
   }
 
   private void sendLoginVerificationEmailIfAllowed(UserEntity user) {
+    String userId = String.valueOf(user.getId());
     if (!canSendLoginVerificationEmail(user)) {
       log.info(
           LogConstants.REQUEST_CONFLICT + LogConstants.USER_ID,
@@ -100,7 +101,12 @@ public class AuthLoginHelper {
         loginDeviceEmailHelper.buildVerifyLoginDeviceEmailMessage(
             user.getEmail(), verificationToken.accessToken(), verificationToken.expiresIn());
 
-    emailService.send(loginDeviceEmailMessage);
+    try {
+      emailService.send(loginDeviceEmailMessage);
+    } catch (RuntimeException ex) {
+      rollbackLoginVerificationEmailCooldown(userId, user.getId(), ex);
+      throw ex;
+    }
     log.info(
         LogConstants.REQUEST_START + LogConstants.USER_ID,
         LogConstants.AUTH,
@@ -126,5 +132,30 @@ public class AuthLoginHelper {
           ex);
       return true;
     }
+  }
+
+  private void rollbackLoginVerificationEmailCooldown(
+      String userId, Long logUserId, RuntimeException emailSendException) {
+    try {
+      rateLimitStore.clear(RedisConstants.AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE, userId);
+    } catch (RuntimeException rollbackException) {
+      rollbackException.addSuppressed(emailSendException);
+      log.warn(
+          LogConstants.REQUEST_CONFLICT + LogConstants.USER_ID,
+          LogConstants.AUTH,
+          LogConstants.LOGIN_ACTION,
+          "failed to roll back login verification email cooldown after send failure",
+          logUserId,
+          rollbackException);
+      return;
+    }
+
+    log.warn(
+        LogConstants.REQUEST_CONFLICT + LogConstants.USER_ID,
+        LogConstants.AUTH,
+        LogConstants.LOGIN_ACTION,
+        "rolled back login verification email cooldown after send failure",
+        logUserId,
+        emailSendException);
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
@@ -1,6 +1,7 @@
 package com.tychewealth.service.helper.auth;
 
 import com.tychewealth.constants.LogConstants;
+import com.tychewealth.constants.RedisConstants;
 import com.tychewealth.dto.auth.LoginResponseDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.entity.UserEntity;
@@ -13,7 +14,9 @@ import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.trusteddevice.TrustedDeviceHelper;
 import com.tychewealth.service.monitoring.AuthMetrics;
+import com.tychewealth.service.ratelimit.RateLimitStore;
 import com.tychewealth.service.token.AuthTokenPayload;
+import java.time.Duration;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,11 +27,14 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class AuthLoginHelper {
 
+  private static final Duration LOGIN_DEVICE_EMAIL_COOLDOWN = Duration.ofDays(1);
+
   private final AccessTokenHelper accessTokenHelper;
   private final AuthRefreshTokenHelper refreshTokenHelper;
   private final TrustedDeviceHelper trustedDeviceHelper;
   private final LoginDeviceEmailHelper loginDeviceEmailHelper;
   private final EmailService emailService;
+  private final RateLimitStore rateLimitStore;
   private final UserMapper userMapper;
   private final AuthMetrics authMetrics;
 
@@ -73,12 +79,22 @@ public class AuthLoginHelper {
           ErrorDefinition.AUTH_TRUSTED_DEVICE_LIMIT_REACHED, null, HttpStatus.CONFLICT);
     }
 
-    sendLoginVerificationEmail(user);
+    sendLoginVerificationEmailIfAllowed(user);
     throw AuthException.of(
         ErrorDefinition.AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED, null, HttpStatus.FORBIDDEN);
   }
 
-  private void sendLoginVerificationEmail(UserEntity user) {
+  private void sendLoginVerificationEmailIfAllowed(UserEntity user) {
+    if (!canSendLoginVerificationEmail(user)) {
+      log.info(
+          LogConstants.REQUEST_CONFLICT + LogConstants.USER_ID,
+          LogConstants.AUTH,
+          LogConstants.LOGIN_ACTION,
+          "login verification email cooldown active",
+          user.getId());
+      return;
+    }
+
     AuthTokenPayload verificationToken = accessTokenHelper.generateVerifyLoginDeviceToken(user);
     var loginDeviceEmailMessage =
         loginDeviceEmailHelper.buildVerifyLoginDeviceEmailMessage(
@@ -90,5 +106,25 @@ public class AuthLoginHelper {
         LogConstants.AUTH,
         LogConstants.LOGIN_ACTION,
         user.getId());
+  }
+
+  private boolean canSendLoginVerificationEmail(UserEntity user) {
+    try {
+      long attempts =
+          rateLimitStore.increment(
+              RedisConstants.AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE,
+              String.valueOf(user.getId()),
+              LOGIN_DEVICE_EMAIL_COOLDOWN);
+      return attempts == 1;
+    } catch (RuntimeException ex) {
+      log.warn(
+          LogConstants.REQUEST_CONFLICT + LogConstants.USER_ID,
+          LogConstants.AUTH,
+          LogConstants.LOGIN_ACTION,
+          LogConstants.RATE_LIMIT_STORE_UNAVAILABLE_MESSAGE,
+          user.getId(),
+          ex);
+      return true;
+    }
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
@@ -108,7 +108,7 @@ public class AuthLoginHelper {
       throw ex;
     }
     log.info(
-        LogConstants.REQUEST_START + LogConstants.USER_ID,
+        LogConstants.REQUEST_SUCCESS + LogConstants.USER_ID,
         LogConstants.AUTH,
         LogConstants.LOGIN_ACTION,
         user.getId());

--- a/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/auth/AuthLoginHelper.java
@@ -4,13 +4,19 @@ import com.tychewealth.constants.LogConstants;
 import com.tychewealth.dto.auth.LoginResponseDto;
 import com.tychewealth.dto.user.UserResponseDto;
 import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.mapper.user.UserMapper;
+import com.tychewealth.service.EmailService;
+import com.tychewealth.service.helper.email.LoginDeviceEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
+import com.tychewealth.service.helper.trusteddevice.TrustedDeviceHelper;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -20,10 +26,16 @@ public class AuthLoginHelper {
 
   private final AccessTokenHelper accessTokenHelper;
   private final AuthRefreshTokenHelper refreshTokenHelper;
+  private final TrustedDeviceHelper trustedDeviceHelper;
+  private final LoginDeviceEmailHelper loginDeviceEmailHelper;
+  private final EmailService emailService;
   private final UserMapper userMapper;
   private final AuthMetrics authMetrics;
 
   public LoginResponseDto login(UserEntity user) {
+
+    handleUntrustedDeviceLogin(user);
+
     UserResponseDto response = userMapper.toDto(user);
     AuthTokenPayload tokenPayload = accessTokenHelper.generateAccessToken(user);
     refreshTokenHelper.revokeActiveTokensByUserId(user.getId());
@@ -43,5 +55,40 @@ public class AuthLoginHelper {
         refreshToken.token(),
         tokenPayload.expiresIn(),
         response);
+  }
+
+  private void handleUntrustedDeviceLogin(UserEntity user) {
+    if (trustedDeviceHelper.isTrustedCurrentDevice(user)) {
+      return;
+    }
+
+    if (trustedDeviceHelper.hasReachedTrustedDeviceLimit(user.getId())) {
+      log.warn(
+          LogConstants.REQUEST_CONFLICT + LogConstants.USER_ID,
+          LogConstants.AUTH,
+          LogConstants.LOGIN_ACTION,
+          "trusted device limit reached for unrecognized device",
+          user.getId());
+      throw AuthException.of(
+          ErrorDefinition.AUTH_TRUSTED_DEVICE_LIMIT_REACHED, null, HttpStatus.CONFLICT);
+    }
+
+    sendLoginVerificationEmail(user);
+    throw AuthException.of(
+        ErrorDefinition.AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED, null, HttpStatus.FORBIDDEN);
+  }
+
+  private void sendLoginVerificationEmail(UserEntity user) {
+    AuthTokenPayload verificationToken = accessTokenHelper.generateVerifyLoginDeviceToken(user);
+    var loginDeviceEmailMessage =
+        loginDeviceEmailHelper.buildVerifyLoginDeviceEmailMessage(
+            user.getEmail(), verificationToken.accessToken(), verificationToken.expiresIn());
+
+    emailService.send(loginDeviceEmailMessage);
+    log.info(
+        LogConstants.REQUEST_START + LogConstants.USER_ID,
+        LogConstants.AUTH,
+        LogConstants.LOGIN_ACTION,
+        user.getId());
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/LoginDeviceEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/LoginDeviceEmailHelper.java
@@ -1,0 +1,69 @@
+package com.tychewealth.service.helper.email;
+
+import com.tychewealth.service.email.EmailMessage;
+import com.tychewealth.utils.Utils;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class LoginDeviceEmailHelper {
+
+  private static final String VERIFY_LOGIN_SUBJECT = "Confirm your login";
+  private static final String VERIFY_LOGIN_LINK_PLACEHOLDER = "{{verification_link}}";
+  private static final String VERIFY_LOGIN_EXPIRATION_PLACEHOLDER = "{{expiration_text}}";
+
+  private final String verifyLoginDeviceUrl;
+  private final String cachedLoginDeviceTemplate;
+
+  public LoginDeviceEmailHelper(
+      URI verifyLoginDeviceUri,
+      @Value("classpath:templates/email/verify-login-device.html")
+          Resource verifyLoginDeviceTemplate) {
+    this.verifyLoginDeviceUrl = verifyLoginDeviceUri.toString();
+    try {
+      this.cachedLoginDeviceTemplate =
+          StreamUtils.copyToString(
+              verifyLoginDeviceTemplate.getInputStream(), StandardCharsets.UTF_8);
+    } catch (IOException ex) {
+      throw new IllegalStateException("Unable to load login device email template", ex);
+    }
+  }
+
+  public EmailMessage buildVerifyLoginDeviceEmailMessage(
+      String email, String verificationToken, long expiresInSeconds) {
+    String verificationLink = buildVerificationLink(verificationToken);
+    String expirationText = Utils.formatExpirationText(expiresInSeconds);
+    return new EmailMessage(
+        email,
+        VERIFY_LOGIN_SUBJECT,
+        renderHtml(verificationLink, expirationText),
+        buildText(verificationLink, expirationText));
+  }
+
+  private String buildVerificationLink(String token) {
+    return UriComponentsBuilder.fromUriString(verifyLoginDeviceUrl)
+        .queryParam("token", token)
+        .build(true)
+        .toUriString();
+  }
+
+  private String renderHtml(String verificationLink, String expirationText) {
+    return cachedLoginDeviceTemplate
+        .replace(VERIFY_LOGIN_LINK_PLACEHOLDER, verificationLink)
+        .replace(VERIFY_LOGIN_EXPIRATION_PLACEHOLDER, expirationText);
+  }
+
+  private String buildText(String verificationLink, String expirationText) {
+    return "We detected a login attempt to your Tyche Wealth account. Confirm it by visiting "
+        + verificationLink
+        + ". This link will expire in "
+        + expirationText
+        + ". If this wasn't you, change your password.";
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/email/RegisterEmailHelper.java
@@ -1,5 +1,7 @@
 package com.tychewealth.service.helper.email;
 
+import static com.tychewealth.utils.Utils.formatExpirationText;
+
 import com.tychewealth.service.email.EmailMessage;
 import java.io.IOException;
 import java.net.URI;
@@ -62,15 +64,5 @@ public class RegisterEmailHelper {
         + ". This link will expire in "
         + expirationText
         + ".";
-  }
-
-  private String formatExpirationText(long expiresInSeconds) {
-    if (expiresInSeconds % 3600 == 0) {
-      long hours = expiresInSeconds / 3600;
-      return hours + (hours == 1 ? " hour" : " hours");
-    }
-
-    long expiresInMinutes = (expiresInSeconds + 59) / 60;
-    return expiresInMinutes + (expiresInMinutes == 1 ? " minute" : " minutes");
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -72,11 +72,19 @@ public class AccessTokenHelper {
   }
 
   public Long extractVerifyEmailUserId(String token) {
+    return extractUserIdForPurpose(token, VERIFY_REGISTRATION_TOKEN_PURPOSE);
+  }
+
+  public Long extractVerifyLoginDeviceUserId(String token) {
+    return extractUserIdForPurpose(token, VERIFY_LOGIN_DEVICE_TOKEN_PURPOSE);
+  }
+
+  private Long extractUserIdForPurpose(String token, String expectedPurpose) {
     try {
       Claims claims = parseClaims(token);
       String purpose = claims.get(TOKEN_PURPOSE_CLAIM, String.class);
-      if (!VERIFY_REGISTRATION_TOKEN_PURPOSE.equals(purpose)) {
-        throw new IllegalArgumentException("Token is not intended for email verification");
+      if (!expectedPurpose.equals(purpose)) {
+        throw new IllegalArgumentException("Token is not intended for this verification flow");
       }
       return Long.valueOf(claims.getSubject());
     } catch (JwtException | IllegalArgumentException ex) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -38,12 +38,15 @@ public class AccessTokenHelper {
   private final SecretKey signingKey;
   private final long accessTokenTtlSeconds;
   private final long verifyEmailTokenTtlSeconds;
+  private final long verifyLoginDeviceTokenTtlSeconds;
 
   public AccessTokenHelper(
       @Value("${app.auth.jwt.secret}") String jwtSecret,
       @Value("${app.auth.jwt.access-token-ttl-seconds:900}") long accessTokenTtlSeconds,
       @Value("${app.auth.jwt.verify-email-token-ttl-seconds:86400}")
-          long verifyEmailTokenTtlSeconds) {
+          long verifyEmailTokenTtlSeconds,
+      @Value("${app.auth.jwt.verify-login-device-token-ttl-seconds:86400}")
+          long verifyLoginDeviceTokenTtlSeconds) {
 
     if (accessTokenTtlSeconds <= 0) {
       throw new IllegalArgumentException(
@@ -53,10 +56,15 @@ public class AccessTokenHelper {
       throw new IllegalArgumentException(
           "app.auth.jwt.verify-email-token-ttl-seconds must be greater than 0");
     }
+    if (verifyLoginDeviceTokenTtlSeconds <= 0) {
+      throw new IllegalArgumentException(
+          "app.auth.jwt.verify-login-device-token-ttl-seconds must be greater than 0");
+    }
 
     this.signingKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
     this.accessTokenTtlSeconds = accessTokenTtlSeconds;
     this.verifyEmailTokenTtlSeconds = verifyEmailTokenTtlSeconds;
+    this.verifyLoginDeviceTokenTtlSeconds = verifyLoginDeviceTokenTtlSeconds;
   }
 
   public AuthTokenPayload generateAccessToken(UserEntity user) {
@@ -68,7 +76,7 @@ public class AccessTokenHelper {
   }
 
   public AuthTokenPayload generateVerifyLoginDeviceToken(UserEntity user) {
-    return generateToken(user, verifyEmailTokenTtlSeconds, VERIFY_LOGIN_DEVICE_TOKEN_PURPOSE);
+    return generateToken(user, verifyLoginDeviceTokenTtlSeconds, VERIFY_LOGIN_DEVICE_TOKEN_PURPOSE);
   }
 
   public Long extractVerifyEmailUserId(String token) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/token/AccessTokenHelper.java
@@ -2,6 +2,7 @@ package com.tychewealth.service.helper.token;
 
 import static com.tychewealth.constants.AuthConstants.TOKEN_PURPOSE_CLAIM;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.AuthConstants.VERIFY_LOGIN_DEVICE_TOKEN_PURPOSE;
 import static com.tychewealth.constants.AuthConstants.VERIFY_REGISTRATION_TOKEN_PURPOSE;
 import static com.tychewealth.constants.CommonConstants.FIELD_EMAIL;
 import static com.tychewealth.constants.CommonConstants.FIELD_USERNAME;
@@ -64,6 +65,10 @@ public class AccessTokenHelper {
 
   public AuthTokenPayload generateVerifyEmailToken(UserEntity user) {
     return generateToken(user, verifyEmailTokenTtlSeconds, VERIFY_REGISTRATION_TOKEN_PURPOSE);
+  }
+
+  public AuthTokenPayload generateVerifyLoginDeviceToken(UserEntity user) {
+    return generateToken(user, verifyEmailTokenTtlSeconds, VERIFY_LOGIN_DEVICE_TOKEN_PURPOSE);
   }
 
   public Long extractVerifyEmailUserId(String token) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
@@ -6,13 +6,18 @@ import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.utils.Utils;
+import jakarta.servlet.http.Cookie;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Component
 @AllArgsConstructor
@@ -52,5 +57,36 @@ public class TrustedDeviceHelper {
     if (trustedDeviceRepository.countByUserId(userId) >= MAX_TRUSTED_DEVICES_PER_USER) {
       throw new AuthException(ErrorDefinition.CONFLICT, null, HttpStatus.CONFLICT);
     }
+  }
+
+  public boolean hasReachedTrustedDeviceLimit(Long userId) {
+    return trustedDeviceRepository.countByUserId(userId) >= MAX_TRUSTED_DEVICES_PER_USER;
+  }
+
+  public boolean isTrustedCurrentDevice(UserEntity user) {
+    return extractTrustedDeviceToken()
+        .map(Utils::sha256Hex)
+        .flatMap(
+            tokenHash -> trustedDeviceRepository.findByUserIdAndTokenHash(user.getId(), tokenHash))
+        .isPresent();
+  }
+
+  private Optional<String> extractTrustedDeviceToken() {
+    ServletRequestAttributes requestAttributes =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    if (requestAttributes == null) {
+      return Optional.empty();
+    }
+
+    Cookie[] cookies = requestAttributes.getRequest().getCookies();
+    if (cookies == null) {
+      return Optional.empty();
+    }
+
+    return Arrays.stream(cookies)
+        .filter(cookie -> TRUSTED_DEVICE_COOKIE_NAME.equals(cookie.getName()))
+        .map(Cookie::getValue)
+        .filter(value -> value != null && !value.isBlank())
+        .findFirst();
   }
 }

--- a/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
@@ -1,9 +1,14 @@
 package com.tychewealth.service.helper.trusteddevice;
 
+import com.tychewealth.entity.TrustedDeviceEntity;
+import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.TrustedDeviceRepository;
+import com.tychewealth.utils.Utils;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -15,8 +20,23 @@ public class TrustedDeviceHelper {
 
   private static final String TRUSTED_DEVICE_COOKIE_NAME = "trusted_device";
   private static final int MAX_TRUSTED_DEVICES_PER_USER = 3;
+  private static final Duration TRUSTED_DEVICE_MAX_AGE = Duration.ofSeconds(Integer.MAX_VALUE);
 
   private final TrustedDeviceRepository trustedDeviceRepository;
+
+  public ResponseCookie createTrustedDeviceCookie(UserEntity user) {
+    validateTrustedDeviceLimit(user.getId());
+
+    String trustedDeviceToken = UUID.randomUUID().toString();
+    TrustedDeviceEntity trustedDevice = new TrustedDeviceEntity();
+    trustedDevice.setUser(user);
+    trustedDevice.setTokenHash(Utils.sha256Hex(trustedDeviceToken));
+    trustedDevice.setExpiresAt(Instant.now().plus(TRUSTED_DEVICE_MAX_AGE));
+    trustedDevice.setLastUsedAt(Instant.now());
+    trustedDeviceRepository.save(trustedDevice);
+
+    return buildTrustedDeviceCookie(trustedDeviceToken, TRUSTED_DEVICE_MAX_AGE);
+  }
 
   public ResponseCookie buildTrustedDeviceCookie(String trustedDeviceToken, Duration maxAge) {
     return ResponseCookie.from(TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceToken)

--- a/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
@@ -84,7 +84,8 @@ public class TrustedDeviceHelper {
 
     if (trustedDeviceRepository.countByUserIdAndExpiresAtAfter(userId, now)
         >= MAX_TRUSTED_DEVICES_PER_USER) {
-      throw new AuthException(ErrorDefinition.CONFLICT, null, HttpStatus.CONFLICT);
+      throw new AuthException(
+          ErrorDefinition.AUTH_TRUSTED_DEVICE_LIMIT_REACHED, null, HttpStatus.CONFLICT);
     }
   }
 

--- a/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
@@ -5,6 +5,7 @@ import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.TrustedDeviceRepository;
+import com.tychewealth.repository.UserRepository;
 import com.tychewealth.utils.Utils;
 import jakarta.servlet.http.Cookie;
 import java.time.Duration;
@@ -16,6 +17,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -29,15 +31,17 @@ public class TrustedDeviceHelper {
   private static final Duration TRUSTED_DEVICE_MAX_AGE = Duration.ofSeconds(Integer.MAX_VALUE);
 
   private final TrustedDeviceRepository trustedDeviceRepository;
+  private final UserRepository userRepository;
 
+  @Transactional
   public ResponseCookie createTrustedDeviceCookie(UserEntity user) {
     Instant now = Instant.now();
     String trustedDeviceToken = extractTrustedDeviceToken().orElse(null);
 
     if (StringUtils.hasText(trustedDeviceToken)) {
       Optional<TrustedDeviceEntity> existingTrustedDevice =
-          trustedDeviceRepository.findByUserIdAndTokenHash(
-              user.getId(), Utils.sha256Hex(trustedDeviceToken));
+          trustedDeviceRepository.findByUserIdAndTokenHashAndExpiresAtAfter(
+              user.getId(), Utils.sha256Hex(trustedDeviceToken), now);
 
       if (existingTrustedDevice.isPresent()) {
         TrustedDeviceEntity trustedDevice = existingTrustedDevice.get();
@@ -48,6 +52,10 @@ public class TrustedDeviceHelper {
       }
     }
 
+    userRepository
+        .findByIdForUpdate(user.getId())
+        .orElseThrow(
+            () -> new AuthException(ErrorDefinition.UNAUTHORIZED, null, HttpStatus.UNAUTHORIZED));
     validateTrustedDeviceLimit(user.getId(), now);
 
     trustedDeviceToken = UUID.randomUUID().toString();
@@ -88,10 +96,13 @@ public class TrustedDeviceHelper {
   }
 
   public boolean isTrustedCurrentDevice(UserEntity user) {
+    Instant now = Instant.now();
     return extractTrustedDeviceToken()
         .map(Utils::sha256Hex)
         .flatMap(
-            tokenHash -> trustedDeviceRepository.findByUserIdAndTokenHash(user.getId(), tokenHash))
+            tokenHash ->
+                trustedDeviceRepository.findByUserIdAndTokenHashAndExpiresAtAfter(
+                    user.getId(), tokenHash, now))
         .isPresent();
   }
 

--- a/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -30,14 +31,31 @@ public class TrustedDeviceHelper {
   private final TrustedDeviceRepository trustedDeviceRepository;
 
   public ResponseCookie createTrustedDeviceCookie(UserEntity user) {
-    validateTrustedDeviceLimit(user.getId());
+    Instant now = Instant.now();
+    String trustedDeviceToken = extractTrustedDeviceToken().orElse(null);
 
-    String trustedDeviceToken = UUID.randomUUID().toString();
+    if (StringUtils.hasText(trustedDeviceToken)) {
+      Optional<TrustedDeviceEntity> existingTrustedDevice =
+          trustedDeviceRepository.findByUserIdAndTokenHash(
+              user.getId(), Utils.sha256Hex(trustedDeviceToken));
+
+      if (existingTrustedDevice.isPresent()) {
+        TrustedDeviceEntity trustedDevice = existingTrustedDevice.get();
+        trustedDevice.setExpiresAt(now.plus(TRUSTED_DEVICE_MAX_AGE));
+        trustedDevice.setLastUsedAt(now);
+        trustedDeviceRepository.save(trustedDevice);
+        return buildTrustedDeviceCookie(trustedDeviceToken, TRUSTED_DEVICE_MAX_AGE);
+      }
+    }
+
+    validateTrustedDeviceLimit(user.getId(), now);
+
+    trustedDeviceToken = UUID.randomUUID().toString();
     TrustedDeviceEntity trustedDevice = new TrustedDeviceEntity();
     trustedDevice.setUser(user);
     trustedDevice.setTokenHash(Utils.sha256Hex(trustedDeviceToken));
-    trustedDevice.setExpiresAt(Instant.now().plus(TRUSTED_DEVICE_MAX_AGE));
-    trustedDevice.setLastUsedAt(Instant.now());
+    trustedDevice.setExpiresAt(now.plus(TRUSTED_DEVICE_MAX_AGE));
+    trustedDevice.setLastUsedAt(now);
     trustedDeviceRepository.save(trustedDevice);
 
     return buildTrustedDeviceCookie(trustedDeviceToken, TRUSTED_DEVICE_MAX_AGE);
@@ -53,14 +71,20 @@ public class TrustedDeviceHelper {
         .build();
   }
 
-  public void validateTrustedDeviceLimit(Long userId) {
-    if (trustedDeviceRepository.countByUserId(userId) >= MAX_TRUSTED_DEVICES_PER_USER) {
+  public void validateTrustedDeviceLimit(Long userId, Instant now) {
+    trustedDeviceRepository.deleteByUserIdAndExpiresAtBefore(userId, now);
+
+    if (trustedDeviceRepository.countByUserIdAndExpiresAtAfter(userId, now)
+        >= MAX_TRUSTED_DEVICES_PER_USER) {
       throw new AuthException(ErrorDefinition.CONFLICT, null, HttpStatus.CONFLICT);
     }
   }
 
   public boolean hasReachedTrustedDeviceLimit(Long userId) {
-    return trustedDeviceRepository.countByUserId(userId) >= MAX_TRUSTED_DEVICES_PER_USER;
+    Instant now = Instant.now();
+    trustedDeviceRepository.deleteByUserIdAndExpiresAtBefore(userId, now);
+    return trustedDeviceRepository.countByUserIdAndExpiresAtAfter(userId, now)
+        >= MAX_TRUSTED_DEVICES_PER_USER;
   }
 
   public boolean isTrustedCurrentDevice(UserEntity user) {

--- a/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
+++ b/user-service/src/main/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelper.java
@@ -1,0 +1,36 @@
+package com.tychewealth.service.helper.trusteddevice;
+
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.repository.TrustedDeviceRepository;
+import java.time.Duration;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class TrustedDeviceHelper {
+
+  private static final String TRUSTED_DEVICE_COOKIE_NAME = "trusted_device";
+  private static final int MAX_TRUSTED_DEVICES_PER_USER = 3;
+
+  private final TrustedDeviceRepository trustedDeviceRepository;
+
+  public ResponseCookie buildTrustedDeviceCookie(String trustedDeviceToken, Duration maxAge) {
+    return ResponseCookie.from(TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceToken)
+        .httpOnly(true)
+        .secure(true)
+        .sameSite("Lax")
+        .path("/")
+        .maxAge(maxAge)
+        .build();
+  }
+
+  public void validateTrustedDeviceLimit(Long userId) {
+    if (trustedDeviceRepository.countByUserId(userId) >= MAX_TRUSTED_DEVICES_PER_USER) {
+      throw new AuthException(ErrorDefinition.CONFLICT, null, HttpStatus.CONFLICT);
+    }
+  }
+}

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -101,6 +101,7 @@ public class AuthServiceImpl implements AuthService {
 
     try {
       var registeredUser = authRegisterHelper.createUser(register);
+
       verificationEmailHelper.scheduleVerificationEmail(
           registeredUser.response().getId(),
           registeredUser.response().getEmail(),

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -78,6 +78,24 @@ public class AuthServiceImpl implements AuthService {
 
   @Override
   @Transactional
+  public ResponseCookie verifyLoginDevice(String token) {
+    if (token == null || token.isBlank()) {
+      throw new AuthException(ErrorDefinition.GENERIC_BAD_REQUEST, null, HttpStatus.BAD_REQUEST);
+    }
+
+    Long userId = accessTokenHelper.extractVerifyLoginDeviceUserId(token);
+    UserEntity user =
+        userRepository
+            .findByIdAndDeletedAtIsNull(userId)
+            .orElseThrow(
+                () ->
+                    new AuthException(ErrorDefinition.UNAUTHORIZED, null, HttpStatus.UNAUTHORIZED));
+
+    return trustedDeviceHelper.createTrustedDeviceCookie(user);
+  }
+
+  @Override
+  @Transactional
   public UserResponseDto register(RegisterRequestDto register) {
     authValidationHelper.validateRegisterRequest(register);
 

--- a/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/tychewealth/service/impl/AuthServiceImpl.java
@@ -22,6 +22,7 @@ import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
+import com.tychewealth.service.helper.trusteddevice.TrustedDeviceHelper;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.token.AuthTokenPayload;
 import com.tychewealth.utils.Utils;
@@ -30,6 +31,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,12 +48,13 @@ public class AuthServiceImpl implements AuthService {
   private final AuthRefreshTokenHelper authRefreshTokenHelper;
   private final AccessTokenHelper accessTokenHelper;
   private final TokenValidationHelper tokenValidationHelper;
+  private final TrustedDeviceHelper trustedDeviceHelper;
   private final AuthMetrics authMetrics;
   private final UserRepository userRepository;
 
   @Override
   @Transactional
-  public void verifyEmail(String token) {
+  public ResponseCookie verifyEmail(String token) {
     if (token == null || token.isBlank()) {
       throw new AuthException(ErrorDefinition.GENERIC_BAD_REQUEST, null, HttpStatus.BAD_REQUEST);
     }
@@ -64,12 +67,13 @@ public class AuthServiceImpl implements AuthService {
                 () ->
                     new AuthException(ErrorDefinition.UNAUTHORIZED, null, HttpStatus.UNAUTHORIZED));
     if (user.isVerified()) {
-      return;
+      return trustedDeviceHelper.createTrustedDeviceCookie(user);
     }
 
     user.setVerified(true);
     user.setVerificationTokenExpiresAt(null);
     userRepository.save(user);
+    return trustedDeviceHelper.createTrustedDeviceCookie(user);
   }
 
   @Override

--- a/user-service/src/main/java/com/tychewealth/service/ratelimit/RateLimitStore.java
+++ b/user-service/src/main/java/com/tychewealth/service/ratelimit/RateLimitStore.java
@@ -6,5 +6,7 @@ public interface RateLimitStore {
 
   long increment(String namespace, String clientKey, Duration window);
 
+  void clear(String namespace, String clientKey);
+
   void resetNamespace(String namespace);
 }

--- a/user-service/src/main/java/com/tychewealth/service/ratelimit/RedisRateLimitStore.java
+++ b/user-service/src/main/java/com/tychewealth/service/ratelimit/RedisRateLimitStore.java
@@ -32,6 +32,11 @@ public class RedisRateLimitStore implements RateLimitStore {
   }
 
   @Override
+  public void clear(String namespace, String clientKey) {
+    redisTemplate.delete(buildKey(namespace, clientKey));
+  }
+
+  @Override
   public void resetNamespace(String namespace) {
     Set<String> keys = redisTemplate.keys(namespace + ":*");
     if (keys != null && !keys.isEmpty()) {

--- a/user-service/src/main/java/com/tychewealth/utils/Utils.java
+++ b/user-service/src/main/java/com/tychewealth/utils/Utils.java
@@ -53,4 +53,14 @@ public final class Utils {
     LocalDate tomorrow = now.atZone(ZoneOffset.UTC).toLocalDate().plusDays(1);
     return Duration.between(now, tomorrow.atStartOfDay().toInstant(ZoneOffset.UTC));
   }
+
+  public static String formatExpirationText(long expiresInSeconds) {
+    if (expiresInSeconds % 3600 == 0) {
+      long hours = expiresInSeconds / 3600;
+      return hours + (hours == 1 ? " hour" : " hours");
+    }
+
+    long expiresInMinutes = (expiresInSeconds + 59) / 60;
+    return expiresInMinutes + (expiresInMinutes == 1 ? " minute" : " minutes");
+  }
 }

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -23,6 +23,7 @@ spring.jpa.open-in-view=false
 app.auth.jwt.secret=${JWT_SECRET}
 app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS:86400}
+app.auth.jwt.verify-login-device-token-ttl-seconds=${JWT_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS:86400}
 app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
 app.auth.jwt.refresh-token-pepper=${JWT_REFRESH_TOKEN_PEPPER}
 app.auth.verify-registration-url=${VERIFY_REGISTRATION_URL}

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -26,6 +26,7 @@ app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS
 app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
 app.auth.jwt.refresh-token-pepper=${JWT_REFRESH_TOKEN_PEPPER}
 app.auth.verify-registration-url=${VERIFY_REGISTRATION_URL}
+app.auth.verify-login-device-url=${VERIFY_LOGIN_DEVICE_URL}
 
 # Register endpoint protections
 app.auth.register-rate-limit.max-requests=${AUTH_REGISTER_RATE_LIMIT_MAX_REQUESTS:15}

--- a/user-service/src/main/resources/db.changelog/changelog-master.xml
+++ b/user-service/src/main/resources/db.changelog/changelog-master.xml
@@ -9,5 +9,6 @@
     <include file="portfolio-changelog/portfolio-changelog-master.xml" relativeToChangelogFile="true"/>
     <include file="asset-changelog/asset-changelog-master.xml" relativeToChangelogFile="true"/>
     <include file="refresh-token-changelog/refresh-token-changelog-master.xml" relativeToChangelogFile="true"/>
+    <include file="trusted-device-changelog/trusted-device-changelog-master.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/user-service/src/main/resources/db.changelog/trusted-device-changelog/trusted-device-changelog-dll.xml
+++ b/user-service/src/main/resources/db.changelog/trusted-device-changelog/trusted-device-changelog-dll.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="create-trusted-device-sequence" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <sequenceExists sequenceName="trusted_device_seq"/>
+            </not>
+        </preConditions>
+
+        <createSequence sequenceName="trusted_device_seq" startValue="1" incrementBy="1"/>
+
+        <rollback>
+            <dropSequence sequenceName="trusted_device_seq"/>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="create-trusted-devices-table" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <tableExists tableName="trusted_devices"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="trusted_devices">
+            <column name="id" type="BIGINT" defaultValueSequenceNext="trusted_device_seq">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="token_hash" type="VARCHAR(128)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="uk_trusted_devices_token_hash"/>
+            </column>
+            <column name="expires_at" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_used_at" type="TIMESTAMP"/>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="trusted_devices"
+                baseColumnNames="user_id"
+                constraintName="fk_trusted_devices_users"
+                referencedTableName="users"
+                referencedColumnNames="id"/>
+
+        <rollback>
+            <dropTable tableName="trusted_devices"/>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="create-trusted-devices-user-id-index" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <indexExists indexName="idx_trusted_devices_user_id" tableName="trusted_devices"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="idx_trusted_devices_user_id" tableName="trusted_devices">
+            <column name="user_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_trusted_devices_user_id" tableName="trusted_devices"/>
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="create-trusted-devices-user-id-created-at-index" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <not>
+                <indexExists indexName="idx_trusted_devices_user_id_created_at" tableName="trusted_devices"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="idx_trusted_devices_user_id_created_at" tableName="trusted_devices">
+            <column name="user_id"/>
+            <column name="created_at"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_trusted_devices_user_id_created_at" tableName="trusted_devices"/>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/user-service/src/main/resources/db.changelog/trusted-device-changelog/trusted-device-changelog-dll.xml
+++ b/user-service/src/main/resources/db.changelog/trusted-device-changelog/trusted-device-changelog-dll.xml
@@ -98,4 +98,37 @@
 
     </changeSet>
 
+    <changeSet id="set-trusted-devices-user-fk-on-delete-cascade" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <foreignKeyConstraintExists foreignKeyName="fk_trusted_devices_users"/>
+        </preConditions>
+
+        <dropForeignKeyConstraint
+                baseTableName="trusted_devices"
+                constraintName="fk_trusted_devices_users"/>
+
+        <addForeignKeyConstraint
+                baseTableName="trusted_devices"
+                baseColumnNames="user_id"
+                constraintName="fk_trusted_devices_users"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                onDelete="CASCADE"/>
+
+        <rollback>
+            <dropForeignKeyConstraint
+                    baseTableName="trusted_devices"
+                    constraintName="fk_trusted_devices_users"/>
+
+            <addForeignKeyConstraint
+                    baseTableName="trusted_devices"
+                    baseColumnNames="user_id"
+                    constraintName="fk_trusted_devices_users"
+                    referencedTableName="users"
+                    referencedColumnNames="id"/>
+        </rollback>
+
+    </changeSet>
+
 </databaseChangeLog>

--- a/user-service/src/main/resources/db.changelog/trusted-device-changelog/trusted-device-changelog-master.xml
+++ b/user-service/src/main/resources/db.changelog/trusted-device-changelog/trusted-device-changelog-master.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <include file="trusted-device-changelog-dll.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/user-service/src/main/resources/templates/email/verify-login-device.html
+++ b/user-service/src/main/resources/templates/email/verify-login-device.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div
+      style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; color: #111; line-height: 1.5;"
+    >
+      <h1 style="margin-bottom: 24px;">Tyche Wealth</h1>
+
+      <h2 style="margin-bottom: 16px;">Confirm your login</h2>
+
+      <p>Hi,</p>
+
+      <p>We detected a login attempt to your <strong>Tyche Wealth</strong> account.</p>
+
+      <p>If this was you, confirm the login by clicking the button below:</p>
+
+      <div style="text-align: center; margin: 32px 0;">
+        <a
+          href="{{verification_link}}"
+          style="
+            display: inline-block;
+            background-color: #111;
+            color: #fff;
+            padding: 12px 20px;
+            text-decoration: none;
+            border-radius: 6px;
+          "
+        >
+          Confirm login
+        </a>
+      </div>
+
+      <p>If this wasn't you, change your password immediately.</p>
+
+      <p style="margin-top: 32px; font-size: 12px; color: #666;">
+        This link will expire in {{expiration_text}}.
+      </p>
+    </div>
+  </body>
+</html>

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -4,10 +4,12 @@ import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
 
 import com.tychewealth.controller.impl.AuthApiController;
 import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.TrustedDeviceEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorHandler;
 import com.tychewealth.mapper.user.UserMapperImpl;
 import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
@@ -20,6 +22,7 @@ import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
 import com.tychewealth.service.helper.token.VerificationTokenRecoveryHelper;
+import com.tychewealth.service.helper.trusteddevice.TrustedDeviceHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
 import com.tychewealth.service.monitoring.AuthMetrics;
 import com.tychewealth.service.monitoring.UserMetrics;
@@ -47,6 +50,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthLoginHelper.class,
   RegisterEmailHelper.class,
   VerificationEmailHelper.class,
+  TrustedDeviceHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
@@ -57,8 +61,14 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   ErrorHandler.class,
   UserMapperImpl.class
 })
-@EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
-@EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
+@EnableJpaRepositories(
+    basePackageClasses = {
+      UserRepository.class,
+      RefreshTokenRepository.class,
+      TrustedDeviceRepository.class
+    })
+@EntityScan(
+    basePackageClasses = {UserEntity.class, RefreshTokenEntity.class, TrustedDeviceEntity.class})
 public class AuthIntegrationTestConfig {
 
   @org.springframework.context.annotation.Bean

--- a/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/AuthIntegrationTestConfig.java
@@ -15,6 +15,7 @@ import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.email.LoginDeviceEmailHelper;
 import com.tychewealth.service.helper.email.RegisterEmailHelper;
 import com.tychewealth.service.helper.email.VerificationEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
@@ -48,6 +49,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthValidationHelper.class,
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
+  LoginDeviceEmailHelper.class,
   RegisterEmailHelper.class,
   VerificationEmailHelper.class,
   TrustedDeviceHelper.class,
@@ -86,6 +88,7 @@ public class AuthIntegrationTestConfig {
               "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
               "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER,
               "app.auth.verify-registration-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration",
+              "app.auth.verify-login-device-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-login-device",
               "app.email.resend.api-key=test-resend-api-key",
               "app.email.resend.from=Tyche Wealth <auth@tyche-wealth.test>",
               "app.auth.register-rate-limit.max-requests=2",

--- a/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
@@ -19,6 +19,7 @@ import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.email.LoginDeviceEmailHelper;
 import com.tychewealth.service.helper.email.RegisterEmailHelper;
 import com.tychewealth.service.helper.email.VerificationEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
@@ -63,6 +64,7 @@ import org.springframework.data.redis.core.RedisTemplate;
   AuthValidationHelper.class,
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
+  LoginDeviceEmailHelper.class,
   RegisterEmailHelper.class,
   VerificationEmailHelper.class,
   TrustedDeviceHelper.class,
@@ -118,6 +120,7 @@ public class RedisIntegrationTestConfig {
               "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
               "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER,
               "app.auth.verify-registration-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration",
+              "app.auth.verify-login-device-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-login-device",
               "app.email.resend.api-key=test-resend-api-key",
               "app.email.resend.from=Tyche Wealth <auth@tyche-wealth.test>",
               "app.auth.register-rate-limit.max-requests=2",

--- a/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/RedisIntegrationTestConfig.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.tychewealth.controller.impl.AuthApiController;
 import com.tychewealth.controller.impl.UserApiController;
 import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.TrustedDeviceEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorHandler;
 import com.tychewealth.mapper.user.UserMapperImpl;
 import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
@@ -24,6 +26,7 @@ import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
 import com.tychewealth.service.helper.token.VerificationTokenRecoveryHelper;
+import com.tychewealth.service.helper.trusteddevice.TrustedDeviceHelper;
 import com.tychewealth.service.helper.user.UserHelper;
 import com.tychewealth.service.helper.user.UserValidationHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
@@ -62,6 +65,7 @@ import org.springframework.data.redis.core.RedisTemplate;
   AuthLoginHelper.class,
   RegisterEmailHelper.class,
   VerificationEmailHelper.class,
+  TrustedDeviceHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
@@ -74,8 +78,14 @@ import org.springframework.data.redis.core.RedisTemplate;
   ErrorHandler.class,
   UserMapperImpl.class
 })
-@EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
-@EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
+@EnableJpaRepositories(
+    basePackageClasses = {
+      UserRepository.class,
+      RefreshTokenRepository.class,
+      TrustedDeviceRepository.class
+    })
+@EntityScan(
+    basePackageClasses = {UserEntity.class, RefreshTokenEntity.class, TrustedDeviceEntity.class})
 public class RedisIntegrationTestConfig {
 
   @Bean

--- a/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
@@ -18,6 +18,7 @@ import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
 import com.tychewealth.service.helper.auth.AuthRegisterHelper;
 import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.email.LoginDeviceEmailHelper;
 import com.tychewealth.service.helper.email.RegisterEmailHelper;
 import com.tychewealth.service.helper.email.VerificationEmailHelper;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
@@ -57,6 +58,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthValidationHelper.class,
   AuthRegisterHelper.class,
   AuthLoginHelper.class,
+  LoginDeviceEmailHelper.class,
   RegisterEmailHelper.class,
   VerificationEmailHelper.class,
   TrustedDeviceHelper.class,
@@ -97,6 +99,7 @@ public class SecurityIntegrationTestConfig {
               "app.auth.jwt.secret=4AYI7d6GOEvFEcCJZkDA0hGFqI6SuF5RAsxAjqzTmaM=",
               "app.auth.jwt.refresh-token-pepper=" + TEST_REFRESH_TOKEN_PEPPER,
               "app.auth.verify-registration-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-registration",
+              "app.auth.verify-login-device-url=http://localhost:8080/tyche-wealth/user-service/v1/auth/verify-login-device",
               "app.email.resend.api-key=test-resend-api-key",
               "app.email.resend.from=Tyche Wealth <auth@tyche-wealth.test>",
               "app.security.prometheus.username=" + TEST_PROMETHEUS_USERNAME,

--- a/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
+++ b/user-service/src/test/java/com/tychewealth/config/SecurityIntegrationTestConfig.java
@@ -7,10 +7,12 @@ import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
 import com.tychewealth.controller.impl.AuthApiController;
 import com.tychewealth.controller.impl.UserApiController;
 import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.TrustedDeviceEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorHandler;
 import com.tychewealth.mapper.user.UserMapperImpl;
 import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.EmailService;
 import com.tychewealth.service.helper.auth.AuthLoginHelper;
@@ -23,6 +25,7 @@ import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
 import com.tychewealth.service.helper.token.TokenStateHelper;
 import com.tychewealth.service.helper.token.TokenValidationHelper;
 import com.tychewealth.service.helper.token.VerificationTokenRecoveryHelper;
+import com.tychewealth.service.helper.trusteddevice.TrustedDeviceHelper;
 import com.tychewealth.service.helper.user.UserHelper;
 import com.tychewealth.service.helper.user.UserValidationHelper;
 import com.tychewealth.service.impl.AuthServiceImpl;
@@ -56,6 +59,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   AuthLoginHelper.class,
   RegisterEmailHelper.class,
   VerificationEmailHelper.class,
+  TrustedDeviceHelper.class,
   AccessTokenHelper.class,
   TokenStateHelper.class,
   TokenValidationHelper.class,
@@ -68,8 +72,14 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   UserHelper.class,
   UserValidationHelper.class
 })
-@EnableJpaRepositories(basePackageClasses = {UserRepository.class, RefreshTokenRepository.class})
-@EntityScan(basePackageClasses = {UserEntity.class, RefreshTokenEntity.class})
+@EnableJpaRepositories(
+    basePackageClasses = {
+      UserRepository.class,
+      RefreshTokenRepository.class,
+      TrustedDeviceRepository.class
+    })
+@EntityScan(
+    basePackageClasses = {UserEntity.class, RefreshTokenEntity.class, TrustedDeviceEntity.class})
 public class SecurityIntegrationTestConfig {
 
   @Bean

--- a/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -49,6 +49,10 @@ public final class TestConstants {
   public static final String TEST_HEADER_STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
   public static final String TEST_ATTACKER_BASIC_TOKEN = "Basic attacker-token";
   public static final String TEST_TAMPERED_TOKEN_SUFFIX = "tampered";
+  public static final String TEST_AUTH_TOKEN_PARAM = "token";
+  public static final String TEST_VERIFY_REGISTRATION_PATH = "/verify-registration";
+  public static final String TEST_VERIFY_LOGIN_DEVICE_PATH = "/verify-login-device";
+  public static final String TEST_TRUSTED_DEVICE_COOKIE_NAME = "trusted_device";
 
   private TestConstants() {}
 }

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -65,6 +65,7 @@ import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.EmailService;
 import com.tychewealth.service.email.EmailMessage;
@@ -82,6 +83,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ContextConfiguration;
@@ -101,6 +103,7 @@ class AuthApiControllerIntegrationTest {
 
   @Autowired private UserRepository userRepository;
   @Autowired private RefreshTokenRepository refreshTokenRepository;
+  @Autowired private TrustedDeviceRepository trustedDeviceRepository;
   @Autowired private MeterRegistry meterRegistry;
   @Autowired private RefreshRateLimitConfig rateLimitConfig;
 
@@ -119,6 +122,7 @@ class AuthApiControllerIntegrationTest {
   @BeforeEach
   void setUp() {
     refreshTokenRepository.deleteAll();
+    trustedDeviceRepository.deleteAll();
     userRepository.deleteAll();
     rateLimitConfig.resetAll();
     reset(emailService);
@@ -191,12 +195,20 @@ class AuthApiControllerIntegrationTest {
 
     mockMvc
         .perform(get(AUTH_BASE_URL + "/verify-registration").param("token", token))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isNoContent())
+        .andExpect(
+            result ->
+                assertTrue(
+                    result
+                        .getResponse()
+                        .getHeader(HttpHeaders.SET_COOKIE)
+                        .contains("trusted_device=")));
 
     UserEntity verifiedUser =
         userRepository.findByEmailIncludingDeleted(validRequest.getEmail()).orElseThrow();
     assertTrue(verifiedUser.isVerified());
     assertNull(verifiedUser.getVerificationTokenExpiresAt());
+    assertEquals(1, trustedDeviceRepository.count());
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -38,6 +38,7 @@ import static com.tychewealth.testhelper.AuthTestHelper.loginRequest;
 import static com.tychewealth.testhelper.AuthTestHelper.logout;
 import static com.tychewealth.testhelper.AuthTestHelper.refresh;
 import static com.tychewealth.testhelper.AuthTestHelper.registerRequest;
+import static com.tychewealth.testhelper.AuthTestHelper.seedTrustedDevice;
 import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
 import static com.tychewealth.utils.Utils.sha256Hex;
 import static org.hamcrest.Matchers.containsString;
@@ -74,6 +75,7 @@ import com.tychewealth.service.helper.token.AccessTokenHelper;
 import com.tychewealth.service.ratelimit.RateLimitStore;
 import com.tychewealth.service.token.AuthTokenPayload;
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.servlet.http.Cookie;
 import java.time.Instant;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -121,6 +123,7 @@ class AuthApiControllerIntegrationTest {
   private UserEntity existingEmailUser;
   private UserEntity existingUsernameUser;
   private UserEntity existingLoginUser;
+  private Cookie trustedDeviceCookie;
 
   @BeforeEach
   void setUp() {
@@ -268,6 +271,70 @@ class AuthApiControllerIntegrationTest {
   }
 
   @Test
+  void verifyLoginDeviceReturnsNoContentAndCreatesTrustedDeviceWhenTokenIsValid() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload verifyLoginDeviceToken =
+        accessTokenHelper.generateVerifyLoginDeviceToken(user);
+
+    mockMvc
+        .perform(
+            get(AUTH_BASE_URL + "/verify-login-device")
+                .param("token", verifyLoginDeviceToken.accessToken()))
+        .andExpect(status().isNoContent())
+        .andExpect(
+            result ->
+                assertTrue(
+                    result
+                        .getResponse()
+                        .getHeader(HttpHeaders.SET_COOKIE)
+                        .contains("trusted_device=")));
+
+    assertEquals(1, trustedDeviceRepository.count());
+  }
+
+  @Test
+  void verifyLoginDeviceAllowsNextLoginFromTrustedDevice() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload verifyLoginDeviceToken =
+        accessTokenHelper.generateVerifyLoginDeviceToken(user);
+
+    String setCookieHeader =
+        mockMvc
+            .perform(
+                get(AUTH_BASE_URL + "/verify-login-device")
+                    .param("token", verifyLoginDeviceToken.accessToken()))
+            .andExpect(status().isNoContent())
+            .andReturn()
+            .getResponse()
+            .getHeader(HttpHeaders.SET_COOKIE);
+
+    String trustedDeviceValue = extractCookieValue(setCookieHeader, "trusted_device");
+
+    loginRequest(
+            mockMvc,
+            objectMapper,
+            validLoginRequest,
+            new Cookie("trusted_device", trustedDeviceValue))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").isString())
+        .andExpect(jsonPath("$.refreshToken").isString());
+  }
+
+  @Test
+  void verifyLoginDeviceReturnsUnauthorizedWhenTokenIsRegularAccessToken() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload accessToken = accessTokenHelper.generateAccessToken(user);
+
+    mockMvc
+        .perform(
+            get(AUTH_BASE_URL + "/verify-login-device").param("token", accessToken.accessToken()))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
+        .andExpect(jsonPath("$.description").value(ErrorDefinition.UNAUTHORIZED.getDescription()));
+  }
+
+  @Test
   void registerReturnsConflictWhenEmailAlreadyExists() throws Exception {
     userRepository.save(existingEmailUser);
     double failureBefore = counterValue(meterRegistry, METRIC_AUTH_REGISTER_FAILURE);
@@ -379,11 +446,12 @@ class AuthApiControllerIntegrationTest {
 
   @Test
   void loginReturnsTokenAndUserWhenCredentialsAreValid() throws Exception {
-    userRepository.save(existingLoginUser);
+    UserEntity savedUser = userRepository.save(existingLoginUser);
+    trustedDeviceCookie = seedTrustedDevice(trustedDeviceRepository, savedUser);
     double requestsBefore = counterValue(meterRegistry, METRIC_AUTH_LOGIN_REQUESTS);
     double successBefore = counterValue(meterRegistry, METRIC_AUTH_LOGIN_SUCCESS);
 
-    loginRequest(mockMvc, objectMapper, validLoginRequest)
+    loginRequest(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie)
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.tokenType").value(TOKEN_TYPE_BEARER))
         .andExpect(jsonPath("$.accessToken").isString())
@@ -509,10 +577,13 @@ class AuthApiControllerIntegrationTest {
 
   @Test
   void secondLoginRevokesPreviousRefreshToken() throws Exception {
-    userRepository.save(existingLoginUser);
+    UserEntity savedUser = userRepository.save(existingLoginUser);
+    trustedDeviceCookie = seedTrustedDevice(trustedDeviceRepository, savedUser);
 
-    LoginResponseDto firstLoginResponse = login(mockMvc, objectMapper, validLoginRequest);
-    LoginResponseDto secondLoginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto firstLoginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
+    LoginResponseDto secondLoginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
     assertNotEquals(firstLoginResponse.getRefreshToken(), secondLoginResponse.getRefreshToken());
 
     refresh(mockMvc, objectMapper, firstLoginResponse.getRefreshToken())
@@ -708,6 +779,13 @@ class AuthApiControllerIntegrationTest {
 
   private String extractVerificationToken(String html) {
     Matcher matcher = VERIFY_REGISTRATION_TOKEN_PATTERN.matcher(html);
+    assertTrue(matcher.find());
+    return matcher.group(1);
+  }
+
+  private String extractCookieValue(String setCookieHeader, String cookieName) {
+    Pattern cookiePattern = Pattern.compile(cookieName + "=([^;]+)");
+    Matcher matcher = cookiePattern.matcher(setCookieHeader);
     assertTrue(matcher.find());
     return matcher.group(1);
   }

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_REGISTER_FAI
 import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_REGISTER_RATE_LIMITED;
 import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_REGISTER_REQUESTS;
 import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_REGISTER_SUCCESS;
+import static com.tychewealth.constants.RedisConstants.AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_INVALID;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
@@ -70,6 +71,7 @@ import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.EmailService;
 import com.tychewealth.service.email.EmailMessage;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
+import com.tychewealth.service.ratelimit.RateLimitStore;
 import com.tychewealth.service.token.AuthTokenPayload;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
@@ -106,6 +108,7 @@ class AuthApiControllerIntegrationTest {
   @Autowired private TrustedDeviceRepository trustedDeviceRepository;
   @Autowired private MeterRegistry meterRegistry;
   @Autowired private RefreshRateLimitConfig rateLimitConfig;
+  @Autowired private RateLimitStore rateLimitStore;
 
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private AccessTokenHelper accessTokenHelper;
@@ -125,6 +128,7 @@ class AuthApiControllerIntegrationTest {
     trustedDeviceRepository.deleteAll();
     userRepository.deleteAll();
     rateLimitConfig.resetAll();
+    rateLimitStore.resetNamespace(AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE);
     reset(emailService);
     validRequest =
         new RegisterRequestDto(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_PASSWORD_VALID);
@@ -450,6 +454,33 @@ class AuthApiControllerIntegrationTest {
         .andExpect(
             jsonPath("$.description")
                 .value(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS.getDescription()));
+  }
+
+  @Test
+  void loginSendsDeviceVerificationEmailWhenDeviceIsNotTrusted() throws Exception {
+    userRepository.save(existingLoginUser);
+
+    loginRequest(mockMvc, objectMapper, validLoginRequest)
+        .andExpect(status().isForbidden())
+        .andExpect(
+            jsonPath("$.code")
+                .value(ErrorDefinition.AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED.getCode()))
+        .andExpect(
+            jsonPath("$.type")
+                .value(ErrorDefinition.AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED.getType()));
+
+    verify(emailService).send(org.mockito.ArgumentMatchers.any(EmailMessage.class));
+  }
+
+  @Test
+  void loginDoesNotResendDeviceVerificationEmailWithinCooldown() throws Exception {
+    userRepository.save(existingLoginUser);
+
+    loginRequest(mockMvc, objectMapper, validLoginRequest).andExpect(status().isForbidden());
+    loginRequest(mockMvc, objectMapper, validLoginRequest).andExpect(status().isForbidden());
+
+    verify(emailService, org.mockito.Mockito.times(1))
+        .send(org.mockito.ArgumentMatchers.any(EmailMessage.class));
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -240,21 +240,29 @@ class AuthApiControllerIntegrationTest {
     UserEntity user = userRepository.save(existingLoginUser);
     AuthTokenPayload verifyEmailToken = accessTokenHelper.generateVerifyEmailToken(user);
 
-    mockMvc
-        .perform(
-            get(AUTH_BASE_URL + "/verify-registration")
-                .param("token", verifyEmailToken.accessToken()))
-        .andExpect(status().isNoContent());
+    String setCookieHeader =
+        mockMvc
+            .perform(
+                get(AUTH_BASE_URL + "/verify-registration")
+                    .param("token", verifyEmailToken.accessToken()))
+            .andExpect(status().isNoContent())
+            .andReturn()
+            .getResponse()
+            .getHeader(HttpHeaders.SET_COOKIE);
+
+    String trustedDeviceValue = extractCookieValue(setCookieHeader, "trusted_device");
 
     mockMvc
         .perform(
             get(AUTH_BASE_URL + "/verify-registration")
-                .param("token", verifyEmailToken.accessToken()))
+                .param("token", verifyEmailToken.accessToken())
+                .cookie(new Cookie("trusted_device", trustedDeviceValue)))
         .andExpect(status().isNoContent());
 
     UserEntity verifiedUser = userRepository.findById(user.getId()).orElseThrow();
     assertTrue(verifiedUser.isVerified());
     assertNull(verifiedUser.getVerificationTokenExpiresAt());
+    assertEquals(1, trustedDeviceRepository.count());
   }
 
   @Test
@@ -319,6 +327,34 @@ class AuthApiControllerIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.accessToken").isString())
         .andExpect(jsonPath("$.refreshToken").isString());
+  }
+
+  @Test
+  void verifyLoginDeviceReusesExistingTrustedDeviceWhenCookieAlreadyExists() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload verifyLoginDeviceToken =
+        accessTokenHelper.generateVerifyLoginDeviceToken(user);
+
+    String setCookieHeader =
+        mockMvc
+            .perform(
+                get(AUTH_BASE_URL + "/verify-login-device")
+                    .param("token", verifyLoginDeviceToken.accessToken()))
+            .andExpect(status().isNoContent())
+            .andReturn()
+            .getResponse()
+            .getHeader(HttpHeaders.SET_COOKIE);
+
+    String trustedDeviceValue = extractCookieValue(setCookieHeader, "trusted_device");
+
+    mockMvc
+        .perform(
+            get(AUTH_BASE_URL + "/verify-login-device")
+                .param("token", verifyLoginDeviceToken.accessToken())
+                .cookie(new Cookie("trusted_device", trustedDeviceValue)))
+        .andExpect(status().isNoContent());
+
+    assertEquals(1, trustedDeviceRepository.count());
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -548,6 +549,22 @@ class AuthApiControllerIntegrationTest {
     loginRequest(mockMvc, objectMapper, validLoginRequest).andExpect(status().isForbidden());
 
     verify(emailService, org.mockito.Mockito.times(1))
+        .send(org.mockito.ArgumentMatchers.any(EmailMessage.class));
+  }
+
+  @Test
+  void loginRetriesDeviceVerificationEmailWhenPreviousSendFails() throws Exception {
+    userRepository.save(existingLoginUser);
+    doThrow(new IllegalStateException("email send failed"))
+        .when(emailService)
+        .send(org.mockito.ArgumentMatchers.any(EmailMessage.class));
+
+    loginRequest(mockMvc, objectMapper, validLoginRequest)
+        .andExpect(status().isInternalServerError());
+    loginRequest(mockMvc, objectMapper, validLoginRequest)
+        .andExpect(status().isInternalServerError());
+
+    verify(emailService, org.mockito.Mockito.times(2))
         .send(org.mockito.ArgumentMatchers.any(EmailMessage.class));
   }
 

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -31,7 +31,9 @@ import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_METRICS
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_MISSING;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_REVOKED;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_REGISTRATION_PATH;
 import static com.tychewealth.testdata.EntityBuilder.buildRefreshToken;
 import static com.tychewealth.testhelper.AuthTestHelper.login;
 import static com.tychewealth.testhelper.AuthTestHelper.loginRequest;
@@ -39,6 +41,8 @@ import static com.tychewealth.testhelper.AuthTestHelper.logout;
 import static com.tychewealth.testhelper.AuthTestHelper.refresh;
 import static com.tychewealth.testhelper.AuthTestHelper.registerRequest;
 import static com.tychewealth.testhelper.AuthTestHelper.seedTrustedDevice;
+import static com.tychewealth.testhelper.AuthTestHelper.verifyLoginDeviceRequest;
+import static com.tychewealth.testhelper.AuthTestHelper.verifyRegistrationRequest;
 import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
 import static com.tychewealth.utils.Utils.sha256Hex;
 import static org.hamcrest.Matchers.containsString;
@@ -51,7 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -195,14 +198,13 @@ class AuthApiControllerIntegrationTest {
     EmailMessage sentEmail = emailCaptor.getValue();
     assertEquals(validRequest.getEmail(), sentEmail.to());
     assertEquals("Verify your email", sentEmail.subject());
-    assertTrue(sentEmail.html().contains("/auth/verify-registration"));
+    assertTrue(sentEmail.html().contains("/auth" + TEST_VERIFY_REGISTRATION_PATH));
     assertTrue(sentEmail.html().contains("24 hours"));
     assertTrue(sentEmail.text().contains("24 hours"));
 
     String token = extractVerificationToken(sentEmail.html());
 
-    mockMvc
-        .perform(get(AUTH_BASE_URL + "/verify-registration").param("token", token))
+    verifyRegistrationRequest(mockMvc, token)
         .andExpect(status().isNoContent())
         .andExpect(
             result ->
@@ -210,7 +212,7 @@ class AuthApiControllerIntegrationTest {
                     result
                         .getResponse()
                         .getHeader(HttpHeaders.SET_COOKIE)
-                        .contains("trusted_device=")));
+                        .contains(TEST_TRUSTED_DEVICE_COOKIE_NAME + "=")));
 
     UserEntity verifiedUser =
         userRepository.findByEmailIncludingDeleted(validRequest.getEmail()).orElseThrow();
@@ -224,10 +226,7 @@ class AuthApiControllerIntegrationTest {
     UserEntity user = userRepository.save(existingLoginUser);
     AuthTokenPayload verifyEmailToken = accessTokenHelper.generateVerifyEmailToken(user);
 
-    mockMvc
-        .perform(
-            get(AUTH_BASE_URL + "/verify-registration")
-                .param("token", verifyEmailToken.accessToken()))
+    verifyRegistrationRequest(mockMvc, verifyEmailToken.accessToken())
         .andExpect(status().isNoContent());
 
     UserEntity verifiedUser = userRepository.findById(user.getId()).orElseThrow();
@@ -241,22 +240,19 @@ class AuthApiControllerIntegrationTest {
     AuthTokenPayload verifyEmailToken = accessTokenHelper.generateVerifyEmailToken(user);
 
     String setCookieHeader =
-        mockMvc
-            .perform(
-                get(AUTH_BASE_URL + "/verify-registration")
-                    .param("token", verifyEmailToken.accessToken()))
+        verifyRegistrationRequest(mockMvc, verifyEmailToken.accessToken())
             .andExpect(status().isNoContent())
             .andReturn()
             .getResponse()
             .getHeader(HttpHeaders.SET_COOKIE);
 
-    String trustedDeviceValue = extractCookieValue(setCookieHeader, "trusted_device");
+    String trustedDeviceValue =
+        extractCookieValue(setCookieHeader, TEST_TRUSTED_DEVICE_COOKIE_NAME);
 
-    mockMvc
-        .perform(
-            get(AUTH_BASE_URL + "/verify-registration")
-                .param("token", verifyEmailToken.accessToken())
-                .cookie(new Cookie("trusted_device", trustedDeviceValue)))
+    verifyRegistrationRequest(
+            mockMvc,
+            verifyEmailToken.accessToken(),
+            new Cookie(TEST_TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceValue))
         .andExpect(status().isNoContent());
 
     UserEntity verifiedUser = userRepository.findById(user.getId()).orElseThrow();
@@ -270,9 +266,7 @@ class AuthApiControllerIntegrationTest {
     UserEntity user = userRepository.save(existingLoginUser);
     AuthTokenPayload accessToken = accessTokenHelper.generateAccessToken(user);
 
-    mockMvc
-        .perform(
-            get(AUTH_BASE_URL + "/verify-registration").param("token", accessToken.accessToken()))
+    verifyRegistrationRequest(mockMvc, accessToken.accessToken())
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
@@ -285,10 +279,7 @@ class AuthApiControllerIntegrationTest {
     AuthTokenPayload verifyLoginDeviceToken =
         accessTokenHelper.generateVerifyLoginDeviceToken(user);
 
-    mockMvc
-        .perform(
-            get(AUTH_BASE_URL + "/verify-login-device")
-                .param("token", verifyLoginDeviceToken.accessToken()))
+    verifyLoginDeviceRequest(mockMvc, verifyLoginDeviceToken.accessToken())
         .andExpect(status().isNoContent())
         .andExpect(
             result ->
@@ -296,7 +287,7 @@ class AuthApiControllerIntegrationTest {
                     result
                         .getResponse()
                         .getHeader(HttpHeaders.SET_COOKIE)
-                        .contains("trusted_device=")));
+                        .contains(TEST_TRUSTED_DEVICE_COOKIE_NAME + "=")));
 
     assertEquals(1, trustedDeviceRepository.count());
   }
@@ -308,22 +299,20 @@ class AuthApiControllerIntegrationTest {
         accessTokenHelper.generateVerifyLoginDeviceToken(user);
 
     String setCookieHeader =
-        mockMvc
-            .perform(
-                get(AUTH_BASE_URL + "/verify-login-device")
-                    .param("token", verifyLoginDeviceToken.accessToken()))
+        verifyLoginDeviceRequest(mockMvc, verifyLoginDeviceToken.accessToken())
             .andExpect(status().isNoContent())
             .andReturn()
             .getResponse()
             .getHeader(HttpHeaders.SET_COOKIE);
 
-    String trustedDeviceValue = extractCookieValue(setCookieHeader, "trusted_device");
+    String trustedDeviceValue =
+        extractCookieValue(setCookieHeader, TEST_TRUSTED_DEVICE_COOKIE_NAME);
 
     loginRequest(
             mockMvc,
             objectMapper,
             validLoginRequest,
-            new Cookie("trusted_device", trustedDeviceValue))
+            new Cookie(TEST_TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceValue))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.accessToken").isString())
         .andExpect(jsonPath("$.refreshToken").isString());
@@ -336,25 +325,58 @@ class AuthApiControllerIntegrationTest {
         accessTokenHelper.generateVerifyLoginDeviceToken(user);
 
     String setCookieHeader =
-        mockMvc
-            .perform(
-                get(AUTH_BASE_URL + "/verify-login-device")
-                    .param("token", verifyLoginDeviceToken.accessToken()))
+        verifyLoginDeviceRequest(mockMvc, verifyLoginDeviceToken.accessToken())
             .andExpect(status().isNoContent())
             .andReturn()
             .getResponse()
             .getHeader(HttpHeaders.SET_COOKIE);
 
-    String trustedDeviceValue = extractCookieValue(setCookieHeader, "trusted_device");
+    String trustedDeviceValue =
+        extractCookieValue(setCookieHeader, TEST_TRUSTED_DEVICE_COOKIE_NAME);
 
-    mockMvc
-        .perform(
-            get(AUTH_BASE_URL + "/verify-login-device")
-                .param("token", verifyLoginDeviceToken.accessToken())
-                .cookie(new Cookie("trusted_device", trustedDeviceValue)))
+    verifyLoginDeviceRequest(
+            mockMvc,
+            verifyLoginDeviceToken.accessToken(),
+            new Cookie(TEST_TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceValue))
         .andExpect(status().isNoContent());
 
     assertEquals(1, trustedDeviceRepository.count());
+  }
+
+  @Test
+  void verifyLoginDeviceDoesNotReuseExpiredTrustedDeviceWhenCookieAlreadyExists() throws Exception {
+    UserEntity user = userRepository.save(existingLoginUser);
+    AuthTokenPayload verifyLoginDeviceToken =
+        accessTokenHelper.generateVerifyLoginDeviceToken(user);
+
+    String setCookieHeader =
+        verifyLoginDeviceRequest(mockMvc, verifyLoginDeviceToken.accessToken())
+            .andExpect(status().isNoContent())
+            .andReturn()
+            .getResponse()
+            .getHeader(HttpHeaders.SET_COOKIE);
+
+    String trustedDeviceValue =
+        extractCookieValue(setCookieHeader, TEST_TRUSTED_DEVICE_COOKIE_NAME);
+    var existingTrustedDevice = trustedDeviceRepository.findAll().getFirst();
+    existingTrustedDevice.setExpiresAt(Instant.now().minusSeconds(5));
+    trustedDeviceRepository.save(existingTrustedDevice);
+
+    String renewedSetCookieHeader =
+        verifyLoginDeviceRequest(
+                mockMvc,
+                verifyLoginDeviceToken.accessToken(),
+                new Cookie(TEST_TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceValue))
+            .andExpect(status().isNoContent())
+            .andReturn()
+            .getResponse()
+            .getHeader(HttpHeaders.SET_COOKIE);
+
+    String renewedTrustedDeviceValue =
+        extractCookieValue(renewedSetCookieHeader, TEST_TRUSTED_DEVICE_COOKIE_NAME);
+
+    assertEquals(1, trustedDeviceRepository.count());
+    assertNotEquals(trustedDeviceValue, renewedTrustedDeviceValue);
   }
 
   @Test
@@ -362,9 +384,7 @@ class AuthApiControllerIntegrationTest {
     UserEntity user = userRepository.save(existingLoginUser);
     AuthTokenPayload accessToken = accessTokenHelper.generateAccessToken(user);
 
-    mockMvc
-        .perform(
-            get(AUTH_BASE_URL + "/verify-login-device").param("token", accessToken.accessToken()))
+    verifyLoginDeviceRequest(mockMvc, accessToken.accessToken())
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
@@ -440,7 +460,7 @@ class AuthApiControllerIntegrationTest {
 
     EmailMessage sentEmail = emailCaptor.getValue();
     assertEquals(existingLoginUser.getEmail(), sentEmail.to());
-    assertTrue(sentEmail.html().contains("/auth/verify-registration"));
+    assertTrue(sentEmail.html().contains("/auth" + TEST_VERIFY_REGISTRATION_PATH));
 
     UserEntity updatedUser = userRepository.findById(user.getId()).orElseThrow();
     assertNotNull(updatedUser.getVerificationTokenExpiresAt());

--- a/user-service/src/test/java/com/tychewealth/controller/RedisIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/RedisIntegrationTest.java
@@ -14,6 +14,7 @@ import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
 import static com.tychewealth.testhelper.AuthTestHelper.login;
 import static com.tychewealth.testhelper.AuthTestHelper.logout;
+import static com.tychewealth.testhelper.AuthTestHelper.seedTrustedDevice;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,8 +31,10 @@ import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.helper.token.AuthRefreshTokenHelper;
+import jakarta.servlet.http.Cookie;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,14 +55,17 @@ class RedisIntegrationTest {
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserRepository userRepository;
   @Autowired private RefreshTokenRepository refreshTokenRepository;
+  @Autowired private TrustedDeviceRepository trustedDeviceRepository;
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private AuthRefreshTokenHelper authRefreshTokenHelper;
 
   private LoginRequestDto validLoginRequest;
+  private Cookie trustedDeviceCookie;
 
   @BeforeEach
   void setUp() {
     refreshTokenRepository.deleteAll();
+    trustedDeviceRepository.deleteAll();
     userRepository.deleteAll();
 
     UserEntity existingLoginUser = new UserEntity();
@@ -67,14 +73,16 @@ class RedisIntegrationTest {
     existingLoginUser.setUsername(TEST_USERNAME_LAURA);
     existingLoginUser.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
     existingLoginUser.setVerified(true);
-    userRepository.save(existingLoginUser);
+    UserEntity savedUser = userRepository.save(existingLoginUser);
+    trustedDeviceCookie = seedTrustedDevice(trustedDeviceRepository, savedUser);
 
     validLoginRequest = new LoginRequestDto(TEST_EMAIL_LAURA, TEST_PASSWORD_VALID);
   }
 
   @Test
   void logoutRevokesAccessTokenForProtectedRetrieveEndpoint() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     logout(mockMvc, objectMapper, loginResponse.getAccessToken(), loginResponse.getRefreshToken())
         .andExpect(status().isNoContent());
@@ -92,7 +100,8 @@ class RedisIntegrationTest {
 
   @Test
   void logoutRevokedAccessTokenIsRejectedByProtectedWriteEndpoint() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     logout(mockMvc, objectMapper, loginResponse.getAccessToken(), loginResponse.getRefreshToken())
         .andExpect(status().isNoContent());
@@ -117,7 +126,8 @@ class RedisIntegrationTest {
 
   @Test
   void logoutWithoutAuthorizationHeaderStillRevokesRefreshTokenAndAccessToken() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     logout(mockMvc, objectMapper, loginResponse.getRefreshToken())
         .andExpect(status().isNoContent());
@@ -141,7 +151,8 @@ class RedisIntegrationTest {
 
   @Test
   void logoutRejectsInvalidAuthorizationHeaderEvenWhenRefreshTokenIsValid() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     mockMvc
         .perform(
@@ -159,7 +170,8 @@ class RedisIntegrationTest {
 
   @Test
   void updatePasswordRevokesCurrentAccessToken() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     mockMvc
         .perform(
@@ -188,7 +200,8 @@ class RedisIntegrationTest {
 
   @Test
   void deleteRevokesCurrentAccessToken() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     mockMvc
         .perform(

--- a/user-service/src/test/java/com/tychewealth/security/SecurityIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/security/SecurityIntegrationTest.java
@@ -25,6 +25,7 @@ import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
 import static com.tychewealth.testhelper.AuthTestHelper.login;
 import static com.tychewealth.testhelper.AuthTestHelper.logout;
 import static com.tychewealth.testhelper.AuthTestHelper.refresh;
+import static com.tychewealth.testhelper.AuthTestHelper.seedTrustedDevice;
 import static com.tychewealth.testhelper.UserTestHelper.passwordUpdateRequestBody;
 import static com.tychewealth.utils.Utils.sha256Hex;
 import static org.hamcrest.Matchers.containsString;
@@ -48,8 +49,10 @@ import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.helper.token.AccessTokenHelper;
+import jakarta.servlet.http.Cookie;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,15 +76,18 @@ class SecurityIntegrationTest {
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserRepository userRepository;
   @Autowired private RefreshTokenRepository refreshTokenRepository;
+  @Autowired private TrustedDeviceRepository trustedDeviceRepository;
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private AccessTokenHelper accessTokenHelper;
   @Autowired private RefreshRateLimitConfig rateLimitConfig;
 
   private LoginRequestDto validLoginRequest;
+  private Cookie trustedDeviceCookie;
 
   @BeforeEach
   void setUp() {
     refreshTokenRepository.deleteAll();
+    trustedDeviceRepository.deleteAll();
     userRepository.deleteAll();
     rateLimitConfig.resetAll();
 
@@ -90,7 +96,8 @@ class SecurityIntegrationTest {
     existingUser.setUsername(TEST_USERNAME_LAURA);
     existingUser.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
     existingUser.setVerified(true);
-    userRepository.save(existingUser);
+    UserEntity savedUser = userRepository.save(existingUser);
+    trustedDeviceCookie = seedTrustedDevice(trustedDeviceRepository, savedUser);
 
     validLoginRequest = new LoginRequestDto(TEST_EMAIL_LAURA, TEST_PASSWORD_VALID);
   }
@@ -102,6 +109,7 @@ class SecurityIntegrationTest {
             post(AUTH_LOGIN_URL)
                 .secure(true)
                 .contentType(MediaType.APPLICATION_JSON)
+                .cookie(trustedDeviceCookie)
                 .content(objectMapper.writeValueAsString(validLoginRequest)))
         .andExpect(status().isOk())
         .andExpect(header().string(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE))
@@ -127,6 +135,7 @@ class SecurityIntegrationTest {
             .perform(
                 post(AUTH_LOGIN_URL)
                     .contentType(MediaType.APPLICATION_JSON)
+                    .cookie(trustedDeviceCookie)
                     .content(objectMapper.writeValueAsString(validLoginRequest)))
             .andExpect(status().isOk())
             .andReturn();
@@ -211,7 +220,8 @@ class SecurityIntegrationTest {
 
   @Test
   void rotatedRefreshTokenCannotBeReused() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     String rotatedBody =
         refresh(mockMvc, objectMapper, loginResponse.getRefreshToken())
@@ -233,7 +243,8 @@ class SecurityIntegrationTest {
 
   @Test
   void loggedOutRefreshTokenCannotBeReused() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     logout(mockMvc, objectMapper, loginResponse.getRefreshToken())
         .andExpect(status().isNoContent());
@@ -245,7 +256,8 @@ class SecurityIntegrationTest {
 
   @Test
   void updatePasswordInvalidatesExistingRefreshTokenForAttacker() throws Exception {
-    LoginResponseDto loginResponse = login(mockMvc, objectMapper, validLoginRequest);
+    LoginResponseDto loginResponse =
+        login(mockMvc, objectMapper, validLoginRequest, trustedDeviceCookie);
 
     mockMvc
         .perform(

--- a/user-service/src/test/java/com/tychewealth/service/helper/token/AccessTokenHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/token/AccessTokenHelperTest.java
@@ -16,6 +16,7 @@ class AccessTokenHelperTest {
       "0123456789012345678901234567890123456789012345678901234567890123";
   private static final long TEST_ACCESS_TOKEN_TTL_SECONDS = 900;
   private static final long TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS = 86400;
+  private static final long TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS = 1800;
 
   private AccessTokenHelper accessTokenHelper;
 
@@ -23,7 +24,10 @@ class AccessTokenHelperTest {
   void setUp() {
     accessTokenHelper =
         new AccessTokenHelper(
-            TEST_JWT_SECRET, TEST_ACCESS_TOKEN_TTL_SECONDS, TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS);
+            TEST_JWT_SECRET,
+            TEST_ACCESS_TOKEN_TTL_SECONDS,
+            TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS);
   }
 
   @Test
@@ -56,5 +60,16 @@ class AccessTokenHelperTest {
     AuthTokenPayload verifyRegistrationToken = accessTokenHelper.generateVerifyEmailToken(user);
 
     assertEquals(TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS, verifyRegistrationToken.expiresIn());
+  }
+
+  @Test
+  void generateVerifyLoginDeviceTokenUsesDedicatedTtl() {
+    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
+    user.setId(42L);
+
+    AuthTokenPayload verifyLoginDeviceToken =
+        accessTokenHelper.generateVerifyLoginDeviceToken(user);
+
+    assertEquals(TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS, verifyLoginDeviceToken.expiresIn());
   }
 }

--- a/user-service/src/test/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelperTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import com.tychewealth.entity.TrustedDeviceEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import java.time.Instant;
@@ -90,6 +91,7 @@ class TrustedDeviceHelperTest {
             AuthException.class, () -> trustedDeviceHelper.createTrustedDeviceCookie(user));
 
     assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    assertEquals(ErrorDefinition.AUTH_TRUSTED_DEVICE_LIMIT_REACHED, exception.getErrorDefinition());
     verify(trustedDeviceRepository, never()).save(any(TrustedDeviceEntity.class));
   }
 }

--- a/user-service/src/test/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/trusteddevice/TrustedDeviceHelperTest.java
@@ -1,0 +1,95 @@
+package com.tychewealth.service.helper.trusteddevice;
+
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.entity.TrustedDeviceEntity;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.repository.TrustedDeviceRepository;
+import com.tychewealth.repository.UserRepository;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class TrustedDeviceHelperTest {
+
+  private static final Long TRUSTED_DEVICE_USER_ID = 7L;
+  private static final Long TRUSTED_DEVICE_LIMIT_USER_ID = 9L;
+
+  @Mock private TrustedDeviceRepository trustedDeviceRepository;
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private TrustedDeviceHelper trustedDeviceHelper;
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  void createTrustedDeviceCookieLocksUserBeforeCheckingQuotaAndSaving() {
+    UserEntity user = new UserEntity();
+    user.setId(TRUSTED_DEVICE_USER_ID);
+
+    when(userRepository.findByIdForUpdate(user.getId())).thenReturn(Optional.of(user));
+    when(trustedDeviceRepository.countByUserIdAndExpiresAtAfter(anyLong(), any(Instant.class)))
+        .thenReturn(0L);
+
+    var cookie = trustedDeviceHelper.createTrustedDeviceCookie(user);
+
+    ArgumentCaptor<TrustedDeviceEntity> trustedDeviceCaptor =
+        ArgumentCaptor.forClass(TrustedDeviceEntity.class);
+    InOrder inOrder = inOrder(userRepository, trustedDeviceRepository);
+    inOrder.verify(userRepository).findByIdForUpdate(user.getId());
+    inOrder
+        .verify(trustedDeviceRepository)
+        .deleteByUserIdAndExpiresAtBefore(anyLong(), any(Instant.class));
+    inOrder
+        .verify(trustedDeviceRepository)
+        .countByUserIdAndExpiresAtAfter(anyLong(), any(Instant.class));
+    inOrder.verify(trustedDeviceRepository).save(trustedDeviceCaptor.capture());
+
+    TrustedDeviceEntity savedTrustedDevice = trustedDeviceCaptor.getValue();
+    assertEquals(user, savedTrustedDevice.getUser());
+    assertNotNull(savedTrustedDevice.getTokenHash());
+    assertNotNull(savedTrustedDevice.getExpiresAt());
+    assertNotNull(savedTrustedDevice.getLastUsedAt());
+    assertEquals(TEST_TRUSTED_DEVICE_COOKIE_NAME, cookie.getName());
+  }
+
+  @Test
+  void createTrustedDeviceCookieThrowsConflictWhenQuotaIsReachedAfterLock() {
+    UserEntity user = new UserEntity();
+    user.setId(TRUSTED_DEVICE_LIMIT_USER_ID);
+
+    when(userRepository.findByIdForUpdate(user.getId())).thenReturn(Optional.of(user));
+    when(trustedDeviceRepository.countByUserIdAndExpiresAtAfter(anyLong(), any(Instant.class)))
+        .thenReturn(3L);
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class, () -> trustedDeviceHelper.createTrustedDeviceCookie(user));
+
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    verify(trustedDeviceRepository, never()).save(any(TrustedDeviceEntity.class));
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/testdata/EntityBuilder.java
+++ b/user-service/src/test/java/com/tychewealth/testdata/EntityBuilder.java
@@ -5,6 +5,7 @@ import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
 import com.tychewealth.entity.AssetEntity;
 import com.tychewealth.entity.PortfolioEntity;
 import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.TrustedDeviceEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.enums.AssetTypeEnum;
 import com.tychewealth.enums.CurrencyCodeEnum;
@@ -54,6 +55,16 @@ public final class EntityBuilder {
     refreshToken.setExpiresAt(expiresAt);
     refreshToken.setRevoked(revoked);
     return refreshToken;
+  }
+
+  public static TrustedDeviceEntity buildTrustedDevice(
+      String token, UserEntity user, Instant expiresAt, Instant lastUsedAt) {
+    TrustedDeviceEntity trustedDevice = new TrustedDeviceEntity();
+    trustedDevice.setUser(user);
+    trustedDevice.setTokenHash(Utils.sha256Hex(token));
+    trustedDevice.setExpiresAt(expiresAt);
+    trustedDevice.setLastUsedAt(lastUsedAt);
+    return trustedDevice;
   }
 
   public static AssetEntity buildAsset(

--- a/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
@@ -1,10 +1,17 @@
 package com.tychewealth.testhelper;
 
+import static com.tychewealth.constants.ApiConstants.AUTH_BASE_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_LOGIN_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_LOGOUT_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REGISTER_URL;
 import static com.tychewealth.constants.AuthConstants.*;
+import static com.tychewealth.constants.TestConstants.TEST_AUTH_TOKEN_PARAM;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_LOGIN_DEVICE_PATH;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_REGISTRATION_PATH;
+import static com.tychewealth.testdata.EntityBuilder.buildTrustedDevice;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -13,10 +20,8 @@ import com.tychewealth.dto.auth.LoginResponseDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
-import com.tychewealth.entity.TrustedDeviceEntity;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.repository.TrustedDeviceRepository;
-import com.tychewealth.utils.Utils;
 import jakarta.servlet.http.Cookie;
 import java.time.Instant;
 import java.util.UUID;
@@ -102,6 +107,40 @@ public final class AuthTestHelper {
     return mockMvc.perform(requestBuilder);
   }
 
+  public static ResultActions verifyRegistrationRequest(MockMvc mockMvc, String token)
+      throws Exception {
+    return verifyRegistrationRequest(mockMvc, token, null);
+  }
+
+  public static ResultActions verifyRegistrationRequest(
+      MockMvc mockMvc, String token, Cookie trustedDevice) throws Exception {
+    var requestBuilder =
+        get(AUTH_BASE_URL + TEST_VERIFY_REGISTRATION_PATH).param(TEST_AUTH_TOKEN_PARAM, token);
+
+    if (trustedDevice != null) {
+      requestBuilder.cookie(trustedDevice);
+    }
+
+    return mockMvc.perform(requestBuilder);
+  }
+
+  public static ResultActions verifyLoginDeviceRequest(MockMvc mockMvc, String token)
+      throws Exception {
+    return verifyLoginDeviceRequest(mockMvc, token, null);
+  }
+
+  public static ResultActions verifyLoginDeviceRequest(
+      MockMvc mockMvc, String token, Cookie trustedDevice) throws Exception {
+    var requestBuilder =
+        get(AUTH_BASE_URL + TEST_VERIFY_LOGIN_DEVICE_PATH).param(TEST_AUTH_TOKEN_PARAM, token);
+
+    if (trustedDevice != null) {
+      requestBuilder.cookie(trustedDevice);
+    }
+
+    return mockMvc.perform(requestBuilder);
+  }
+
   public static String buildLongEmail() {
     String local = "a".repeat(64);
     String label63 = "b".repeat(63);
@@ -112,14 +151,11 @@ public final class AuthTestHelper {
   public static Cookie seedTrustedDevice(
       TrustedDeviceRepository trustedDeviceRepository, UserEntity user) {
     String trustedDeviceToken = "trusted-device-" + UUID.randomUUID();
-
-    TrustedDeviceEntity trustedDevice = new TrustedDeviceEntity();
-    trustedDevice.setUser(user);
-    trustedDevice.setTokenHash(Utils.sha256Hex(trustedDeviceToken));
-    trustedDevice.setExpiresAt(Instant.now().plusSeconds(Integer.MAX_VALUE));
-    trustedDevice.setLastUsedAt(Instant.now());
+    Instant now = Instant.now();
+    var trustedDevice =
+        buildTrustedDevice(trustedDeviceToken, user, now.plusSeconds(Integer.MAX_VALUE), now);
     trustedDeviceRepository.save(trustedDevice);
 
-    return new Cookie("trusted_device", trustedDeviceToken);
+    return new Cookie(TEST_TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceToken);
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
@@ -13,6 +13,13 @@ import com.tychewealth.dto.auth.LoginResponseDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.entity.TrustedDeviceEntity;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.repository.TrustedDeviceRepository;
+import com.tychewealth.utils.Utils;
+import jakarta.servlet.http.Cookie;
+import java.time.Instant;
+import java.util.UUID;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -23,8 +30,14 @@ public final class AuthTestHelper {
 
   public static LoginResponseDto login(
       MockMvc mockMvc, ObjectMapper objectMapper, LoginRequestDto request) throws Exception {
+    return login(mockMvc, objectMapper, request, null);
+  }
+
+  public static LoginResponseDto login(
+      MockMvc mockMvc, ObjectMapper objectMapper, LoginRequestDto request, Cookie trustedDevice)
+      throws Exception {
     String responseBody =
-        loginRequest(mockMvc, objectMapper, request)
+        loginRequest(mockMvc, objectMapper, request, trustedDevice)
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -43,10 +56,22 @@ public final class AuthTestHelper {
 
   public static ResultActions loginRequest(
       MockMvc mockMvc, ObjectMapper objectMapper, LoginRequestDto request) throws Exception {
-    return mockMvc.perform(
+    return loginRequest(mockMvc, objectMapper, request, null);
+  }
+
+  public static ResultActions loginRequest(
+      MockMvc mockMvc, ObjectMapper objectMapper, LoginRequestDto request, Cookie trustedDevice)
+      throws Exception {
+    var requestBuilder =
         post(AUTH_LOGIN_URL)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(request)));
+            .content(objectMapper.writeValueAsString(request));
+
+    if (trustedDevice != null) {
+      requestBuilder.cookie(trustedDevice);
+    }
+
+    return mockMvc.perform(requestBuilder);
   }
 
   public static ResultActions refresh(
@@ -82,5 +107,19 @@ public final class AuthTestHelper {
     String label63 = "b".repeat(63);
     String domain = label63 + "." + label63 + "." + label63 + ".es";
     return local + "@" + domain;
+  }
+
+  public static Cookie seedTrustedDevice(
+      TrustedDeviceRepository trustedDeviceRepository, UserEntity user) {
+    String trustedDeviceToken = "trusted-device-" + UUID.randomUUID();
+
+    TrustedDeviceEntity trustedDevice = new TrustedDeviceEntity();
+    trustedDevice.setUser(user);
+    trustedDevice.setTokenHash(Utils.sha256Hex(trustedDeviceToken));
+    trustedDevice.setExpiresAt(Instant.now().plusSeconds(Integer.MAX_VALUE));
+    trustedDevice.setLastUsedAt(Instant.now());
+    trustedDeviceRepository.save(trustedDevice);
+
+    return new Cookie("trusted_device", trustedDeviceToken);
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testhelper/InMemoryRateLimitStore.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/InMemoryRateLimitStore.java
@@ -34,6 +34,11 @@ public class InMemoryRateLimitStore implements RateLimitStore {
   }
 
   @Override
+  public void clear(String namespace, String clientKey) {
+    counters.remove(buildKey(namespace, clientKey));
+  }
+
+  @Override
   public void resetNamespace(String namespace) {
     String prefix = namespace + ":";
     counters.keySet().removeIf(key -> key.startsWith(prefix));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device verification endpoint with email-based confirmation and trusted-device cookie issuance
  * Trusted-device management with persistent storage, limits, and cookie-based reuse
  * Email generation for login-device confirmation and token support for verification flows

* **Configuration**
  * Added device verification URL and token TTL properties

* **Database Schema**
  * Added trusted_devices table, sequence, indexes, and migrations

* **Tests**
  * Integration and unit tests extended for trusted-device flows and email cooldowns

* **Chores**
  * Rate-limit API gained a per-client clear operation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->