### PR TITLE
[TYCHE-31] add new auth unitary tests

### DIFF
--- a/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/user-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -20,13 +20,16 @@ public final class TestConstants {
   public static final String TEST_UPDATE_USERNAME_REQUEST = "AfterUpdate";
   public static final String TEST_OCCUPIED_USERNAME = "occupiedname";
   public static final String TEST_OTHER_EMAIL = "otro.usuario@tychewealth.com";
+  public static final String TEST_MISSING_EMAIL = "missing@tychewealth.com";
 
   public static final String TEST_REFRESH_TOKEN_MISSING = "missing-token";
   public static final String TEST_REFRESH_TOKEN_EXISTING = "existing-refresh-token";
   public static final String TEST_REFRESH_TOKEN_PEPPER = "test-refresh-token-pepper";
   public static final String TEST_RESEND_BASE_URL = "https://api.resend.com";
   public static final String TEST_EMAIL_SUBJECT_VERIFY = "Verify your email";
+  public static final String TEST_EMAIL_SUBJECT_RESET_PASSWORD = "Reset your password";
   public static final String TEST_EMAIL_HTML_BODY = "<p>Hello</p>";
+  public static final String TEST_EMAIL_TEXT_BODY = "body";
 
   public static final String TEST_PROMETHEUS_USERNAME = "prometheus";
   public static final String TEST_PROMETHEUS_PASSWORD = "secret";
@@ -37,9 +40,14 @@ public final class TestConstants {
   public static final long TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS = 86400L;
   public static final long TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS = 1800L;
   public static final long TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS = 3600L;
+  public static final String TEST_VERIFY_EMAIL_TOKEN = "verify-email-token";
+  public static final String TEST_VERIFY_LOGIN_DEVICE_TOKEN = "verify-login-device-token";
+  public static final String TEST_FORGOT_PASSWORD_TOKEN = "forgot-token";
   public static final String TEST_ACCESS_TOKEN = "access-token";
+  public static final String TEST_ENCODED_PASSWORD = "encoded-password";
   public static final String TEST_ACCESS_TOKEN_JTI = "jti-123";
   public static final String TEST_BEARER_ACCESS_TOKEN = "Bearer access-token";
+  public static final String TEST_TRUSTED_DEVICE_TOKEN = "trusted-device-token";
   public static final String TEST_VERIFY_REGISTRATION_PATH = "/verify-registration";
   public static final String TEST_TRUSTED_DEVICE_COOKIE_NAME = "trusted_device";
   public static final String TEST_RATE_LIMIT_STORE_UNAVAILABLE = "store unavailable";

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthForgotPasswordHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthForgotPasswordHelperTest.java
@@ -1,5 +1,16 @@
 package com.tychewealth.service.helper.auth;
 
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_HTML_BODY;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_SUBJECT_RESET_PASSWORD;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_TEXT_BODY;
+import static com.tychewealth.constants.TestConstants.TEST_FORGOT_PASSWORD_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_MISSING_EMAIL;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -40,24 +51,31 @@ class AuthForgotPasswordHelperTest {
 
   @Test
   void forgotPasswordReturnsSilentlyWhenUserDoesNotExist() {
-    when(userRepository.findByEmailAndDeletedAtIsNull("missing@tychewealth.com"))
+    when(userRepository.findByEmailAndDeletedAtIsNull(TEST_MISSING_EMAIL))
         .thenReturn(Optional.empty());
 
-    authForgotPasswordHelper.forgotPassword(
-        new ForgotPasswordRequestDto("missing@tychewealth.com"));
+    authForgotPasswordHelper.forgotPassword(new ForgotPasswordRequestDto(TEST_MISSING_EMAIL));
 
     verify(emailSender, never()).send(any());
   }
 
   @Test
   void forgotPasswordDoesNotResendEmailWhilePreviousTokenIsStillActive() {
-    UserEntity user = new UserEntity();
-    user.setId(42L);
-    user.setEmail("laura.gomez@tychewealth.com");
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
+    user.setId(TEST_USER_ID);
 
-    AuthTokenDto token = new AuthTokenDto("Bearer", "forgot-token", 900L, "jti-1");
+    AuthTokenDto token =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_FORGOT_PASSWORD_TOKEN,
+            TEST_FORGOT_PASSWORD_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
     EmailMessageDto emailMessage =
-        new EmailMessageDto(user.getEmail(), "Reset your password", "<p>body</p>", "body");
+        new EmailMessageDto(
+            user.getEmail(),
+            TEST_EMAIL_SUBJECT_RESET_PASSWORD,
+            TEST_EMAIL_HTML_BODY,
+            TEST_EMAIL_TEXT_BODY);
 
     when(userRepository.findByEmailAndDeletedAtIsNull(user.getEmail()))
         .thenReturn(Optional.of(user));

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthLoginHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthLoginHelperTest.java
@@ -1,0 +1,285 @@
+package com.tychewealth.service.helper.auth;
+
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.LogConstants.LOGIN_ACTION;
+import static com.tychewealth.constants.RedisConstants.AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_HTML_BODY;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_SUBJECT_VERIFY;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_TEXT_BODY;
+import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_EXISTING;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_LOGIN_DEVICE_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.auth.AuthTokenDto;
+import com.tychewealth.dto.auth.LoginResponseDto;
+import com.tychewealth.dto.email.request.EmailMessageDto;
+import com.tychewealth.dto.user.UserResponseDto;
+import com.tychewealth.email.EmailSender;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AccessTokenType;
+import com.tychewealth.enums.AuthMetricEnum;
+import com.tychewealth.enums.EmailSendResult;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.exception.EmailException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.mapper.user.UserMapper;
+import com.tychewealth.monitoring.AuthMetrics;
+import com.tychewealth.ratelimit.RateLimitStore;
+import com.tychewealth.service.email.AuthEmailFactory;
+import com.tychewealth.service.token.AccessTokenCodec;
+import com.tychewealth.service.trusteddevice.TrustedDeviceManager;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AuthLoginHelperTest {
+
+  @Mock private AccessTokenCodec accessTokenCodec;
+  @Mock private AuthRefreshTokenHelper refreshTokenHelper;
+  @Mock private TrustedDeviceManager trustedDeviceManager;
+  @Mock private AuthEmailFactory authEmailFactory;
+  @Mock private EmailSender emailSender;
+  @Mock private RateLimitStore rateLimitStore;
+  @Mock private UserMapper userMapper;
+
+  private SimpleMeterRegistry meterRegistry;
+  private AuthLoginHelper authLoginHelper;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    authLoginHelper =
+        new AuthLoginHelper(
+            accessTokenCodec,
+            refreshTokenHelper,
+            trustedDeviceManager,
+            authEmailFactory,
+            emailSender,
+            rateLimitStore,
+            userMapper,
+            new AuthMetrics(meterRegistry));
+  }
+
+  @Test
+  void loginReturnsTokensAndUserWhenCurrentDeviceIsTrusted() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    UserResponseDto responseDto =
+        new UserResponseDto(TEST_USER_ID, TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    AuthTokenDto accessToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_ACCESS_TOKEN,
+            TEST_ACCESS_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    AuthRefreshTokenHelper.LinkedRefreshToken refreshToken =
+        new AuthRefreshTokenHelper.LinkedRefreshToken(TEST_REFRESH_TOKEN_EXISTING, null);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(true);
+    when(userMapper.toDto(user)).thenReturn(responseDto);
+    when(accessTokenCodec.generateToken(user, AccessTokenType.ACCESS)).thenReturn(accessToken);
+    when(refreshTokenHelper.saveToken(user, TEST_ACCESS_TOKEN_JTI, LOGIN_ACTION))
+        .thenReturn(refreshToken);
+
+    LoginResponseDto result = authLoginHelper.login(user);
+
+    assertEquals(TOKEN_TYPE_BEARER, result.getTokenType());
+    assertEquals(TEST_ACCESS_TOKEN, result.getAccessToken());
+    assertEquals(TEST_REFRESH_TOKEN_EXISTING, result.getRefreshToken());
+    assertEquals(TEST_ACCESS_TOKEN_TTL_SECONDS, result.getExpiresIn());
+    assertSame(responseDto, result.getUser());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.LOGIN_SUCCESS.metricName()));
+
+    verify(refreshTokenHelper).revokeActiveTokensByUserId(TEST_USER_ID);
+    verify(refreshTokenHelper).saveToken(user, TEST_ACCESS_TOKEN_JTI, LOGIN_ACTION);
+    verifyNoInteractions(authEmailFactory, emailSender, rateLimitStore);
+  }
+
+  @Test
+  void loginThrowsConflictWhenDeviceIsUntrustedAndTrustedDeviceLimitIsReached() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(false);
+    when(trustedDeviceManager.hasReachedTrustedDeviceLimit(TEST_USER_ID)).thenReturn(true);
+
+    AuthException exception = assertThrows(AuthException.class, () -> authLoginHelper.login(user));
+
+    assertEquals(ErrorDefinition.AUTH_TRUSTED_DEVICE_LIMIT_REACHED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    verifyNoInteractions(
+        accessTokenCodec, refreshTokenHelper, authEmailFactory, emailSender, rateLimitStore);
+  }
+
+  @Test
+  void loginSendsVerificationEmailAndThrowsForbiddenWhenDeviceIsUntrusted() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    EmailMessageDto emailMessage =
+        new EmailMessageDto(
+            TEST_EMAIL_LAURA,
+            TEST_EMAIL_SUBJECT_VERIFY,
+            TEST_EMAIL_HTML_BODY,
+            TEST_EMAIL_TEXT_BODY);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(false);
+    when(trustedDeviceManager.hasReachedTrustedDeviceLimit(TEST_USER_ID)).thenReturn(false);
+    when(rateLimitStore.increment(
+            AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE,
+            String.valueOf(TEST_USER_ID),
+            java.time.Duration.ofDays(1)))
+        .thenReturn(1L);
+    when(accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE))
+        .thenReturn(verificationToken);
+    when(authEmailFactory.buildVerifyLoginDeviceEmailMessage(
+            TEST_EMAIL_LAURA,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS))
+        .thenReturn(emailMessage);
+    when(emailSender.send(emailMessage)).thenReturn(EmailSendResult.DELIVERED);
+
+    AuthException exception = assertThrows(AuthException.class, () -> authLoginHelper.login(user));
+
+    assertEquals(
+        ErrorDefinition.AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.FORBIDDEN, exception.getHttpStatus());
+    verify(emailSender).send(emailMessage);
+    verify(refreshTokenHelper, never()).revokeActiveTokensByUserId(TEST_USER_ID);
+  }
+
+  @Test
+  void loginThrowsForbiddenWithoutSendingEmailWhenCooldownIsActive() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(false);
+    when(trustedDeviceManager.hasReachedTrustedDeviceLimit(TEST_USER_ID)).thenReturn(false);
+    when(rateLimitStore.increment(
+            AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE,
+            String.valueOf(TEST_USER_ID),
+            java.time.Duration.ofDays(1)))
+        .thenReturn(2L);
+
+    AuthException exception = assertThrows(AuthException.class, () -> authLoginHelper.login(user));
+
+    assertEquals(
+        ErrorDefinition.AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.FORBIDDEN, exception.getHttpStatus());
+    verifyNoInteractions(accessTokenCodec, authEmailFactory, emailSender);
+    verify(refreshTokenHelper, never()).revokeActiveTokensByUserId(TEST_USER_ID);
+  }
+
+  @Test
+  void loginThrowsEmailExceptionAndRollsBackCooldownWhenDeliveryIsSkippedByQuota() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    EmailMessageDto emailMessage =
+        new EmailMessageDto(
+            TEST_EMAIL_LAURA,
+            TEST_EMAIL_SUBJECT_VERIFY,
+            TEST_EMAIL_HTML_BODY,
+            TEST_EMAIL_TEXT_BODY);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(false);
+    when(trustedDeviceManager.hasReachedTrustedDeviceLimit(TEST_USER_ID)).thenReturn(false);
+    when(rateLimitStore.increment(
+            AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE,
+            String.valueOf(TEST_USER_ID),
+            java.time.Duration.ofDays(1)))
+        .thenReturn(1L);
+    when(accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE))
+        .thenReturn(verificationToken);
+    when(authEmailFactory.buildVerifyLoginDeviceEmailMessage(
+            TEST_EMAIL_LAURA,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS))
+        .thenReturn(emailMessage);
+    when(emailSender.send(emailMessage)).thenReturn(EmailSendResult.SKIPPED_DAILY_QUOTA);
+
+    EmailException exception =
+        assertThrows(EmailException.class, () -> authLoginHelper.login(user));
+
+    assertEquals(ErrorDefinition.EMAIL_DELIVERY_FAILED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getHttpStatus());
+    verify(rateLimitStore)
+        .clear(AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE, String.valueOf(TEST_USER_ID));
+    verify(refreshTokenHelper, never()).revokeActiveTokensByUserId(TEST_USER_ID);
+  }
+
+  @Test
+  void loginRethrowsSendFailureAndRollsBackCooldown() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    EmailMessageDto emailMessage =
+        new EmailMessageDto(
+            TEST_EMAIL_LAURA,
+            TEST_EMAIL_SUBJECT_VERIFY,
+            TEST_EMAIL_HTML_BODY,
+            TEST_EMAIL_TEXT_BODY);
+    EmailException sendException =
+        EmailException.of(
+            ErrorDefinition.EMAIL_DELIVERY_FAILED, null, HttpStatus.INTERNAL_SERVER_ERROR);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(false);
+    when(trustedDeviceManager.hasReachedTrustedDeviceLimit(TEST_USER_ID)).thenReturn(false);
+    when(rateLimitStore.increment(
+            AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE,
+            String.valueOf(TEST_USER_ID),
+            java.time.Duration.ofDays(1)))
+        .thenReturn(1L);
+    when(accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE))
+        .thenReturn(verificationToken);
+    when(authEmailFactory.buildVerifyLoginDeviceEmailMessage(
+            TEST_EMAIL_LAURA,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS))
+        .thenReturn(emailMessage);
+    when(emailSender.send(emailMessage)).thenThrow(sendException);
+
+    EmailException exception =
+        assertThrows(EmailException.class, () -> authLoginHelper.login(user));
+
+    assertSame(sendException, exception);
+    verify(rateLimitStore)
+        .clear(AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE, String.valueOf(TEST_USER_ID));
+    verify(refreshTokenHelper, never()).revokeActiveTokensByUserId(TEST_USER_ID);
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthRefreshTokenHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthRefreshTokenHelperTest.java
@@ -1,0 +1,173 @@
+package com.tychewealth.service.helper.auth;
+
+import static com.tychewealth.constants.LogConstants.LOGIN_ACTION;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_RATE_LIMIT_STORE_UNAVAILABLE;
+import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_EXISTING;
+import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AuthMetricEnum;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.monitoring.AuthMetrics;
+import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.service.token.TokenStateStore;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AuthRefreshTokenHelperTest {
+
+  private static final long TEST_REFRESH_TOKEN_TTL_SECONDS = 1209600L;
+
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private TokenStateStore tokenStateStore;
+
+  private SimpleMeterRegistry meterRegistry;
+  private AuthRefreshTokenHelper authRefreshTokenHelper;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    authRefreshTokenHelper =
+        new AuthRefreshTokenHelper(
+            refreshTokenRepository,
+            tokenStateStore,
+            new AuthMetrics(meterRegistry),
+            TEST_REFRESH_TOKEN_TTL_SECONDS,
+            TEST_REFRESH_TOKEN_PEPPER);
+  }
+
+  @Test
+  void saveTokenPersistsRefreshTokenLinksStateAndReturnsIssuedToken() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    ArgumentCaptor<RefreshTokenEntity> entityCaptor =
+        ArgumentCaptor.forClass(RefreshTokenEntity.class);
+    ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Instant> expiresAtCaptor = ArgumentCaptor.forClass(Instant.class);
+
+    AuthRefreshTokenHelper.LinkedRefreshToken result =
+        authRefreshTokenHelper.saveToken(user, TEST_ACCESS_TOKEN_JTI, LOGIN_ACTION);
+
+    assertNotNull(result.token());
+    assertNotNull(result.expiresAt());
+    assertTrue(result.expiresAt().isAfter(Instant.now()));
+
+    verify(refreshTokenRepository).save(entityCaptor.capture());
+    verify(tokenStateStore)
+        .linkRefreshTokenToAccessToken(
+            tokenCaptor.capture(),
+            org.mockito.ArgumentMatchers.eq(TEST_ACCESS_TOKEN_JTI),
+            expiresAtCaptor.capture());
+
+    RefreshTokenEntity persisted = entityCaptor.getValue();
+    assertSame(user, persisted.getUser());
+    assertEquals(authRefreshTokenHelper.hashRefreshToken(result.token()), persisted.getToken());
+    assertEquals(result.expiresAt(), persisted.getExpiresAt());
+    assertEquals(false, persisted.isRevoked());
+    assertEquals(result.token(), tokenCaptor.getValue());
+    assertEquals(result.expiresAt(), expiresAtCaptor.getValue());
+    assertEquals(
+        1.0, counterValue(meterRegistry, AuthMetricEnum.REFRESH_TOKEN_ISSUED.metricName()));
+  }
+
+  @Test
+  void saveTokenRollsBackAndThrowsWhenLinkingStateFailsRepeatedly() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    ArgumentCaptor<RefreshTokenEntity> entityCaptor =
+        ArgumentCaptor.forClass(RefreshTokenEntity.class);
+
+    org.mockito.Mockito.doThrow(new IllegalStateException(TEST_RATE_LIMIT_STORE_UNAVAILABLE))
+        .when(tokenStateStore)
+        .linkRefreshTokenToAccessToken(anyString(), anyString(), any(Instant.class));
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () -> authRefreshTokenHelper.saveToken(user, TEST_ACCESS_TOKEN_JTI, LOGIN_ACTION));
+
+    verify(refreshTokenRepository).save(entityCaptor.capture());
+    verify(refreshTokenRepository).deleteByToken(entityCaptor.getValue().getToken());
+    assertEquals(ErrorDefinition.GENERIC_INTERNAL_ERROR, exception.getErrorDefinition());
+    assertEquals(HttpStatus.SERVICE_UNAVAILABLE, exception.getHttpStatus());
+    assertEquals(
+        1.0, counterValue(meterRegistry, AuthMetricEnum.TOKEN_STATE_UNAVAILABLE.metricName()));
+  }
+
+  @Test
+  void revokeActiveTokensByUserIdReturnsRevokedCountAndIncrementsMetric() {
+    when(refreshTokenRepository.revokeActiveTokensByUserId(
+            org.mockito.ArgumentMatchers.eq(TEST_USER_ID), any(Instant.class)))
+        .thenReturn(3);
+
+    int result = authRefreshTokenHelper.revokeActiveTokensByUserId(TEST_USER_ID);
+
+    assertEquals(3, result);
+    assertEquals(
+        3.0, counterValue(meterRegistry, AuthMetricEnum.REFRESH_TOKEN_REVOKED.metricName()));
+  }
+
+  @Test
+  void validateRefreshTokenReturnsEntityWhenTokenIsActive() {
+    RefreshTokenEntity refreshTokenEntity = new RefreshTokenEntity();
+    String hashedToken = authRefreshTokenHelper.hashRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+
+    when(refreshTokenRepository.revokeTokenIfActive(
+            org.mockito.ArgumentMatchers.eq(hashedToken), any(Instant.class)))
+        .thenReturn(1);
+    when(refreshTokenRepository.findByToken(hashedToken))
+        .thenReturn(Optional.of(refreshTokenEntity));
+
+    RefreshTokenEntity result =
+        authRefreshTokenHelper.validateRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+
+    assertSame(refreshTokenEntity, result);
+    assertEquals(
+        1.0, counterValue(meterRegistry, AuthMetricEnum.REFRESH_TOKEN_REVOKED.metricName()));
+  }
+
+  @Test
+  void validateRefreshTokenThrowsUnauthorizedWhenTokenIsInvalid() {
+    String hashedToken = authRefreshTokenHelper.hashRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+    when(refreshTokenRepository.revokeTokenIfActive(
+            org.mockito.ArgumentMatchers.eq(hashedToken), any(Instant.class)))
+        .thenReturn(0);
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () -> authRefreshTokenHelper.validateRefreshToken(TEST_REFRESH_TOKEN_EXISTING));
+
+    assertEquals(ErrorDefinition.AUTH_REFRESH_TOKEN_INVALID, exception.getErrorDefinition());
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REFRESH_FAILURE.metricName()));
+    assertEquals(
+        0.0, counterValue(meterRegistry, AuthMetricEnum.REFRESH_TOKEN_REVOKED.metricName()));
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthRegisterHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthRegisterHelperTest.java
@@ -1,0 +1,86 @@
+package com.tychewealth.service.helper.auth;
+
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_ENCODED_PASSWORD;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.auth.AuthTokenDto;
+import com.tychewealth.dto.auth.RegisteredUserResultDto;
+import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.user.UserResponseDto;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AccessTokenType;
+import com.tychewealth.mapper.user.UserMapper;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.token.AccessTokenCodec;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthRegisterHelperTest {
+
+  private static final Instant TEST_VERIFICATION_TOKEN_EXPIRES_AT =
+      Instant.parse("2026-04-02T12:00:00Z");
+
+  @Mock private UserRepository userRepository;
+  @Mock private UserMapper userMapper;
+  @Mock private PasswordEncoder passwordEncoder;
+  @Mock private AccessTokenCodec accessTokenCodec;
+
+  @InjectMocks private AuthRegisterHelper authRegisterHelper;
+
+  @Test
+  void createUserEncodesPasswordPersistsUserAndReturnsVerificationToken() {
+    RegisterRequestDto requestDto =
+        new RegisterRequestDto(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_PASSWORD_VALID);
+    UserEntity toCreate = new UserEntity();
+    UserEntity created = new UserEntity();
+    created.setId(TEST_USER_ID);
+    UserResponseDto responseDto =
+        new UserResponseDto(TEST_USER_ID, TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_EMAIL_TOKEN,
+            TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+
+    when(userMapper.create(requestDto)).thenReturn(toCreate);
+    when(passwordEncoder.encode(TEST_PASSWORD_VALID)).thenReturn(TEST_ENCODED_PASSWORD);
+    when(userRepository.save(toCreate)).thenReturn(created);
+    when(accessTokenCodec.generateToken(created, AccessTokenType.VERIFY_EMAIL))
+        .thenReturn(verificationToken);
+    when(accessTokenCodec.extractExpiration(TEST_VERIFY_EMAIL_TOKEN))
+        .thenReturn(TEST_VERIFICATION_TOKEN_EXPIRES_AT);
+    when(userMapper.toDto(created)).thenReturn(responseDto);
+
+    RegisteredUserResultDto result = authRegisterHelper.createUser(requestDto);
+
+    assertEquals(TEST_ENCODED_PASSWORD, toCreate.getPassword());
+    assertEquals(TEST_VERIFICATION_TOKEN_EXPIRES_AT, created.getVerificationTokenExpiresAt());
+    assertSame(responseDto, result.response());
+    assertSame(verificationToken, result.verificationToken());
+
+    verify(userMapper).create(requestDto);
+    verify(passwordEncoder).encode(TEST_PASSWORD_VALID);
+    verify(userRepository).save(toCreate);
+    verify(accessTokenCodec).generateToken(created, AccessTokenType.VERIFY_EMAIL);
+    verify(accessTokenCodec).extractExpiration(TEST_VERIFY_EMAIL_TOKEN);
+    verify(userMapper).toDto(created);
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthResendVerificationEmailHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthResendVerificationEmailHelperTest.java
@@ -1,0 +1,115 @@
+package com.tychewealth.service.helper.auth;
+
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.auth.AuthTokenDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AccessTokenType;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.email.VerificationEmailWorkflow;
+import com.tychewealth.service.token.AccessTokenCodec;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthResendVerificationEmailHelperTest {
+
+  private static final Instant TEST_PREVIOUS_VERIFICATION_TOKEN_EXPIRES_AT =
+      Instant.parse("2026-04-02T10:00:00Z");
+  private static final Instant TEST_FAILED_ATTEMPT_EXPIRY = Instant.parse("2026-04-03T10:00:00Z");
+
+  @Mock private UserRepository userRepository;
+  @Mock private AuthValidationHelper authValidationHelper;
+  @Mock private AccessTokenCodec accessTokenCodec;
+  @Mock private VerificationEmailWorkflow verificationEmailWorkflow;
+
+  @InjectMocks private AuthResendVerificationEmailHelper authResendVerificationEmailHelper;
+
+  @Test
+  void resendVerificationEmailReturnsSilentlyWhenUserDoesNotExist() {
+    ResendVerificationEmailRequestDto requestDto =
+        new ResendVerificationEmailRequestDto(TEST_EMAIL_LAURA);
+
+    when(userRepository.findByEmailAndDeletedAtIsNullForUpdate(TEST_EMAIL_LAURA))
+        .thenReturn(Optional.empty());
+
+    authResendVerificationEmailHelper.resendVerificationEmail(requestDto);
+
+    verify(userRepository).findByEmailAndDeletedAtIsNullForUpdate(TEST_EMAIL_LAURA);
+    verifyNoInteractions(authValidationHelper, accessTokenCodec, verificationEmailWorkflow);
+  }
+
+  @Test
+  void resendVerificationEmailReturnsSilentlyWhenUserCannotResend() {
+    ResendVerificationEmailRequestDto requestDto =
+        new ResendVerificationEmailRequestDto(TEST_EMAIL_LAURA);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
+    user.setId(TEST_USER_ID);
+
+    when(userRepository.findByEmailAndDeletedAtIsNullForUpdate(TEST_EMAIL_LAURA))
+        .thenReturn(Optional.of(user));
+    when(authValidationHelper.canResendVerificationEmail(user)).thenReturn(false);
+
+    authResendVerificationEmailHelper.resendVerificationEmail(requestDto);
+
+    verify(authValidationHelper).canResendVerificationEmail(user);
+    verify(accessTokenCodec, never()).generateToken(user, AccessTokenType.VERIFY_EMAIL);
+    verifyNoInteractions(verificationEmailWorkflow);
+  }
+
+  @Test
+  void resendVerificationEmailSchedulesWorkflowAndUpdatesExpiryWhenUserCanResend() {
+    ResendVerificationEmailRequestDto requestDto =
+        new ResendVerificationEmailRequestDto(TEST_EMAIL_LAURA);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
+    user.setId(TEST_USER_ID);
+    user.setVerificationTokenExpiresAt(TEST_PREVIOUS_VERIFICATION_TOKEN_EXPIRES_AT);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_EMAIL_TOKEN,
+            TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+
+    when(userRepository.findByEmailAndDeletedAtIsNullForUpdate(TEST_EMAIL_LAURA))
+        .thenReturn(Optional.of(user));
+    when(authValidationHelper.canResendVerificationEmail(user)).thenReturn(true);
+    when(accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_EMAIL))
+        .thenReturn(verificationToken);
+    when(accessTokenCodec.extractExpiration(TEST_VERIFY_EMAIL_TOKEN))
+        .thenReturn(TEST_FAILED_ATTEMPT_EXPIRY);
+
+    authResendVerificationEmailHelper.resendVerificationEmail(requestDto);
+
+    assertEquals(TEST_FAILED_ATTEMPT_EXPIRY, user.getVerificationTokenExpiresAt());
+    verify(accessTokenCodec).generateToken(user, AccessTokenType.VERIFY_EMAIL);
+    verify(accessTokenCodec).extractExpiration(TEST_VERIFY_EMAIL_TOKEN);
+    verify(verificationEmailWorkflow)
+        .scheduleVerificationEmail(
+            eq(TEST_USER_ID),
+            eq(TEST_EMAIL_LAURA),
+            eq(verificationToken),
+            eq(TEST_FAILED_ATTEMPT_EXPIRY),
+            eq(TEST_PREVIOUS_VERIFICATION_TOKEN_EXPIRES_AT),
+            any(Runnable.class));
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthValidationHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthValidationHelperTest.java
@@ -1,0 +1,262 @@
+package com.tychewealth.service.helper.auth;
+
+import static com.tychewealth.constants.AuthConstants.EMAIL_CONSTRAINT;
+import static com.tychewealth.constants.AuthConstants.USERNAME_CONSTRAINT;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_ENCODED_PASSWORD;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_TOO_SHORT;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.auth.request.LoginRequestDto;
+import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AuthMetricEnum;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.monitoring.AuthMetrics;
+import com.tychewealth.repository.UserRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthValidationHelperTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private SimpleMeterRegistry meterRegistry;
+  private AuthValidationHelper authValidationHelper;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    authValidationHelper =
+        new AuthValidationHelper(userRepository, passwordEncoder, new AuthMetrics(meterRegistry));
+  }
+
+  @Test
+  void validateRegisterRequestPassesWhenEmailUsernameAndPasswordAreValid() {
+    RegisterRequestDto requestDto =
+        new RegisterRequestDto(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_PASSWORD_VALID);
+
+    when(userRepository.findByEmailIncludingDeleted(TEST_EMAIL_LAURA)).thenReturn(Optional.empty());
+    when(userRepository.findByUsernameIncludingDeleted(TEST_USERNAME_LAURA))
+        .thenReturn(Optional.empty());
+
+    authValidationHelper.validateRegisterRequest(requestDto);
+
+    verify(userRepository).findByEmailIncludingDeleted(TEST_EMAIL_LAURA);
+    verify(userRepository).findByUsernameIncludingDeleted(TEST_USERNAME_LAURA);
+  }
+
+  @Test
+  void validateEmailIsAvailableThrowsConflictWhenEmailAlreadyExists() {
+    UserEntity existingUser =
+        buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    when(userRepository.findByEmailIncludingDeleted(TEST_EMAIL_LAURA))
+        .thenReturn(Optional.of(existingUser));
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () -> authValidationHelper.validateEmailIsAvailable(TEST_EMAIL_LAURA));
+
+    assertEquals(ErrorDefinition.AUTH_REGISTRATION_CONFLICT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_FAILURE.metricName()));
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_CONFLICT.metricName()));
+  }
+
+  @Test
+  void validateUsernameIsAvailableThrowsConflictWhenUsernameAlreadyExists() {
+    UserEntity existingUser =
+        buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    when(userRepository.findByUsernameIncludingDeleted(TEST_USERNAME_LAURA))
+        .thenReturn(Optional.of(existingUser));
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () -> authValidationHelper.validateUsernameIsAvailable(TEST_USERNAME_LAURA));
+
+    assertEquals(ErrorDefinition.AUTH_REGISTRATION_CONFLICT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_FAILURE.metricName()));
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_CONFLICT.metricName()));
+  }
+
+  @Test
+  void validateRegisterPasswordFormatThrowsWhenPasswordIsInvalid() {
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () -> authValidationHelper.validateRegisterPasswordFormat(TEST_PASSWORD_TOO_SHORT));
+
+    assertEquals(
+        ErrorDefinition.AUTH_REGISTER_PASSWORD_FORMAT_INVALID, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_FAILURE.metricName()));
+  }
+
+  @Test
+  void validateLoginRequestReturnsUserWhenCredentialsAreValid() {
+    LoginRequestDto requestDto = new LoginRequestDto(TEST_EMAIL_VALID, TEST_PASSWORD_VALID);
+    UserEntity user = buildUser(TEST_EMAIL_VALID, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setVerified(true);
+
+    when(userRepository.findByEmailAndDeletedAtIsNull(TEST_EMAIL_VALID))
+        .thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD)).thenReturn(true);
+
+    UserEntity result = authValidationHelper.validateLoginRequest(requestDto);
+
+    assertSame(user, result);
+    verify(passwordEncoder).matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD);
+  }
+
+  @Test
+  void validateLoginRequestThrowsWhenEmailDoesNotExist() {
+    LoginRequestDto requestDto = new LoginRequestDto(TEST_EMAIL_VALID, TEST_PASSWORD_VALID);
+    when(userRepository.findByEmailAndDeletedAtIsNull(TEST_EMAIL_VALID))
+        .thenReturn(Optional.empty());
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class, () -> authValidationHelper.validateLoginRequest(requestDto));
+
+    assertEquals(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, exception.getErrorDefinition());
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.LOGIN_FAILURE.metricName()));
+    assertEquals(
+        1.0, counterValue(meterRegistry, AuthMetricEnum.LOGIN_INVALID_CREDENTIALS.metricName()));
+  }
+
+  @Test
+  void validateLoginRequestThrowsWhenUserIsNotVerified() {
+    LoginRequestDto requestDto = new LoginRequestDto(TEST_EMAIL_VALID, TEST_PASSWORD_VALID);
+    UserEntity user = buildUser(TEST_EMAIL_VALID, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setVerified(false);
+
+    when(userRepository.findByEmailAndDeletedAtIsNull(TEST_EMAIL_VALID))
+        .thenReturn(Optional.of(user));
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class, () -> authValidationHelper.validateLoginRequest(requestDto));
+
+    assertEquals(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, exception.getErrorDefinition());
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+    verify(passwordEncoder, never()).matches(TEST_PASSWORD_VALID, null);
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.LOGIN_FAILURE.metricName()));
+    assertEquals(
+        1.0, counterValue(meterRegistry, AuthMetricEnum.LOGIN_INVALID_CREDENTIALS.metricName()));
+  }
+
+  @Test
+  void validateLoginPasswordThrowsWhenPasswordDoesNotMatch() {
+    when(passwordEncoder.matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD)).thenReturn(false);
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () ->
+                authValidationHelper.validateLoginPassword(
+                    TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD));
+
+    assertEquals(ErrorDefinition.AUTH_LOGIN_INVALID_CREDENTIALS, exception.getErrorDefinition());
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.LOGIN_FAILURE.metricName()));
+    assertEquals(
+        1.0, counterValue(meterRegistry, AuthMetricEnum.LOGIN_INVALID_CREDENTIALS.metricName()));
+  }
+
+  @Test
+  void canResendVerificationEmailReturnsTrueWhenTokenIsMissing() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setVerified(false);
+    user.setVerificationTokenExpiresAt(null);
+
+    assertTrue(authValidationHelper.canResendVerificationEmail(user));
+  }
+
+  @Test
+  void canResendVerificationEmailReturnsTrueWhenTokenIsExpired() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setVerified(false);
+    user.setVerificationTokenExpiresAt(Instant.now().minusSeconds(60));
+
+    assertTrue(authValidationHelper.canResendVerificationEmail(user));
+  }
+
+  @Test
+  void validateRegisterPersistenceConflictReturnsAuthExceptionForEmailConstraint() {
+    DataIntegrityViolationException exception =
+        new DataIntegrityViolationException("duplicate key for " + EMAIL_CONSTRAINT);
+
+    AuthException result =
+        assertThrows(
+            AuthException.class,
+            () -> {
+              throw authValidationHelper.validateRegisterPersistenceConflict(exception);
+            });
+
+    assertEquals(ErrorDefinition.AUTH_REGISTRATION_CONFLICT, result.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, result.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_FAILURE.metricName()));
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_CONFLICT.metricName()));
+  }
+
+  @Test
+  void validateRegisterPersistenceConflictReturnsAuthExceptionForUsernameConstraintInCause() {
+    DataIntegrityViolationException exception =
+        new DataIntegrityViolationException(
+            "persistence failure", new IllegalStateException("constraint " + USERNAME_CONSTRAINT));
+
+    AuthException result =
+        assertThrows(
+            AuthException.class,
+            () -> {
+              throw authValidationHelper.validateRegisterPersistenceConflict(exception);
+            });
+
+    assertEquals(ErrorDefinition.AUTH_REGISTRATION_CONFLICT, result.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, result.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_FAILURE.metricName()));
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_CONFLICT.metricName()));
+  }
+
+  @Test
+  void validateRegisterPersistenceConflictRethrowsOriginalExceptionWhenConstraintIsUnrelated() {
+    DataIntegrityViolationException exception =
+        new DataIntegrityViolationException("some unrelated persistence failure");
+
+    DataIntegrityViolationException thrown =
+        assertThrows(
+            DataIntegrityViolationException.class,
+            () -> authValidationHelper.validateRegisterPersistenceConflict(exception));
+
+    assertSame(exception, thrown);
+    assertEquals(0.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_FAILURE.metricName()));
+    assertEquals(0.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_CONFLICT.metricName()));
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthVerifyEmailHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthVerifyEmailHelperTest.java
@@ -1,0 +1,119 @@
+package com.tychewealth.service.helper.auth;
+
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.token.AccessTokenCodec;
+import com.tychewealth.service.trusteddevice.TrustedDeviceManager;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+
+@ExtendWith(MockitoExtension.class)
+class AuthVerifyEmailHelperTest {
+
+  private static final Instant TEST_VERIFICATION_TOKEN_EXPIRES_AT =
+      Instant.parse("2026-04-03T12:00:00Z");
+
+  @Mock private AccessTokenCodec accessTokenCodec;
+  @Mock private UserRepository userRepository;
+  @Mock private TrustedDeviceManager trustedDeviceManager;
+
+  @InjectMocks private AuthVerifyEmailHelper authVerifyEmailHelper;
+
+  @Test
+  void verifyThrowsBadRequestWhenTokenIsBlank() {
+    AuthException exception =
+        assertThrows(AuthException.class, () -> authVerifyEmailHelper.verify(" "));
+
+    assertEquals(ErrorDefinition.GENERIC_BAD_REQUEST, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+  }
+
+  @Test
+  void verifyThrowsUnauthorizedWhenUserDoesNotExist() {
+    when(accessTokenCodec.extractVerifyEmailUserId(TEST_VERIFY_EMAIL_TOKEN))
+        .thenReturn(TEST_USER_ID);
+    when(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID)).thenReturn(Optional.empty());
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class, () -> authVerifyEmailHelper.verify(TEST_VERIFY_EMAIL_TOKEN));
+
+    assertEquals(ErrorDefinition.UNAUTHORIZED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+  }
+
+  @Test
+  void verifyReturnsTrustedDeviceCookieWithoutSavingWhenUserIsAlreadyVerified() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    user.setVerified(true);
+    ResponseCookie cookie = buildTrustedDeviceCookie();
+
+    when(accessTokenCodec.extractVerifyEmailUserId(TEST_VERIFY_EMAIL_TOKEN))
+        .thenReturn(TEST_USER_ID);
+    when(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID)).thenReturn(Optional.of(user));
+    when(trustedDeviceManager.createTrustedDeviceCookie(user)).thenReturn(cookie);
+
+    ResponseCookie result = authVerifyEmailHelper.verify(TEST_VERIFY_EMAIL_TOKEN);
+
+    assertSame(cookie, result);
+    verify(userRepository, never()).save(user);
+    verify(trustedDeviceManager).createTrustedDeviceCookie(user);
+  }
+
+  @Test
+  void verifyMarksUserAsVerifiedClearsExpiryAndReturnsTrustedDeviceCookie() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    user.setVerified(false);
+    user.setVerificationTokenExpiresAt(TEST_VERIFICATION_TOKEN_EXPIRES_AT);
+    ResponseCookie cookie = buildTrustedDeviceCookie();
+
+    when(accessTokenCodec.extractVerifyEmailUserId(TEST_VERIFY_EMAIL_TOKEN))
+        .thenReturn(TEST_USER_ID);
+    when(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID)).thenReturn(Optional.of(user));
+    when(trustedDeviceManager.createTrustedDeviceCookie(user)).thenReturn(cookie);
+
+    ResponseCookie result = authVerifyEmailHelper.verify(TEST_VERIFY_EMAIL_TOKEN);
+
+    assertSame(cookie, result);
+    assertTrue(user.isVerified());
+    assertNull(user.getVerificationTokenExpiresAt());
+    verify(userRepository).save(user);
+    verify(trustedDeviceManager).createTrustedDeviceCookie(user);
+  }
+
+  private ResponseCookie buildTrustedDeviceCookie() {
+    return ResponseCookie.from(TEST_TRUSTED_DEVICE_COOKIE_NAME, TEST_TRUSTED_DEVICE_TOKEN)
+        .httpOnly(true)
+        .path("/")
+        .maxAge(Duration.ofHours(1))
+        .build();
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthVerifyLoginDeviceHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthVerifyLoginDeviceHelperTest.java
@@ -1,0 +1,86 @@
+package com.tychewealth.service.helper.auth;
+
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_LOGIN_DEVICE_TOKEN;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.token.AccessTokenCodec;
+import com.tychewealth.service.trusteddevice.TrustedDeviceManager;
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+
+@ExtendWith(MockitoExtension.class)
+class AuthVerifyLoginDeviceHelperTest {
+
+  @Mock private AccessTokenCodec accessTokenCodec;
+  @Mock private UserRepository userRepository;
+  @Mock private TrustedDeviceManager trustedDeviceManager;
+
+  @InjectMocks private AuthVerifyLoginDeviceHelper authVerifyLoginDeviceHelper;
+
+  @Test
+  void verifyThrowsBadRequestWhenTokenIsBlank() {
+    AuthException exception =
+        assertThrows(AuthException.class, () -> authVerifyLoginDeviceHelper.verify(" "));
+
+    assertEquals(ErrorDefinition.GENERIC_BAD_REQUEST, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+  }
+
+  @Test
+  void verifyThrowsUnauthorizedWhenUserDoesNotExist() {
+    when(accessTokenCodec.extractVerifyLoginDeviceUserId(TEST_VERIFY_LOGIN_DEVICE_TOKEN))
+        .thenReturn(TEST_USER_ID);
+    when(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID)).thenReturn(Optional.empty());
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class,
+            () -> authVerifyLoginDeviceHelper.verify(TEST_VERIFY_LOGIN_DEVICE_TOKEN));
+
+    assertEquals(ErrorDefinition.UNAUTHORIZED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+  }
+
+  @Test
+  void verifyReturnsTrustedDeviceCookieWhenUserExists() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    ResponseCookie cookie =
+        ResponseCookie.from(TEST_TRUSTED_DEVICE_COOKIE_NAME, TEST_TRUSTED_DEVICE_TOKEN)
+            .httpOnly(true)
+            .path("/")
+            .maxAge(Duration.ofHours(1))
+            .build();
+
+    when(accessTokenCodec.extractVerifyLoginDeviceUserId(TEST_VERIFY_LOGIN_DEVICE_TOKEN))
+        .thenReturn(TEST_USER_ID);
+    when(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID)).thenReturn(Optional.of(user));
+    when(trustedDeviceManager.createTrustedDeviceCookie(user)).thenReturn(cookie);
+
+    ResponseCookie result = authVerifyLoginDeviceHelper.verify(TEST_VERIFY_LOGIN_DEVICE_TOKEN);
+
+    assertSame(cookie, result);
+    verify(trustedDeviceManager).createTrustedDeviceCookie(user);
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/impl/AuthServiceImplTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/impl/AuthServiceImplTest.java
@@ -1,0 +1,307 @@
+package com.tychewealth.service.impl;
+
+import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
+import static com.tychewealth.constants.LogConstants.REFRESH_TOKEN_ACTION;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_TTL_SECONDS;
+import static com.tychewealth.constants.TestConstants.TEST_BEARER_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_EXISTING;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.auth.AuthTokenDto;
+import com.tychewealth.dto.auth.LoginResponseDto;
+import com.tychewealth.dto.auth.RefreshTokenResponseDto;
+import com.tychewealth.dto.auth.RegisteredUserResultDto;
+import com.tychewealth.dto.auth.request.ForgotPasswordRequestDto;
+import com.tychewealth.dto.auth.request.LoginRequestDto;
+import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
+import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
+import com.tychewealth.dto.user.UserResponseDto;
+import com.tychewealth.entity.RefreshTokenEntity;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AccessTokenType;
+import com.tychewealth.enums.AuthMetricEnum;
+import com.tychewealth.error.exception.AuthException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.monitoring.AuthMetrics;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.email.VerificationEmailWorkflow;
+import com.tychewealth.service.helper.auth.AuthForgotPasswordHelper;
+import com.tychewealth.service.helper.auth.AuthLoginHelper;
+import com.tychewealth.service.helper.auth.AuthRefreshTokenHelper;
+import com.tychewealth.service.helper.auth.AuthRegisterHelper;
+import com.tychewealth.service.helper.auth.AuthResendVerificationEmailHelper;
+import com.tychewealth.service.helper.auth.AuthValidationHelper;
+import com.tychewealth.service.helper.auth.AuthVerifyEmailHelper;
+import com.tychewealth.service.helper.auth.AuthVerifyLoginDeviceHelper;
+import com.tychewealth.service.token.AccessTokenCodec;
+import com.tychewealth.service.token.TokenStateStore;
+import com.tychewealth.service.token.TokenValidator;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+
+  private static final Instant TEST_VERIFICATION_TOKEN_EXPIRES_AT =
+      Instant.parse("2026-04-04T10:00:00Z");
+  private static final String TEST_NEW_REFRESH_TOKEN = "new-refresh-token";
+
+  @Mock private AuthValidationHelper authValidationHelper;
+  @Mock private AuthRegisterHelper authRegisterHelper;
+  @Mock private AuthLoginHelper authLoginHelper;
+  @Mock private AuthResendVerificationEmailHelper authResendVerificationEmailHelper;
+  @Mock private AuthVerifyEmailHelper authVerifyEmailHelper;
+  @Mock private AuthVerifyLoginDeviceHelper authVerifyLoginDeviceHelper;
+  @Mock private VerificationEmailWorkflow verificationEmailWorkflow;
+  @Mock private TokenStateStore tokenStateStore;
+  @Mock private AuthRefreshTokenHelper authRefreshTokenHelper;
+  @Mock private AccessTokenCodec accessTokenCodec;
+  @Mock private TokenValidator tokenValidator;
+  @Mock private AuthForgotPasswordHelper authForgotPasswordHelper;
+  @Mock private UserRepository userRepository;
+
+  private SimpleMeterRegistry meterRegistry;
+  private AuthServiceImpl authService;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    authService =
+        new AuthServiceImpl(
+            authValidationHelper,
+            authRegisterHelper,
+            authLoginHelper,
+            authResendVerificationEmailHelper,
+            authVerifyEmailHelper,
+            authVerifyLoginDeviceHelper,
+            verificationEmailWorkflow,
+            tokenStateStore,
+            authRefreshTokenHelper,
+            accessTokenCodec,
+            tokenValidator,
+            authForgotPasswordHelper,
+            new AuthMetrics(meterRegistry),
+            userRepository);
+  }
+
+  @Test
+  void verifyEmailDelegatesToHelper() {
+    ResponseCookie cookie =
+        ResponseCookie.from(TEST_TRUSTED_DEVICE_COOKIE_NAME, TEST_TRUSTED_DEVICE_TOKEN).build();
+    when(authVerifyEmailHelper.verify(TEST_VERIFY_EMAIL_TOKEN)).thenReturn(cookie);
+
+    ResponseCookie result = authService.verifyEmail(TEST_VERIFY_EMAIL_TOKEN);
+
+    assertSame(cookie, result);
+  }
+
+  @Test
+  void verifyLoginDeviceDelegatesToHelper() {
+    ResponseCookie cookie =
+        ResponseCookie.from(TEST_TRUSTED_DEVICE_COOKIE_NAME, TEST_TRUSTED_DEVICE_TOKEN).build();
+    when(authVerifyLoginDeviceHelper.verify(TEST_VERIFY_EMAIL_TOKEN)).thenReturn(cookie);
+
+    ResponseCookie result = authService.verifyLoginDevice(TEST_VERIFY_EMAIL_TOKEN);
+
+    assertSame(cookie, result);
+  }
+
+  @Test
+  void forgotPasswordDelegatesToHelper() {
+    ForgotPasswordRequestDto requestDto = new ForgotPasswordRequestDto(TEST_EMAIL_LAURA);
+
+    authService.forgotPassword(requestDto);
+
+    verify(authForgotPasswordHelper).forgotPassword(requestDto);
+  }
+
+  @Test
+  void registerValidatesCreatesUserSchedulesVerificationEmailAndReturnsResponse() {
+    RegisterRequestDto requestDto =
+        new RegisterRequestDto(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_PASSWORD_VALID);
+    UserResponseDto responseDto =
+        new UserResponseDto(TEST_USER_ID, TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_EMAIL_TOKEN,
+            TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    RegisteredUserResultDto registeredUser =
+        new RegisteredUserResultDto(responseDto, verificationToken);
+    ArgumentCaptor<Runnable> successCallbackCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+    when(authRegisterHelper.createUser(requestDto)).thenReturn(registeredUser);
+    when(accessTokenCodec.extractExpiration(TEST_VERIFY_EMAIL_TOKEN))
+        .thenReturn(TEST_VERIFICATION_TOKEN_EXPIRES_AT);
+
+    UserResponseDto result = authService.register(requestDto);
+
+    assertSame(responseDto, result);
+    verify(authValidationHelper).validateRegisterRequest(requestDto);
+    verify(verificationEmailWorkflow)
+        .scheduleVerificationEmail(
+            eq(TEST_USER_ID),
+            eq(TEST_EMAIL_LAURA),
+            eq(verificationToken),
+            eq(TEST_VERIFICATION_TOKEN_EXPIRES_AT),
+            eq(null),
+            successCallbackCaptor.capture());
+
+    successCallbackCaptor.getValue().run();
+
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REGISTER_SUCCESS.metricName()));
+  }
+
+  @Test
+  void registerThrowsMappedExceptionWhenPersistenceConflictHappens() {
+    RegisterRequestDto requestDto =
+        new RegisterRequestDto(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_PASSWORD_VALID);
+    DataIntegrityViolationException persistenceException =
+        new DataIntegrityViolationException("duplicate");
+    AuthException mappedException =
+        new AuthException(ErrorDefinition.AUTH_REGISTRATION_CONFLICT, null, HttpStatus.CONFLICT);
+
+    when(authRegisterHelper.createUser(requestDto)).thenThrow(persistenceException);
+    when(authValidationHelper.validateRegisterPersistenceConflict(persistenceException))
+        .thenReturn(mappedException);
+
+    AuthException thrown =
+        assertThrows(AuthException.class, () -> authService.register(requestDto));
+
+    assertSame(mappedException, thrown);
+  }
+
+  @Test
+  void resendVerificationEmailDelegatesToHelper() {
+    ResendVerificationEmailRequestDto requestDto =
+        new ResendVerificationEmailRequestDto(TEST_EMAIL_LAURA);
+
+    authService.resendVerificationEmail(requestDto);
+
+    verify(authResendVerificationEmailHelper).resendVerificationEmail(requestDto);
+  }
+
+  @Test
+  void loginValidatesRequestAndDelegatesToLoginHelper() {
+    LoginRequestDto requestDto = new LoginRequestDto(TEST_EMAIL_LAURA, TEST_PASSWORD_VALID);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    LoginResponseDto loginResponse =
+        new LoginResponseDto(
+            TOKEN_TYPE_BEARER, TEST_ACCESS_TOKEN, TEST_REFRESH_TOKEN_EXISTING, 900L, null);
+
+    when(authValidationHelper.validateLoginRequest(requestDto)).thenReturn(user);
+    when(authLoginHelper.login(user)).thenReturn(loginResponse);
+
+    LoginResponseDto result = authService.login(requestDto);
+
+    assertSame(loginResponse, result);
+  }
+
+  @Test
+  void refreshValidatesRotatesTokensAndReturnsResponse() {
+    RefreshTokenRequestDto requestDto = new RefreshTokenRequestDto(TEST_REFRESH_TOKEN_EXISTING);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    RefreshTokenEntity currentRefreshToken = new RefreshTokenEntity();
+    currentRefreshToken.setUser(user);
+    currentRefreshToken.setExpiresAt(TEST_VERIFICATION_TOKEN_EXPIRES_AT);
+    AuthTokenDto accessToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_ACCESS_TOKEN,
+            TEST_ACCESS_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    AuthRefreshTokenHelper.LinkedRefreshToken newRefreshToken =
+        new AuthRefreshTokenHelper.LinkedRefreshToken(
+            TEST_NEW_REFRESH_TOKEN, TEST_VERIFICATION_TOKEN_EXPIRES_AT);
+
+    when(authRefreshTokenHelper.validateRefreshToken(TEST_REFRESH_TOKEN_EXISTING))
+        .thenReturn(currentRefreshToken);
+    when(accessTokenCodec.generateToken(user, AccessTokenType.ACCESS)).thenReturn(accessToken);
+    when(authRefreshTokenHelper.saveToken(user, TEST_ACCESS_TOKEN_JTI, REFRESH_TOKEN_ACTION))
+        .thenReturn(newRefreshToken);
+
+    RefreshTokenResponseDto result = authService.refresh(requestDto);
+
+    verify(tokenValidator).validateRefreshTokenRequest(requestDto);
+    verify(tokenStateStore).unlinkRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+    assertEquals(TOKEN_TYPE_BEARER, result.getTokenType());
+    assertEquals(TEST_ACCESS_TOKEN, result.getAccessToken());
+    assertEquals(TEST_ACCESS_TOKEN_TTL_SECONDS, result.getExpiresIn());
+    assertEquals(TEST_NEW_REFRESH_TOKEN, result.getRefreshToken());
+    assertEquals(1.0, counterValue(meterRegistry, AuthMetricEnum.REFRESH_SUCCESS.metricName()));
+  }
+
+  @Test
+  void logoutRevokesTokensAndUnlinksRefreshToken() {
+    RefreshTokenRequestDto requestDto = new RefreshTokenRequestDto(TEST_REFRESH_TOKEN_EXISTING);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    RefreshTokenEntity refreshToken = new RefreshTokenEntity();
+    refreshToken.setUser(user);
+    refreshToken.setExpiresAt(TEST_VERIFICATION_TOKEN_EXPIRES_AT);
+
+    when(authRefreshTokenHelper.validateRefreshToken(TEST_REFRESH_TOKEN_EXISTING))
+        .thenReturn(refreshToken);
+    when(tokenStateStore.findAccessTokenJtiByRefreshToken(TEST_REFRESH_TOKEN_EXISTING))
+        .thenReturn(Optional.of(TEST_ACCESS_TOKEN_JTI));
+
+    authService.logout(TEST_BEARER_ACCESS_TOKEN, requestDto);
+
+    verify(tokenValidator).validateRefreshTokenRequest(requestDto);
+    verify(tokenStateStore).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+    verify(tokenStateStore)
+        .revokeAccessToken(TEST_ACCESS_TOKEN_JTI, TEST_VERIFICATION_TOKEN_EXPIRES_AT);
+    verify(tokenStateStore).unlinkRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+  }
+
+  @Test
+  void logoutStillUnlinksRefreshTokenWhenNoLinkedAccessTokenExists() {
+    RefreshTokenRequestDto requestDto = new RefreshTokenRequestDto(TEST_REFRESH_TOKEN_EXISTING);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    RefreshTokenEntity refreshToken = new RefreshTokenEntity();
+    refreshToken.setUser(user);
+
+    when(authRefreshTokenHelper.validateRefreshToken(TEST_REFRESH_TOKEN_EXISTING))
+        .thenReturn(refreshToken);
+    when(tokenStateStore.findAccessTokenJtiByRefreshToken(TEST_REFRESH_TOKEN_EXISTING))
+        .thenReturn(Optional.empty());
+
+    authService.logout(TEST_BEARER_ACCESS_TOKEN, requestDto);
+
+    verify(tokenStateStore, never()).revokeAccessToken(eq(TEST_ACCESS_TOKEN_JTI), any());
+    verify(tokenStateStore).unlinkRefreshToken(TEST_REFRESH_TOKEN_EXISTING);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for authentication workflows, including password reset, email verification, device verification, token refresh, registration, and logout processes.

Closes #63 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->