### PR TITLE
[TYCHE-29] add new token unitary tests

### DIFF
--- a/user-service/src/main/java/com/tychewealth/service/token/support/TokenStateSupport.java
+++ b/user-service/src/main/java/com/tychewealth/service/token/support/TokenStateSupport.java
@@ -5,15 +5,12 @@ import static com.tychewealth.constants.LogConstants.ACCESS_TOKEN_ACTION;
 import static com.tychewealth.constants.LogConstants.AUTH;
 import static com.tychewealth.constants.LogConstants.INVALID_AUTHORIZATION_HEADER_MESSAGE;
 import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
+import static com.tychewealth.utils.Utils.sha256Hex;
 
 import com.tychewealth.enums.AuthMetricEnum;
 import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.monitoring.AuthMetrics;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -34,7 +31,7 @@ public class TokenStateSupport {
   }
 
   public String buildRefreshTokenAccessTokenLinkKey(String refreshToken) {
-    return REFRESH_TOKEN_ACCESS_TOKEN_LINK_KEY_PREFIX + sha256(refreshToken);
+    return REFRESH_TOKEN_ACCESS_TOKEN_LINK_KEY_PREFIX + sha256Hex(refreshToken);
   }
 
   public Optional<String> findAccessTokenJtiByRefreshToken(
@@ -75,15 +72,5 @@ public class TokenStateSupport {
     }
 
     return token;
-  }
-
-  private String sha256(String refreshToken) {
-    try {
-      MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-      byte[] hash = messageDigest.digest(refreshToken.getBytes(StandardCharsets.UTF_8));
-      return HexFormat.of().formatHex(hash);
-    } catch (NoSuchAlgorithmException ex) {
-      throw new IllegalStateException("SHA-256 algorithm not available", ex);
-    }
   }
 }

--- a/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -19,7 +19,6 @@ public final class TestConstants {
   public static final String TEST_FIELD_CONFIRM_NEW_PASSWORD = "confirmNewPassword";
 
   public static final String TEST_UPDATE_USERNAME_REQUEST = "AfterUpdate";
-  public static final String TEST_UPDATE_USERNAME_NORMALIZED = "afterupdate";
   public static final String TEST_OCCUPIED_USERNAME = "occupiedname";
   public static final String TEST_OTHER_EMAIL = "otro.usuario@tychewealth.com";
 
@@ -50,6 +49,16 @@ public final class TestConstants {
   public static final String TEST_ATTACKER_BASIC_TOKEN = "Basic attacker-token";
   public static final String TEST_TAMPERED_TOKEN_SUFFIX = "tampered";
   public static final String TEST_AUTH_TOKEN_PARAM = "token";
+  public static final long TEST_USER_ID = 42L;
+  public static final String TEST_JWT_SECRET =
+      "0123456789012345678901234567890123456789012345678901234567890123";
+  public static final long TEST_ACCESS_TOKEN_TTL_SECONDS = 900L;
+  public static final long TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS = 86400L;
+  public static final long TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS = 1800L;
+  public static final long TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS = 3600L;
+  public static final String TEST_ACCESS_TOKEN = "access-token";
+  public static final String TEST_ACCESS_TOKEN_JTI = "jti-123";
+  public static final String TEST_BEARER_ACCESS_TOKEN = "Bearer access-token";
   public static final String TEST_VERIFY_REGISTRATION_PATH = "/verify-registration";
   public static final String TEST_VERIFY_LOGIN_DEVICE_PATH = "/verify-login-device";
   public static final String TEST_TRUSTED_DEVICE_COOKIE_NAME = "trusted_device";

--- a/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -4,7 +4,6 @@ public final class TestConstants {
 
   public static final String TEST_EMAIL_LAURA = "laura.gomez@tychewealth.com";
   public static final String TEST_EMAIL_VALID = "valid@tychewealth.com";
-  public static final String TEST_EMAIL_INVALID = "not-an-email";
   public static final String TEST_USERNAME_LAURA = "lauragomez";
   public static final String TEST_USERNAME_VALID = "validuser";
   public static final String TEST_USERNAME_TOO_SHORT = "ab";
@@ -24,31 +23,13 @@ public final class TestConstants {
 
   public static final String TEST_REFRESH_TOKEN_MISSING = "missing-token";
   public static final String TEST_REFRESH_TOKEN_EXISTING = "existing-refresh-token";
-  public static final String TEST_REFRESH_TOKEN_REVOKED = "revoked-refresh-token";
-  public static final String TEST_REFRESH_TOKEN_EXPIRED = "expired-refresh-token";
-  public static final String TEST_REFRESH_TOKEN_METRICS = "metrics-refresh-token";
   public static final String TEST_REFRESH_TOKEN_PEPPER = "test-refresh-token-pepper";
   public static final String TEST_RESEND_BASE_URL = "https://api.resend.com";
-  public static final String TEST_RESEND_API_KEY = "re_test_key";
-  public static final String TEST_RESEND_FROM = "Tyche Wealth <auth@tyche-wealth.com>";
   public static final String TEST_EMAIL_SUBJECT_VERIFY = "Verify your email";
   public static final String TEST_EMAIL_HTML_BODY = "<p>Hello</p>";
-  public static final String TEST_EMAIL_TEXT_BODY = "Hello";
-  public static final int TEST_EMAIL_DAILY_LIMIT = 2;
 
   public static final String TEST_PROMETHEUS_USERNAME = "prometheus";
   public static final String TEST_PROMETHEUS_PASSWORD = "secret";
-  public static final String TEST_MISSING_USERNAME = "missing";
-  public static final String TEST_PROMETHEUS_ROLE = "ROLE_PROMETHEUS";
-  public static final String TEST_PROMETHEUS_CREDENTIALS_ERROR =
-      "Prometheus username/password not configured";
-  public static final String TEST_HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
-  public static final String TEST_HEADER_X_FRAME_OPTIONS = "X-Frame-Options";
-  public static final String TEST_HEADER_REFERRER_POLICY = "Referrer-Policy";
-  public static final String TEST_HEADER_STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
-  public static final String TEST_ATTACKER_BASIC_TOKEN = "Basic attacker-token";
-  public static final String TEST_TAMPERED_TOKEN_SUFFIX = "tampered";
-  public static final String TEST_AUTH_TOKEN_PARAM = "token";
   public static final long TEST_USER_ID = 42L;
   public static final String TEST_JWT_SECRET =
       "0123456789012345678901234567890123456789012345678901234567890123";
@@ -60,20 +41,8 @@ public final class TestConstants {
   public static final String TEST_ACCESS_TOKEN_JTI = "jti-123";
   public static final String TEST_BEARER_ACCESS_TOKEN = "Bearer access-token";
   public static final String TEST_VERIFY_REGISTRATION_PATH = "/verify-registration";
-  public static final String TEST_VERIFY_LOGIN_DEVICE_PATH = "/verify-login-device";
   public static final String TEST_TRUSTED_DEVICE_COOKIE_NAME = "trusted_device";
   public static final String TEST_RATE_LIMIT_STORE_UNAVAILABLE = "store unavailable";
-  public static final String TEST_RATE_LIMIT_NAMESPACE = "namespace";
-  public static final String TEST_RATE_LIMIT_CLIENT = "client";
-  public static final String TEST_AUTH_RATE_LIMIT_LOGIN_NAMESPACE = "rate-limit:auth:login";
-  public static final String TEST_AUTH_RATE_LIMIT_REGISTER_NAMESPACE = "rate-limit:auth:register";
-  public static final String TEST_AUTH_RATE_LIMIT_REFRESH_NAMESPACE = "rate-limit:auth:refresh";
-  public static final String TEST_AUTH_RATE_LIMIT_FORGOT_PASSWORD_NAMESPACE =
-      "rate-limit:auth:forgot-password";
-  public static final String TEST_AUTH_RATE_LIMIT_RESEND_VERIFICATION_NAMESPACE =
-      "rate-limit:auth:resend-verification";
-  public static final String TEST_AUTH_RATE_LIMIT_VERIFY_LOGIN_DEVICE_NAMESPACE =
-      "rate-limit:auth:verify-login-device";
 
   private TestConstants() {}
 }

--- a/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthApiControllerIntegrationTest.java
@@ -28,11 +28,8 @@ import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_INVALID;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_EXISTING;
-import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_EXPIRED;
-import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_METRICS;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_MISSING;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
-import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_REVOKED;
 import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
 import static com.tychewealth.constants.TestConstants.TEST_VERIFY_REGISTRATION_PATH;
@@ -109,6 +106,9 @@ class AuthApiControllerIntegrationTest {
 
   private static final Pattern VERIFY_REGISTRATION_TOKEN_PATTERN =
       Pattern.compile("token=([^\"&]+)");
+  private static final String TEST_REFRESH_TOKEN_REVOKED = "revoked-refresh-token";
+  private static final String TEST_REFRESH_TOKEN_EXPIRED = "expired-refresh-token";
+  private static final String TEST_REFRESH_TOKEN_METRICS = "metrics-refresh-token";
 
   @Autowired private MockMvc mockMvc;
 

--- a/user-service/src/test/java/com/tychewealth/controller/UserApiControllerIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/UserApiControllerIntegrationTest.java
@@ -24,7 +24,6 @@ import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_INVALID;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_NEW_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
-import static com.tychewealth.constants.TestConstants.TEST_UPDATE_USERNAME_NORMALIZED;
 import static com.tychewealth.constants.TestConstants.TEST_UPDATE_USERNAME_REQUEST;
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
 import static com.tychewealth.constants.ValidationConstants.NEW_PASSWORD_AND_CONFIRM_MUST_MATCH;
@@ -60,6 +59,7 @@ import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.token.AccessTokenCodec;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
+import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -150,22 +150,24 @@ class UserApiControllerIntegrationTest {
   void updateChangesUsernameWhenUserIsAuthenticated() throws Exception {
     UserEntity saved = userRepository.save(existingUser);
     String accessToken = createAccessToken(accessTokenCodec, saved);
+    String normalizedUsername = TEST_UPDATE_USERNAME_REQUEST.toLowerCase(Locale.ROOT);
 
     updateRequest(mockMvc, objectMapper, accessToken, TEST_UPDATE_USERNAME_REQUEST)
         .andExpect(status().isOk())
         .andExpect(jsonPath("$." + FIELD_ID).value(saved.getId()))
         .andExpect(jsonPath("$." + FIELD_EMAIL).value(saved.getEmail()))
-        .andExpect(jsonPath("$." + FIELD_USERNAME).value(TEST_UPDATE_USERNAME_NORMALIZED));
+        .andExpect(jsonPath("$." + FIELD_USERNAME).value(normalizedUsername));
 
     UserEntity updatedUser = userRepository.findById(saved.getId()).orElseThrow();
-    assertEquals(TEST_UPDATE_USERNAME_NORMALIZED, updatedUser.getUsername());
+    assertEquals(normalizedUsername, updatedUser.getUsername());
   }
 
   @Test
   void updateReturnsUnauthorizedWhenUserIsNotAuthenticated() throws Exception {
     double unauthorizedBefore = counterValue(meterRegistry, METRIC_USER_UNAUTHORIZED);
+    String normalizedUsername = TEST_UPDATE_USERNAME_REQUEST.toLowerCase(Locale.ROOT);
 
-    updateRequestUnauthorized(mockMvc, objectMapper, TEST_UPDATE_USERNAME_NORMALIZED)
+    updateRequestUnauthorized(mockMvc, objectMapper, normalizedUsername)
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
@@ -200,8 +202,9 @@ class UserApiControllerIntegrationTest {
     userRepository.save(saved);
     String accessToken = createAccessToken(accessTokenCodec, saved);
     double notFoundBefore = counterValue(meterRegistry, METRIC_USER_NOT_FOUND);
+    String normalizedUsername = TEST_UPDATE_USERNAME_REQUEST.toLowerCase(Locale.ROOT);
 
-    updateRequest(mockMvc, objectMapper, accessToken, TEST_UPDATE_USERNAME_NORMALIZED)
+    updateRequest(mockMvc, objectMapper, accessToken, normalizedUsername)
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.USER_NOT_FOUND.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.USER_NOT_FOUND.getType()))

--- a/user-service/src/test/java/com/tychewealth/email/EmailSenderTest.java
+++ b/user-service/src/test/java/com/tychewealth/email/EmailSenderTest.java
@@ -3,14 +3,10 @@ package com.tychewealth.email;
 import static com.tychewealth.constants.ApiConstants.RESEND_EMAILS_PATH;
 import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER_PREFIX;
-import static com.tychewealth.constants.TestConstants.TEST_EMAIL_DAILY_LIMIT;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_HTML_BODY;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_SUBJECT_VERIFY;
-import static com.tychewealth.constants.TestConstants.TEST_EMAIL_TEXT_BODY;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_VALID;
-import static com.tychewealth.constants.TestConstants.TEST_RESEND_API_KEY;
 import static com.tychewealth.constants.TestConstants.TEST_RESEND_BASE_URL;
-import static com.tychewealth.constants.TestConstants.TEST_RESEND_FROM;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
@@ -39,6 +35,10 @@ class EmailSenderTest {
   private static final String SEND_EMAIL_REQUEST_FIXTURE =
       "/fixtures/email/send-email-request.json";
   private static final String NULL_JSON = "{}";
+  private static final String TEST_EMAIL_TEXT_BODY = "Hello";
+  private static final int TEST_EMAIL_DAILY_LIMIT = 2;
+  private static final String TEST_RESEND_API_KEY = "re_test_key";
+  private static final String TEST_RESEND_FROM = "Tyche Wealth <auth@tyche-wealth.com>";
 
   private MockRestServiceServer mockRestServiceServer;
   private EmailSender emailSender;

--- a/user-service/src/test/java/com/tychewealth/ratelimit/AuthRateLimitSupportTest.java
+++ b/user-service/src/test/java/com/tychewealth/ratelimit/AuthRateLimitSupportTest.java
@@ -5,12 +5,6 @@ import static com.tychewealth.constants.ApiConstants.AUTH_LOGIN_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REGISTER_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_RESEND_VERIFICATION_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_VERIFY_LOGIN_DEVICE_URL;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_RATE_LIMIT_FORGOT_PASSWORD_NAMESPACE;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_RATE_LIMIT_LOGIN_NAMESPACE;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_RATE_LIMIT_REFRESH_NAMESPACE;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_RATE_LIMIT_REGISTER_NAMESPACE;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_RATE_LIMIT_RESEND_VERIFICATION_NAMESPACE;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_RATE_LIMIT_VERIFY_LOGIN_DEVICE_NAMESPACE;
 import static com.tychewealth.constants.TestConstants.TEST_RATE_LIMIT_STORE_UNAVAILABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,6 +28,16 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.server.ResponseStatusException;
 
 class AuthRateLimitSupportTest {
+
+  private static final String TEST_AUTH_RATE_LIMIT_LOGIN_NAMESPACE = "rate-limit:auth:login";
+  private static final String TEST_AUTH_RATE_LIMIT_REGISTER_NAMESPACE = "rate-limit:auth:register";
+  private static final String TEST_AUTH_RATE_LIMIT_REFRESH_NAMESPACE = "rate-limit:auth:refresh";
+  private static final String TEST_AUTH_RATE_LIMIT_FORGOT_PASSWORD_NAMESPACE =
+      "rate-limit:auth:forgot-password";
+  private static final String TEST_AUTH_RATE_LIMIT_RESEND_VERIFICATION_NAMESPACE =
+      "rate-limit:auth:resend-verification";
+  private static final String TEST_AUTH_RATE_LIMIT_VERIFY_LOGIN_DEVICE_NAMESPACE =
+      "rate-limit:auth:verify-login-device";
 
   private AuthRateLimitSupport authRateLimitSupport;
   private AuthMetrics authMetrics;

--- a/user-service/src/test/java/com/tychewealth/ratelimit/RedisRateLimitStoreTest.java
+++ b/user-service/src/test/java/com/tychewealth/ratelimit/RedisRateLimitStoreTest.java
@@ -1,9 +1,6 @@
 package com.tychewealth.ratelimit;
 
 import static com.tychewealth.constants.RedisConstants.INCREMENT_WITH_TTL_SCRIPT;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_RATE_LIMIT_LOGIN_NAMESPACE;
-import static com.tychewealth.constants.TestConstants.TEST_RATE_LIMIT_CLIENT;
-import static com.tychewealth.constants.TestConstants.TEST_RATE_LIMIT_NAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -23,6 +20,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class RedisRateLimitStoreTest {
+
+  private static final String TEST_AUTH_RATE_LIMIT_LOGIN_NAMESPACE = "rate-limit:auth:login";
+  private static final String TEST_RATE_LIMIT_NAMESPACE = "namespace";
+  private static final String TEST_RATE_LIMIT_CLIENT = "client";
 
   @Mock private RedisTemplate<String, String> redisTemplate;
 

--- a/user-service/src/test/java/com/tychewealth/security/SecurityIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/security/SecurityIntegrationTest.java
@@ -11,16 +11,10 @@ import static com.tychewealth.constants.SecurityConstants.HEADER_VALUE_NOSNIFF;
 import static com.tychewealth.constants.SecurityConstants.HEADER_VALUE_NO_REFERRER;
 import static com.tychewealth.constants.SecurityConstants.HSTS_MAX_AGE_SECONDS;
 import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER_VALUE;
-import static com.tychewealth.constants.TestConstants.TEST_ATTACKER_BASIC_TOKEN;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
-import static com.tychewealth.constants.TestConstants.TEST_HEADER_REFERRER_POLICY;
-import static com.tychewealth.constants.TestConstants.TEST_HEADER_STRICT_TRANSPORT_SECURITY;
-import static com.tychewealth.constants.TestConstants.TEST_HEADER_X_CONTENT_TYPE_OPTIONS;
-import static com.tychewealth.constants.TestConstants.TEST_HEADER_X_FRAME_OPTIONS;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_NEW_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
-import static com.tychewealth.constants.TestConstants.TEST_TAMPERED_TOKEN_SUFFIX;
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
 import static com.tychewealth.testhelper.AuthTestHelper.login;
 import static com.tychewealth.testhelper.AuthTestHelper.logout;
@@ -72,6 +66,13 @@ import org.springframework.test.web.servlet.MvcResult;
 @ContextConfiguration(initializers = SecurityIntegrationTestConfig.Initializer.class)
 @AutoConfigureMockMvc
 class SecurityIntegrationTest {
+
+  private static final String TEST_HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+  private static final String TEST_HEADER_X_FRAME_OPTIONS = "X-Frame-Options";
+  private static final String TEST_HEADER_REFERRER_POLICY = "Referrer-Policy";
+  private static final String TEST_HEADER_STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
+  private static final String TEST_ATTACKER_BASIC_TOKEN = "Basic attacker-token";
+  private static final String TEST_TAMPERED_TOKEN_SUFFIX = "tampered";
 
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;

--- a/user-service/src/test/java/com/tychewealth/security/prometheus/PrometheusUserDetailsServiceTest.java
+++ b/user-service/src/test/java/com/tychewealth/security/prometheus/PrometheusUserDetailsServiceTest.java
@@ -1,9 +1,6 @@
 package com.tychewealth.security.prometheus;
 
-import static com.tychewealth.constants.TestConstants.TEST_MISSING_USERNAME;
-import static com.tychewealth.constants.TestConstants.TEST_PROMETHEUS_CREDENTIALS_ERROR;
 import static com.tychewealth.constants.TestConstants.TEST_PROMETHEUS_PASSWORD;
-import static com.tychewealth.constants.TestConstants.TEST_PROMETHEUS_ROLE;
 import static com.tychewealth.constants.TestConstants.TEST_PROMETHEUS_USERNAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,6 +15,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 class PrometheusUserDetailsServiceTest {
+
+  private static final String TEST_PROMETHEUS_CREDENTIALS_ERROR =
+      "Prometheus username/password not configured";
+  private static final String TEST_MISSING_USERNAME = "missing";
+  private static final String TEST_PROMETHEUS_ROLE = "ROLE_PROMETHEUS";
 
   private final PrometheusSecurityConfig securityConfig = new PrometheusSecurityConfig();
   private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();

--- a/user-service/src/test/java/com/tychewealth/service/token/AccessTokenCodecTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/AccessTokenCodecTest.java
@@ -45,7 +45,7 @@ class AccessTokenCodecTest {
         accessTokenCodec.extractUserId(
             accessTokenCodec.generateToken(user, AccessTokenType.ACCESS).token());
 
-    assertEquals(42L, userId);
+    assertEquals(TEST_USER_ID, userId);
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/service/token/AccessTokenCodecTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/AccessTokenCodecTest.java
@@ -1,26 +1,28 @@
-package com.tychewealth.service.helper.token;
+package com.tychewealth.service.token;
 
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_JWT_SECRET;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.tychewealth.dto.auth.AuthTokenDto;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.enums.AccessTokenType;
 import com.tychewealth.error.exception.AuthException;
-import com.tychewealth.service.token.AccessTokenCodec;
 import com.tychewealth.service.token.support.AccessTokenSupport;
 import com.tychewealth.testdata.EntityBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class AccessTokenCodecTest {
-
-  private static final String TEST_JWT_SECRET =
-      "0123456789012345678901234567890123456789012345678901234567890123";
-  private static final long TEST_ACCESS_TOKEN_TTL_SECONDS = 900;
-  private static final long TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS = 86400;
-  private static final long TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS = 1800;
-  private static final long TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS = 3600;
 
   private AccessTokenCodec accessTokenCodec;
 
@@ -37,8 +39,7 @@ class AccessTokenCodecTest {
 
   @Test
   void extractUserIdReturnsSubjectForNormalAccessToken() {
-    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
-    user.setId(42L);
+    UserEntity user = buildUser();
 
     Long userId =
         accessTokenCodec.extractUserId(
@@ -49,8 +50,7 @@ class AccessTokenCodecTest {
 
   @Test
   void extractUserIdRejectsVerifyRegistrationToken() {
-    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
-    user.setId(42L);
+    UserEntity user = buildUser();
 
     String verifyRegistrationToken =
         accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_EMAIL).token();
@@ -61,8 +61,7 @@ class AccessTokenCodecTest {
 
   @Test
   void generateVerifyEmailTokenUsesTwentyFourHourTtl() {
-    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
-    user.setId(42L);
+    UserEntity user = buildUser();
 
     AuthTokenDto verifyRegistrationToken =
         accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_EMAIL);
@@ -72,8 +71,7 @@ class AccessTokenCodecTest {
 
   @Test
   void generateVerifyLoginDeviceTokenUsesDedicatedTtl() {
-    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
-    user.setId(42L);
+    UserEntity user = buildUser();
 
     AuthTokenDto verifyLoginDeviceToken =
         accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE);
@@ -83,12 +81,28 @@ class AccessTokenCodecTest {
 
   @Test
   void generateForgotPasswordTokenUsesDedicatedTtl() {
-    UserEntity user = EntityBuilder.buildUser("valid@tychewealth.com", "valid-user", "password");
-    user.setId(42L);
+    UserEntity user = buildUser();
 
     AuthTokenDto forgotPasswordToken =
         accessTokenCodec.generateToken(user, AccessTokenType.FORGOT_PASSWORD);
 
     assertEquals(TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS, forgotPasswordToken.expiresIn());
+  }
+
+  @Test
+  void generateAccessTokenIncludesTokenId() {
+    UserEntity user = buildUser();
+
+    AuthTokenDto accessToken = accessTokenCodec.generateToken(user, AccessTokenType.ACCESS);
+
+    assertTrue(accessToken.jti() != null && !accessToken.jti().isBlank());
+    assertEquals(accessToken.jti(), accessTokenCodec.extractTokenId(accessToken.token()));
+  }
+
+  private UserEntity buildUser() {
+    UserEntity user =
+        EntityBuilder.buildUser(TEST_EMAIL_VALID, TEST_USERNAME_VALID, TEST_PASSWORD_VALID);
+    user.setId(TEST_USER_ID);
+    return user;
   }
 }

--- a/user-service/src/test/java/com/tychewealth/service/token/TokenStateStoreTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/TokenStateStoreTest.java
@@ -1,0 +1,157 @@
+package com.tychewealth.service.token;
+
+import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_TOKEN_STATE_UNAVAILABLE;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_BEARER_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_RATE_LIMIT_STORE_UNAVAILABLE;
+import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_EXISTING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.monitoring.AuthMetrics;
+import com.tychewealth.service.token.support.TokenStateSupport;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class TokenStateStoreTest {
+
+  @Mock private RedisTemplate<String, String> redisTemplate;
+  @Mock private AccessTokenCodec accessTokenCodec;
+
+  private SimpleMeterRegistry meterRegistry;
+  private AuthMetrics authMetrics;
+  private TokenStateSupport tokenStateSupport;
+  private TokenStateStore tokenStateStore;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    authMetrics = new AuthMetrics(meterRegistry);
+    tokenStateSupport = new TokenStateSupport();
+    tokenStateStore =
+        new TokenStateStore(redisTemplate, accessTokenCodec, authMetrics, tokenStateSupport);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  void revokeAccessTokenIfPresentDoesNothingWhenHeaderIsBlank() {
+    tokenStateStore.revokeAccessTokenIfPresent(" ");
+
+    verify(accessTokenCodec, never()).extractTokenId(any());
+  }
+
+  @Test
+  void revokeAccessTokenIfPresentRevokesTokenUsingExtractedData() {
+    Instant expiresAt = Instant.now().plusSeconds(60);
+    ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(accessTokenCodec.extractTokenId(TEST_ACCESS_TOKEN)).thenReturn(TEST_ACCESS_TOKEN_JTI);
+    when(accessTokenCodec.extractExpiration(TEST_ACCESS_TOKEN)).thenReturn(expiresAt);
+
+    tokenStateStore.revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+
+    verify(valueOperations)
+        .set(
+            eq(tokenStateSupport.buildAccessTokenRevocationKey(TEST_ACCESS_TOKEN_JTI)),
+            eq("revoked"),
+            any(Duration.class));
+  }
+
+  @Test
+  void revokeAccessTokenDoesNothingWhenTokenIsExpired() {
+    tokenStateStore.revokeAccessToken(TEST_ACCESS_TOKEN_JTI, Instant.now().minusSeconds(5));
+
+    verify(redisTemplate, never()).opsForValue();
+  }
+
+  @Test
+  void linkRefreshTokenToAccessTokenStoresJtiWithTtl() {
+    ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    tokenStateStore.linkRefreshTokenToAccessToken(
+        TEST_REFRESH_TOKEN_EXISTING, TEST_ACCESS_TOKEN_JTI, Instant.now().plusSeconds(60));
+
+    verify(valueOperations)
+        .set(
+            eq(tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING)),
+            eq(TEST_ACCESS_TOKEN_JTI),
+            any(Duration.class));
+  }
+
+  @Test
+  void findAccessTokenJtiByRefreshTokenDelegatesToSupport() {
+    ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.get(
+            tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING)))
+        .thenReturn(TEST_ACCESS_TOKEN_JTI);
+
+    Optional<String> result =
+        tokenStateStore.findAccessTokenJtiByRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+
+    assertTrue(result.isPresent());
+    assertEquals(TEST_ACCESS_TOKEN_JTI, result.orElseThrow());
+  }
+
+  @Test
+  void unlinkRefreshTokenDeletesImmediatelyWithoutTransaction() {
+    tokenStateStore.unlinkRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+
+    verify(redisTemplate)
+        .delete(tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING));
+  }
+
+  @Test
+  void unlinkRefreshTokenDeletesAfterCommitWhenTransactionIsActive() {
+    TransactionSynchronizationManager.initSynchronization();
+
+    tokenStateStore.unlinkRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+
+    for (TransactionSynchronization synchronization :
+        TransactionSynchronizationManager.getSynchronizations()) {
+      synchronization.afterCommit();
+    }
+
+    verify(redisTemplate)
+        .delete(tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING));
+  }
+
+  @Test
+  void isAccessTokenRevokedFailsClosedWhenRedisIsUnavailable() {
+    when(redisTemplate.hasKey(
+            tokenStateSupport.buildAccessTokenRevocationKey(TEST_ACCESS_TOKEN_JTI)))
+        .thenThrow(new IllegalStateException(TEST_RATE_LIMIT_STORE_UNAVAILABLE));
+
+    boolean revoked = tokenStateStore.isAccessTokenRevoked(TEST_ACCESS_TOKEN_JTI);
+
+    assertTrue(revoked);
+    assertEquals(1.0, meterRegistry.get(METRIC_AUTH_TOKEN_STATE_UNAVAILABLE).counter().count());
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/token/TokenStateStoreTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/TokenStateStoreTest.java
@@ -133,6 +133,8 @@ class TokenStateStoreTest {
     TransactionSynchronizationManager.initSynchronization();
 
     tokenStateStore.unlinkRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+    verify(redisTemplate, never())
+        .delete(tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING));
 
     for (TransactionSynchronization synchronization :
         TransactionSynchronizationManager.getSynchronizations()) {

--- a/user-service/src/test/java/com/tychewealth/service/token/TokenValidatorTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/TokenValidatorTest.java
@@ -1,0 +1,86 @@
+package com.tychewealth.service.token;
+
+import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_REFRESH_FAILURE;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_BEARER_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.monitoring.AuthMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TokenValidatorTest {
+
+  @Mock private AccessTokenCodec accessTokenCodec;
+  @Mock private TokenStateStore tokenStateStore;
+
+  private SimpleMeterRegistry meterRegistry;
+  private TokenValidator tokenValidator;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    AuthMetrics authMetrics = new AuthMetrics(meterRegistry);
+    tokenValidator = new TokenValidator(accessTokenCodec, tokenStateStore, authMetrics);
+  }
+
+  @Test
+  void validateAndExtractUserIdReturnsParsedUserIdWhenTokenIsNotRevoked() {
+    when(tokenStateStore.extractBearerToken(TEST_BEARER_ACCESS_TOKEN))
+        .thenReturn(TEST_ACCESS_TOKEN);
+    when(accessTokenCodec.parseAccessToken(TEST_ACCESS_TOKEN))
+        .thenReturn(new AccessTokenCodec.ParsedAccessToken(TEST_USER_ID, TEST_ACCESS_TOKEN_JTI));
+    when(tokenStateStore.isAccessTokenRevoked(TEST_ACCESS_TOKEN_JTI)).thenReturn(false);
+
+    Long userId = tokenValidator.validateAndExtractUserId(TEST_BEARER_ACCESS_TOKEN);
+
+    assertEquals(TEST_USER_ID, userId);
+  }
+
+  @Test
+  void validateAndExtractUserIdRejectsRevokedTokens() {
+    when(tokenStateStore.extractBearerToken(TEST_BEARER_ACCESS_TOKEN))
+        .thenReturn(TEST_ACCESS_TOKEN);
+    when(accessTokenCodec.parseAccessToken(TEST_ACCESS_TOKEN))
+        .thenReturn(new AccessTokenCodec.ParsedAccessToken(TEST_USER_ID, TEST_ACCESS_TOKEN_JTI));
+    when(tokenStateStore.isAccessTokenRevoked(TEST_ACCESS_TOKEN_JTI)).thenReturn(true);
+
+    assertThrows(
+        AuthException.class,
+        () -> tokenValidator.validateAndExtractUserId(TEST_BEARER_ACCESS_TOKEN));
+  }
+
+  @Test
+  void extractBearerTokenDelegatesToStateStore() {
+    when(tokenStateStore.extractBearerToken(TEST_BEARER_ACCESS_TOKEN))
+        .thenReturn(TEST_ACCESS_TOKEN);
+
+    String token = tokenValidator.extractBearerToken(TEST_BEARER_ACCESS_TOKEN);
+
+    assertEquals(TEST_ACCESS_TOKEN, token);
+    verify(tokenStateStore).extractBearerToken(TEST_BEARER_ACCESS_TOKEN);
+  }
+
+  @Test
+  void validateRefreshTokenRequestRejectsMissingRefreshToken() {
+    RefreshTokenRequestDto refreshTokenRequestDto = new RefreshTokenRequestDto(" ");
+
+    assertThrows(
+        AuthException.class,
+        () -> tokenValidator.validateRefreshTokenRequest(refreshTokenRequestDto));
+
+    assertEquals(1.0, meterRegistry.get(METRIC_AUTH_REFRESH_FAILURE).counter().count());
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/token/support/AccessTokenSupportTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/support/AccessTokenSupportTest.java
@@ -1,0 +1,91 @@
+package com.tychewealth.service.token.support;
+
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_JWT_SECRET;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AccessTokenType;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.service.token.AccessTokenCodec;
+import com.tychewealth.testdata.EntityBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AccessTokenSupportTest {
+
+  private AccessTokenSupport accessTokenSupport;
+  private AccessTokenCodec accessTokenCodec;
+
+  @BeforeEach
+  void setUp() {
+    accessTokenSupport = new AccessTokenSupport(TEST_JWT_SECRET);
+    accessTokenCodec =
+        new AccessTokenCodec(
+            accessTokenSupport,
+            TEST_ACCESS_TOKEN_TTL_SECONDS,
+            TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS,
+            TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS);
+  }
+
+  @Test
+  void requirePositiveTtlRejectsNonPositiveValues() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> accessTokenSupport.requirePositiveTtl(0, "app.auth.jwt.access-token-ttl-seconds"));
+  }
+
+  @Test
+  void extractVerifyEmailUserIdReturnsSubjectForVerifyEmailToken() {
+    UserEntity user = buildUser();
+
+    String token = accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_EMAIL).token();
+
+    assertEquals(42L, accessTokenSupport.extractVerifyEmailUserId(token));
+  }
+
+  @Test
+  void extractVerifyLoginDeviceUserIdReturnsSubjectForVerifyLoginDeviceToken() {
+    UserEntity user = buildUser();
+
+    String token =
+        accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE).token();
+
+    assertEquals(42L, accessTokenSupport.extractVerifyLoginDeviceUserId(token));
+  }
+
+  @Test
+  void extractTokenIdReturnsJwtId() {
+    UserEntity user = buildUser();
+
+    String token = accessTokenCodec.generateToken(user, AccessTokenType.ACCESS).token();
+
+    assertNotNull(accessTokenSupport.extractTokenId(token));
+  }
+
+  @Test
+  void extractUserIdRejectsPurposeBoundTokens() {
+    UserEntity user = buildUser();
+
+    String token = accessTokenCodec.generateToken(user, AccessTokenType.FORGOT_PASSWORD).token();
+
+    assertThrows(AuthException.class, () -> accessTokenSupport.extractUserId(token));
+  }
+
+  private UserEntity buildUser() {
+    UserEntity user =
+        EntityBuilder.buildUser(TEST_EMAIL_VALID, TEST_USERNAME_VALID, TEST_PASSWORD_VALID);
+    user.setId(TEST_USER_ID);
+    return user;
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/token/support/AccessTokenSupportTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/support/AccessTokenSupportTest.java
@@ -43,6 +43,9 @@ class AccessTokenSupportTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> accessTokenSupport.requirePositiveTtl(0, "app.auth.jwt.access-token-ttl-seconds"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> accessTokenSupport.requirePositiveTtl(-1, "app.auth.jwt.access-token-ttl-seconds"));
   }
 
   @Test
@@ -51,7 +54,7 @@ class AccessTokenSupportTest {
 
     String token = accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_EMAIL).token();
 
-    assertEquals(42L, accessTokenSupport.extractVerifyEmailUserId(token));
+    assertEquals(TEST_USER_ID, accessTokenSupport.extractVerifyEmailUserId(token));
   }
 
   @Test
@@ -61,7 +64,7 @@ class AccessTokenSupportTest {
     String token =
         accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE).token();
 
-    assertEquals(42L, accessTokenSupport.extractVerifyLoginDeviceUserId(token));
+    assertEquals(TEST_USER_ID, accessTokenSupport.extractVerifyLoginDeviceUserId(token));
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/service/token/support/TokenStateSupportTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/support/TokenStateSupportTest.java
@@ -1,0 +1,100 @@
+package com.tychewealth.service.token.support;
+
+import static com.tychewealth.constants.MetricConstants.METRIC_AUTH_TOKEN_STATE_UNAVAILABLE;
+import static com.tychewealth.constants.TestConstants.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.monitoring.AuthMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class TokenStateSupportTest {
+
+  private TokenStateSupport tokenStateSupport;
+  private RedisTemplate<String, String> redisTemplate;
+  private ValueOperations<String, String> valueOperations;
+  private SimpleMeterRegistry meterRegistry;
+  private AuthMetrics authMetrics;
+
+  @BeforeEach
+  void setUp() {
+    tokenStateSupport = new TokenStateSupport();
+    redisTemplate = mock(RedisTemplate.class);
+    valueOperations = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    meterRegistry = new SimpleMeterRegistry();
+    authMetrics = new AuthMetrics(meterRegistry);
+  }
+
+  @Test
+  void buildAccessTokenRevocationKeyPrefixesTokenId() {
+    assertEquals(
+        "auth:access-token:blacklist:jti:" + TEST_ACCESS_TOKEN_JTI,
+        tokenStateSupport.buildAccessTokenRevocationKey(TEST_ACCESS_TOKEN_JTI));
+  }
+
+  @Test
+  void buildRefreshTokenAccessTokenLinkKeyHashesRefreshToken() {
+    String key = tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING);
+
+    assertTrue(key.startsWith("auth:refresh-token:access-token-jti:"));
+    assertFalse(key.endsWith(TEST_REFRESH_TOKEN_EXISTING));
+  }
+
+  @Test
+  void findAccessTokenJtiByRefreshTokenReturnsStoredValue() {
+    when(valueOperations.get(
+            tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING)))
+        .thenReturn(TEST_ACCESS_TOKEN_JTI);
+
+    Optional<String> result =
+        tokenStateSupport.findAccessTokenJtiByRefreshToken(
+            redisTemplate, TEST_REFRESH_TOKEN_EXISTING);
+
+    assertEquals(Optional.of(TEST_ACCESS_TOKEN_JTI), result);
+  }
+
+  @Test
+  void isAccessTokenRevokedReturnsRedisResultWhenAvailable() {
+    when(redisTemplate.hasKey(
+            tokenStateSupport.buildAccessTokenRevocationKey(TEST_ACCESS_TOKEN_JTI)))
+        .thenReturn(true);
+
+    assertTrue(
+        tokenStateSupport.isAccessTokenRevoked(redisTemplate, authMetrics, TEST_ACCESS_TOKEN_JTI));
+  }
+
+  @Test
+  void isAccessTokenRevokedFailsClosedWhenRedisThrows() {
+    when(redisTemplate.hasKey(
+            tokenStateSupport.buildAccessTokenRevocationKey(TEST_ACCESS_TOKEN_JTI)))
+        .thenThrow(new IllegalStateException(TEST_RATE_LIMIT_STORE_UNAVAILABLE));
+
+    boolean revoked =
+        tokenStateSupport.isAccessTokenRevoked(redisTemplate, authMetrics, TEST_ACCESS_TOKEN_JTI);
+
+    assertTrue(revoked);
+    assertEquals(1.0, meterRegistry.get(METRIC_AUTH_TOKEN_STATE_UNAVAILABLE).counter().count());
+  }
+
+  @Test
+  void extractBearerTokenRejectsInvalidHeaders() {
+    assertThrows(
+        AuthException.class, () -> tokenStateSupport.extractBearerToken(TEST_ACCESS_TOKEN));
+  }
+
+  @Test
+  void extractBearerTokenReturnsTrimmedToken() {
+    assertEquals(TEST_ACCESS_TOKEN, tokenStateSupport.extractBearerToken(TEST_BEARER_ACCESS_TOKEN));
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/token/support/TokenStateSupportTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/token/support/TokenStateSupportTest.java
@@ -47,7 +47,7 @@ class TokenStateSupportTest {
   void buildRefreshTokenAccessTokenLinkKeyHashesRefreshToken() {
     String key = tokenStateSupport.buildRefreshTokenAccessTokenLinkKey(TEST_REFRESH_TOKEN_EXISTING);
 
-    assertTrue(key.startsWith("auth:refresh-token:access-token-jti:"));
+    assertTrue(key.matches("^auth:refresh-token:access-token-jti:[a-f0-9]{64}$"));
     assertFalse(key.endsWith(TEST_REFRESH_TOKEN_EXISTING));
   }
 

--- a/user-service/src/test/java/com/tychewealth/service/trusteddevice/TrustedDeviceManagerTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/trusteddevice/TrustedDeviceManagerTest.java
@@ -1,4 +1,4 @@
-package com.tychewealth.trusteddevice;
+package com.tychewealth.service.trusteddevice;
 
 import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,7 +17,6 @@ import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
-import com.tychewealth.service.trusteddevice.TrustedDeviceManager;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;

--- a/user-service/src/test/java/com/tychewealth/testdata/AuthTestData.java
+++ b/user-service/src/test/java/com/tychewealth/testdata/AuthTestData.java
@@ -1,6 +1,5 @@
 package com.tychewealth.testdata;
 
-import static com.tychewealth.constants.TestConstants.TEST_EMAIL_INVALID;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_LOWERCASE_ONLY;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_TOO_SHORT;
@@ -22,6 +21,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public final class AuthTestData {
+
+  private static final String TEST_EMAIL_INVALID = "not-an-email";
 
   private AuthTestData() {}
 

--- a/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
@@ -6,9 +6,7 @@ import static com.tychewealth.constants.ApiConstants.AUTH_LOGOUT_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REFRESH_URL;
 import static com.tychewealth.constants.ApiConstants.AUTH_REGISTER_URL;
 import static com.tychewealth.constants.AuthConstants.*;
-import static com.tychewealth.constants.TestConstants.TEST_AUTH_TOKEN_PARAM;
 import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
-import static com.tychewealth.constants.TestConstants.TEST_VERIFY_LOGIN_DEVICE_PATH;
 import static com.tychewealth.constants.TestConstants.TEST_VERIFY_REGISTRATION_PATH;
 import static com.tychewealth.testdata.EntityBuilder.buildTrustedDevice;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,6 +28,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 public final class AuthTestHelper {
+
+  private static final String TEST_AUTH_TOKEN_PARAM = "token";
+  private static final String TEST_VERIFY_LOGIN_DEVICE_PATH = "/verify-login-device";
 
   private AuthTestHelper() {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad test coverage for token state, revocation, refresh-token linking, and Redis failure handling.
  * Added token validation and extraction tests, plus checks that generated tokens include stable identifiers.
  * Updated many tests to use consolidated shared test fixtures/constants (kept behavior unchanged).

* **Refactor**
  * Replaced an in-class SHA-256 implementation with a shared utility for computing token-related hashes.

Closes #59 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->