### PR TITLE
[TYCHE-32] add new user unitary tests

### DIFF
--- a/user-service/src/test/java/com/tychewealth/controller/AuthIdempotencyIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthIdempotencyIntegrationTest.java
@@ -37,18 +37,14 @@ import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
 import com.tychewealth.service.token.AccessTokenCodec;
 import jakarta.servlet.http.Cookie;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ContextConfiguration;
@@ -72,8 +68,6 @@ class AuthIdempotencyIntegrationTest {
   @Autowired private StringRedisTemplate stringRedisTemplate;
   @Autowired private AccessTokenCodec accessTokenCodec;
 
-  private final Map<String, String> forgotPasswordTokens = new ConcurrentHashMap<>();
-
   @BeforeEach
   void setUp() {
     refreshTokenRepository.deleteAll();
@@ -82,21 +76,6 @@ class AuthIdempotencyIntegrationTest {
     rateLimitConfig.resetAll();
     reset(emailSender);
     when(emailSender.send(any(EmailMessageDto.class))).thenReturn(EmailSendResult.DELIVERED);
-
-    ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
-    when(valueOperations.setIfAbsent(any(), any(), any(Duration.class)))
-        .thenAnswer(
-            invocation ->
-                forgotPasswordTokens.putIfAbsent(
-                        invocation.getArgument(0), invocation.getArgument(1))
-                    == null);
-    org.mockito.Mockito.doAnswer(
-            invocation -> {
-              forgotPasswordTokens.remove(invocation.getArgument(0));
-              return true;
-            })
-        .when(stringRedisTemplate)
-        .delete(any(String.class));
   }
 
   @Test
@@ -138,7 +117,8 @@ class AuthIdempotencyIntegrationTest {
 
     assertEquals(List.of(204, 204), statuses);
     verify(emailSender, org.mockito.Mockito.times(1)).send(any(EmailMessageDto.class));
-    assertNotNull(forgotPasswordTokens.get(FORGOT_PASSWORD_KEY_PREFIX + savedUser.getId()));
+    assertNotNull(
+        stringRedisTemplate.opsForValue().get(FORGOT_PASSWORD_KEY_PREFIX + savedUser.getId()));
   }
 
   @Test

--- a/user-service/src/test/java/com/tychewealth/controller/AuthIdempotencyIntegrationTest.java
+++ b/user-service/src/test/java/com/tychewealth/controller/AuthIdempotencyIntegrationTest.java
@@ -1,0 +1,202 @@
+package com.tychewealth.controller;
+
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static com.tychewealth.testhelper.AuthTestHelper.extractCookieValue;
+import static com.tychewealth.testhelper.AuthTestHelper.forgotPasswordStatus;
+import static com.tychewealth.testhelper.AuthTestHelper.resendVerificationStatus;
+import static com.tychewealth.testhelper.AuthTestHelper.verifyLoginDeviceRequest;
+import static com.tychewealth.testhelper.AuthTestHelper.verifyLoginDeviceStatus;
+import static com.tychewealth.testhelper.AuthTestHelper.verifyRegistrationRequest;
+import static com.tychewealth.testhelper.AuthTestHelper.verifyRegistrationStatus;
+import static com.tychewealth.testhelper.ConcurrentTestHelper.runConcurrently;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tychewealth.config.AuthIntegrationTestConfig;
+import com.tychewealth.config.AuthRateLimitConfig;
+import com.tychewealth.dto.auth.AuthTokenDto;
+import com.tychewealth.dto.auth.request.ForgotPasswordRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
+import com.tychewealth.dto.email.request.EmailMessageDto;
+import com.tychewealth.email.EmailSender;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.AccessTokenType;
+import com.tychewealth.enums.EmailSendResult;
+import com.tychewealth.repository.RefreshTokenRepository;
+import com.tychewealth.repository.TrustedDeviceRepository;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.token.AccessTokenCodec;
+import jakarta.servlet.http.Cookie;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = AuthIntegrationTestConfig.class)
+@ContextConfiguration(initializers = AuthIntegrationTestConfig.Initializer.class)
+@AutoConfigureMockMvc
+class AuthIdempotencyIntegrationTest {
+
+  private static final String FORGOT_PASSWORD_KEY_PREFIX = "forgot-password:";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private UserRepository userRepository;
+  @Autowired private RefreshTokenRepository refreshTokenRepository;
+  @Autowired private TrustedDeviceRepository trustedDeviceRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private EmailSender emailSender;
+  @Autowired private AuthRateLimitConfig rateLimitConfig;
+  @Autowired private StringRedisTemplate stringRedisTemplate;
+  @Autowired private AccessTokenCodec accessTokenCodec;
+
+  private final Map<String, String> forgotPasswordTokens = new ConcurrentHashMap<>();
+
+  @BeforeEach
+  void setUp() {
+    refreshTokenRepository.deleteAll();
+    trustedDeviceRepository.deleteAll();
+    userRepository.deleteAll();
+    rateLimitConfig.resetAll();
+    reset(emailSender);
+    when(emailSender.send(any(EmailMessageDto.class))).thenReturn(EmailSendResult.DELIVERED);
+
+    ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+    when(valueOperations.setIfAbsent(any(), any(), any(Duration.class)))
+        .thenAnswer(
+            invocation ->
+                forgotPasswordTokens.putIfAbsent(
+                        invocation.getArgument(0), invocation.getArgument(1))
+                    == null);
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              forgotPasswordTokens.remove(invocation.getArgument(0));
+              return true;
+            })
+        .when(stringRedisTemplate)
+        .delete(any(String.class));
+  }
+
+  @Test
+  void resendVerificationEmailConcurrentRetriesSendOnlyOneEmailAndKeepConsistentState()
+      throws Exception {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
+    user.setVerified(false);
+    user.setVerificationTokenExpiresAt(Instant.now().minusSeconds(5));
+    UserEntity savedUser = userRepository.save(user);
+    ResendVerificationEmailRequestDto requestDto =
+        new ResendVerificationEmailRequestDto(TEST_EMAIL_LAURA);
+
+    List<Integer> statuses =
+        runConcurrently(
+            () -> resendVerificationStatus(mockMvc, objectMapper, requestDto),
+            () -> resendVerificationStatus(mockMvc, objectMapper, requestDto));
+
+    assertEquals(List.of(204, 204), statuses);
+    verify(emailSender, org.mockito.Mockito.times(1)).send(any(EmailMessageDto.class));
+
+    UserEntity updatedUser = userRepository.findById(savedUser.getId()).orElseThrow();
+    assertNotNull(updatedUser.getVerificationTokenExpiresAt());
+    assertTrue(updatedUser.getVerificationTokenExpiresAt().isAfter(Instant.now()));
+  }
+
+  @Test
+  void forgotPasswordConcurrentRetriesSendOnlyOneEmail() throws Exception {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
+    user.setVerified(true);
+    UserEntity savedUser = userRepository.save(user);
+    ForgotPasswordRequestDto requestDto = new ForgotPasswordRequestDto(TEST_EMAIL_LAURA);
+
+    List<Integer> statuses =
+        runConcurrently(
+            () -> forgotPasswordStatus(mockMvc, objectMapper, requestDto),
+            () -> forgotPasswordStatus(mockMvc, objectMapper, requestDto));
+
+    assertEquals(List.of(204, 204), statuses);
+    verify(emailSender, org.mockito.Mockito.times(1)).send(any(EmailMessageDto.class));
+    assertNotNull(forgotPasswordTokens.get(FORGOT_PASSWORD_KEY_PREFIX + savedUser.getId()));
+  }
+
+  @Test
+  void verifyRegistrationConcurrentRetriesReuseExistingTrustedDevice() throws Exception {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
+    user.setVerified(false);
+    UserEntity savedUser = userRepository.save(user);
+    AuthTokenDto verificationToken =
+        accessTokenCodec.generateToken(savedUser, AccessTokenType.VERIFY_EMAIL);
+
+    String setCookieHeader =
+        verifyRegistrationRequest(mockMvc, verificationToken.token())
+            .andReturn()
+            .getResponse()
+            .getHeader(HttpHeaders.SET_COOKIE);
+    Cookie trustedDeviceCookie =
+        new Cookie(
+            TEST_TRUSTED_DEVICE_COOKIE_NAME,
+            extractCookieValue(setCookieHeader, TEST_TRUSTED_DEVICE_COOKIE_NAME));
+
+    List<Integer> statuses =
+        runConcurrently(
+            () -> verifyRegistrationStatus(mockMvc, verificationToken.token(), trustedDeviceCookie),
+            () ->
+                verifyRegistrationStatus(mockMvc, verificationToken.token(), trustedDeviceCookie));
+
+    assertEquals(List.of(204, 204), statuses);
+    assertEquals(1L, trustedDeviceRepository.count());
+    assertTrue(userRepository.findById(savedUser.getId()).orElseThrow().isVerified());
+  }
+
+  @Test
+  void verifyLoginDeviceConcurrentRetriesReuseExistingTrustedDevice() throws Exception {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setPassword(passwordEncoder.encode(TEST_PASSWORD_VALID));
+    user.setVerified(true);
+    UserEntity savedUser = userRepository.save(user);
+    AuthTokenDto verificationToken =
+        accessTokenCodec.generateToken(savedUser, AccessTokenType.VERIFY_LOGIN_DEVICE);
+
+    String setCookieHeader =
+        verifyLoginDeviceRequest(mockMvc, verificationToken.token())
+            .andReturn()
+            .getResponse()
+            .getHeader(HttpHeaders.SET_COOKIE);
+    Cookie trustedDeviceCookie =
+        new Cookie(
+            TEST_TRUSTED_DEVICE_COOKIE_NAME,
+            extractCookieValue(setCookieHeader, TEST_TRUSTED_DEVICE_COOKIE_NAME));
+    rateLimitConfig.resetAll();
+
+    List<Integer> statuses =
+        runConcurrently(
+            () -> verifyLoginDeviceStatus(mockMvc, verificationToken.token(), trustedDeviceCookie),
+            () -> verifyLoginDeviceStatus(mockMvc, verificationToken.token(), trustedDeviceCookie));
+
+    assertEquals(List.of(204, 204), statuses);
+    assertEquals(1L, trustedDeviceRepository.count());
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/email/VerificationEmailWorkflowTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/email/VerificationEmailWorkflowTest.java
@@ -2,9 +2,14 @@ package com.tychewealth.service.email;
 
 import static com.tychewealth.constants.AuthConstants.TOKEN_TYPE_BEARER;
 import static com.tychewealth.constants.TestConstants.TEST_ACCESS_TOKEN_JTI;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_HTML_BODY;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_SUBJECT_VERIFY;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_TEXT_BODY;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN;
 import static com.tychewealth.constants.TestConstants.TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,13 +39,12 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @ExtendWith(MockitoExtension.class)
 class VerificationEmailWorkflowTest {
 
-  private static final String TEST_VERIFY_EMAIL_TOKEN = "verify-email-token";
-  private static final String TEST_EMAIL_SUBJECT = "Verify your email";
-  private static final String TEST_EMAIL_HTML = "<p>body</p>";
-  private static final String TEST_EMAIL_TEXT = "body";
   private static final Instant PREVIOUS_VERIFICATION_TOKEN_EXPIRY =
       Instant.parse("2026-04-01T10:15:30Z");
   private static final Instant FAILED_ATTEMPT_EXPIRY = Instant.parse("2026-04-01T11:15:30Z");
+  private static final EmailMessageDto TEST_VERIFICATION_EMAIL_MESSAGE =
+      new EmailMessageDto(
+          TEST_EMAIL_LAURA, TEST_EMAIL_SUBJECT_VERIFY, TEST_EMAIL_HTML_BODY, TEST_EMAIL_TEXT_BODY);
   private static final AuthTokenDto TEST_VERIFICATION_TOKEN =
       new AuthTokenDto(
           TOKEN_TYPE_BEARER,
@@ -64,14 +68,12 @@ class VerificationEmailWorkflowTest {
   void scheduleVerificationEmailSendsEmailAfterCommitAndRunsSuccessCallback() {
     VerificationEmailWorkflow verificationEmailWorkflow =
         new VerificationEmailWorkflow(authEmailFactory, emailSender, userRepository, self);
-    EmailMessageDto emailMessage =
-        new EmailMessageDto(TEST_EMAIL_LAURA, TEST_EMAIL_SUBJECT, TEST_EMAIL_HTML, TEST_EMAIL_TEXT);
     AtomicBoolean successCallbackInvoked = new AtomicBoolean(false);
 
     when(authEmailFactory.buildVerifyEmailMessage(
             TEST_EMAIL_LAURA, TEST_VERIFY_EMAIL_TOKEN, TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS))
-        .thenReturn(emailMessage);
-    when(emailSender.send(emailMessage)).thenReturn(EmailSendResult.DELIVERED);
+        .thenReturn(TEST_VERIFICATION_EMAIL_MESSAGE);
+    when(emailSender.send(TEST_VERIFICATION_EMAIL_MESSAGE)).thenReturn(EmailSendResult.DELIVERED);
 
     TransactionSynchronizationManager.initSynchronization();
 
@@ -87,7 +89,7 @@ class VerificationEmailWorkflowTest {
 
     runAfterCommitCallbacks();
 
-    verify(emailSender).send(emailMessage);
+    verify(emailSender).send(TEST_VERIFICATION_EMAIL_MESSAGE);
     verify(self, never())
         .restoreVerificationTokenExpiryWithErrorHandling(
             TEST_USER_ID, FAILED_ATTEMPT_EXPIRY, PREVIOUS_VERIFICATION_TOKEN_EXPIRY);
@@ -98,14 +100,13 @@ class VerificationEmailWorkflowTest {
   void scheduleVerificationEmailRestoresExpiryWhenDeliveryIsSkipped() {
     VerificationEmailWorkflow verificationEmailWorkflow =
         new VerificationEmailWorkflow(authEmailFactory, emailSender, userRepository, self);
-    EmailMessageDto emailMessage =
-        new EmailMessageDto(TEST_EMAIL_LAURA, TEST_EMAIL_SUBJECT, TEST_EMAIL_HTML, TEST_EMAIL_TEXT);
     AtomicBoolean successCallbackInvoked = new AtomicBoolean(false);
 
     when(authEmailFactory.buildVerifyEmailMessage(
             TEST_EMAIL_LAURA, TEST_VERIFY_EMAIL_TOKEN, TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS))
-        .thenReturn(emailMessage);
-    when(emailSender.send(emailMessage)).thenReturn(EmailSendResult.SKIPPED_DAILY_QUOTA);
+        .thenReturn(TEST_VERIFICATION_EMAIL_MESSAGE);
+    when(emailSender.send(TEST_VERIFICATION_EMAIL_MESSAGE))
+        .thenReturn(EmailSendResult.SKIPPED_DAILY_QUOTA);
 
     TransactionSynchronizationManager.initSynchronization();
 
@@ -119,7 +120,7 @@ class VerificationEmailWorkflowTest {
 
     runAfterCommitCallbacks();
 
-    verify(emailSender).send(emailMessage);
+    verify(emailSender).send(TEST_VERIFICATION_EMAIL_MESSAGE);
     verify(self)
         .restoreVerificationTokenExpiryWithErrorHandling(
             TEST_USER_ID, FAILED_ATTEMPT_EXPIRY, PREVIOUS_VERIFICATION_TOKEN_EXPIRY);
@@ -130,14 +131,13 @@ class VerificationEmailWorkflowTest {
   void scheduleVerificationEmailRestoresExpiryAndRethrowsWhenSendFails() {
     VerificationEmailWorkflow verificationEmailWorkflow =
         new VerificationEmailWorkflow(authEmailFactory, emailSender, userRepository, self);
-    EmailMessageDto emailMessage =
-        new EmailMessageDto(TEST_EMAIL_LAURA, TEST_EMAIL_SUBJECT, TEST_EMAIL_HTML, TEST_EMAIL_TEXT);
     AtomicBoolean successCallbackInvoked = new AtomicBoolean(false);
 
     when(authEmailFactory.buildVerifyEmailMessage(
             TEST_EMAIL_LAURA, TEST_VERIFY_EMAIL_TOKEN, TEST_VERIFY_EMAIL_TOKEN_TTL_SECONDS))
-        .thenReturn(emailMessage);
-    when(emailSender.send(emailMessage)).thenThrow(new IllegalStateException("email send failed"));
+        .thenReturn(TEST_VERIFICATION_EMAIL_MESSAGE);
+    when(emailSender.send(TEST_VERIFICATION_EMAIL_MESSAGE))
+        .thenThrow(new IllegalStateException("email send failed"));
 
     TransactionSynchronizationManager.initSynchronization();
 
@@ -151,7 +151,7 @@ class VerificationEmailWorkflowTest {
 
     assertThrows(IllegalStateException.class, this::runAfterCommitCallbacks);
 
-    verify(emailSender).send(emailMessage);
+    verify(emailSender).send(TEST_VERIFICATION_EMAIL_MESSAGE);
     verify(self)
         .restoreVerificationTokenExpiryWithErrorHandling(
             TEST_USER_ID, FAILED_ATTEMPT_EXPIRY, PREVIOUS_VERIFICATION_TOKEN_EXPIRY);
@@ -162,7 +162,7 @@ class VerificationEmailWorkflowTest {
   void restoreVerificationTokenExpiryWithErrorHandlingRestoresPreviousExpiryWhenCurrentMatches() {
     VerificationEmailWorkflow verificationEmailWorkflow =
         new VerificationEmailWorkflow(authEmailFactory, emailSender, userRepository, self);
-    UserEntity user = new UserEntity();
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
     user.setVerificationTokenExpiresAt(FAILED_ATTEMPT_EXPIRY);
 
     when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.of(user));
@@ -178,7 +178,7 @@ class VerificationEmailWorkflowTest {
   void restoreVerificationTokenExpiryWithErrorHandlingSkipsUpdateWhenCurrentExpiryChanged() {
     VerificationEmailWorkflow verificationEmailWorkflow =
         new VerificationEmailWorkflow(authEmailFactory, emailSender, userRepository, self);
-    UserEntity user = new UserEntity();
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
     user.setVerificationTokenExpiresAt(Instant.parse("2026-04-01T12:15:30Z"));
 
     when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.of(user));

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthLoginHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthLoginHelperTest.java
@@ -196,6 +196,49 @@ class AuthLoginHelperTest {
   }
 
   @Test
+  void loginAllowsVerificationEmailWhenCooldownStoreIsUnavailable() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    EmailMessageDto emailMessage =
+        new EmailMessageDto(
+            TEST_EMAIL_LAURA,
+            TEST_EMAIL_SUBJECT_VERIFY,
+            TEST_EMAIL_HTML_BODY,
+            TEST_EMAIL_TEXT_BODY);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(false);
+    when(trustedDeviceManager.hasReachedTrustedDeviceLimit(TEST_USER_ID)).thenReturn(false);
+    when(rateLimitStore.increment(
+            AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE,
+            String.valueOf(TEST_USER_ID),
+            java.time.Duration.ofDays(1)))
+        .thenThrow(new IllegalStateException("redis unavailable"));
+    when(accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE))
+        .thenReturn(verificationToken);
+    when(authEmailFactory.buildVerifyLoginDeviceEmailMessage(
+            TEST_EMAIL_LAURA,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS))
+        .thenReturn(emailMessage);
+    when(emailSender.send(emailMessage)).thenReturn(EmailSendResult.DELIVERED);
+
+    AuthException exception = assertThrows(AuthException.class, () -> authLoginHelper.login(user));
+
+    assertEquals(
+        ErrorDefinition.AUTH_LOGIN_DEVICE_VERIFICATION_REQUIRED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.FORBIDDEN, exception.getHttpStatus());
+    verify(emailSender).send(emailMessage);
+    verify(rateLimitStore, never())
+        .clear(AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE, String.valueOf(TEST_USER_ID));
+  }
+
+  @Test
   void loginThrowsEmailExceptionAndRollsBackCooldownWhenDeliveryIsSkippedByQuota() {
     UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
     user.setId(TEST_USER_ID);
@@ -233,6 +276,54 @@ class AuthLoginHelperTest {
 
     assertEquals(ErrorDefinition.EMAIL_DELIVERY_FAILED, exception.getErrorDefinition());
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getHttpStatus());
+    verify(rateLimitStore)
+        .clear(AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE, String.valueOf(TEST_USER_ID));
+    verify(refreshTokenHelper, never()).revokeActiveTokensByUserId(TEST_USER_ID);
+  }
+
+  @Test
+  void loginRethrowsOriginalSendFailureWhenCooldownRollbackAlsoFails() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+    user.setId(TEST_USER_ID);
+    AuthTokenDto verificationToken =
+        new AuthTokenDto(
+            TOKEN_TYPE_BEARER,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS,
+            TEST_ACCESS_TOKEN_JTI);
+    EmailMessageDto emailMessage =
+        new EmailMessageDto(
+            TEST_EMAIL_LAURA,
+            TEST_EMAIL_SUBJECT_VERIFY,
+            TEST_EMAIL_HTML_BODY,
+            TEST_EMAIL_TEXT_BODY);
+    EmailException sendException =
+        EmailException.of(
+            ErrorDefinition.EMAIL_DELIVERY_FAILED, null, HttpStatus.INTERNAL_SERVER_ERROR);
+
+    when(trustedDeviceManager.isTrustedCurrentDevice(user)).thenReturn(false);
+    when(trustedDeviceManager.hasReachedTrustedDeviceLimit(TEST_USER_ID)).thenReturn(false);
+    when(rateLimitStore.increment(
+            AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE,
+            String.valueOf(TEST_USER_ID),
+            java.time.Duration.ofDays(1)))
+        .thenReturn(1L);
+    when(accessTokenCodec.generateToken(user, AccessTokenType.VERIFY_LOGIN_DEVICE))
+        .thenReturn(verificationToken);
+    when(authEmailFactory.buildVerifyLoginDeviceEmailMessage(
+            TEST_EMAIL_LAURA,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN,
+            TEST_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS))
+        .thenReturn(emailMessage);
+    when(emailSender.send(emailMessage)).thenThrow(sendException);
+    org.mockito.Mockito.doThrow(new IllegalStateException("redis unavailable"))
+        .when(rateLimitStore)
+        .clear(AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE, String.valueOf(TEST_USER_ID));
+
+    EmailException exception =
+        assertThrows(EmailException.class, () -> authLoginHelper.login(user));
+
+    assertSame(sendException, exception);
     verify(rateLimitStore)
         .clear(AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE, String.valueOf(TEST_USER_ID));
     verify(refreshTokenHelper, never()).revokeActiveTokensByUserId(TEST_USER_ID);

--- a/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthRefreshTokenHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/auth/AuthRefreshTokenHelperTest.java
@@ -11,6 +11,7 @@ import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -89,7 +90,7 @@ class AuthRefreshTokenHelperTest {
     assertSame(user, persisted.getUser());
     assertEquals(authRefreshTokenHelper.hashRefreshToken(result.token()), persisted.getToken());
     assertEquals(result.expiresAt(), persisted.getExpiresAt());
-    assertEquals(false, persisted.isRevoked());
+    assertFalse(persisted.isRevoked());
     assertEquals(result.token(), tokenCaptor.getValue());
     assertEquals(result.expiresAt(), expiresAtCaptor.getValue());
     assertEquals(

--- a/user-service/src/test/java/com/tychewealth/service/helper/user/UserHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/user/UserHelperTest.java
@@ -1,0 +1,128 @@
+package com.tychewealth.service.helper.user;
+
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_ENCODED_PASSWORD;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_NEW_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.user.request.UserPasswordUpdateRequestDto;
+import com.tychewealth.dto.user.request.UserUpdateRequestDto;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.UserMetricEnum;
+import com.tychewealth.error.exception.UserException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.mapper.user.UserMapper;
+import com.tychewealth.monitoring.UserMetrics;
+import com.tychewealth.repository.UserRepository;
+import com.tychewealth.service.helper.auth.AuthRefreshTokenHelper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserHelperTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private UserMapper userMapper;
+  @Mock private AuthRefreshTokenHelper authRefreshTokenHelper;
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private SimpleMeterRegistry meterRegistry;
+  private UserHelper userHelper;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    userHelper =
+        new UserHelper(
+            userRepository,
+            userMapper,
+            authRefreshTokenHelper,
+            passwordEncoder,
+            new UserMetrics(meterRegistry));
+  }
+
+  @Test
+  void findActiveUserReturnsUserWhenItExists() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+
+    when(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID)).thenReturn(Optional.of(user));
+
+    UserEntity result = userHelper.findActiveUser(TEST_USER_ID);
+
+    assertSame(user, result);
+  }
+
+  @Test
+  void findActiveUserThrowsNotFoundWhenUserDoesNotExist() {
+    when(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID)).thenReturn(Optional.empty());
+
+    UserException exception =
+        assertThrows(UserException.class, () -> userHelper.findActiveUser(TEST_USER_ID));
+
+    assertEquals(ErrorDefinition.USER_NOT_FOUND, exception.getErrorDefinition());
+    assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, UserMetricEnum.NOT_FOUND.metricName()));
+  }
+
+  @Test
+  void updateMapsRequestAndSavesUser() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    UserUpdateRequestDto requestDto = new UserUpdateRequestDto(TEST_USERNAME_VALID);
+
+    when(userRepository.save(user)).thenReturn(user);
+
+    UserEntity result = userHelper.update(user, requestDto);
+
+    assertSame(user, result);
+    verify(userMapper).update(requestDto, user);
+    verify(userRepository).save(user);
+  }
+
+  @Test
+  void updatePasswordEncodesPasswordSavesUserAndRevokesRefreshTokens() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+    UserPasswordUpdateRequestDto requestDto =
+        new UserPasswordUpdateRequestDto(
+            TEST_ENCODED_PASSWORD, TEST_PASSWORD_NEW_VALID, TEST_PASSWORD_NEW_VALID);
+
+    when(passwordEncoder.encode(TEST_PASSWORD_NEW_VALID)).thenReturn("new-encoded-password");
+
+    Long result = userHelper.updatePassword(user, requestDto);
+
+    assertEquals(TEST_USER_ID, result);
+    assertEquals("new-encoded-password", user.getPassword());
+    verify(userRepository).save(user);
+    verify(authRefreshTokenHelper).revokeActiveTokensByUserId(TEST_USER_ID);
+  }
+
+  @Test
+  void softDeleteRevokesRefreshTokensSetsDeletedAtAndSavesUser() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+
+    Long result = userHelper.softDelete(user);
+
+    assertEquals(TEST_USER_ID, result);
+    assertNotNull(user.getDeletedAt());
+    verify(authRefreshTokenHelper).revokeActiveTokensByUserId(TEST_USER_ID);
+    verify(userRepository).save(user);
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/helper/user/UserValidationHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/user/UserValidationHelperTest.java
@@ -11,6 +11,7 @@ import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -128,5 +129,21 @@ class UserValidationHelperTest {
 
     verify(passwordEncoder).matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD);
     verify(passwordEncoder).matches(TEST_PASSWORD_NEW_VALID, TEST_ENCODED_PASSWORD);
+  }
+
+  @Test
+  void validatePasswordUpdateShortCircuitsWhenCurrentPasswordIsInvalid() {
+    UserPasswordUpdateRequestDto requestDto =
+        new UserPasswordUpdateRequestDto(
+            TEST_PASSWORD_VALID, TEST_PASSWORD_NEW_VALID, TEST_PASSWORD_NEW_VALID);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+
+    when(passwordEncoder.matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD)).thenReturn(false);
+
+    assertThrows(
+        UserException.class, () -> userValidationHelper.validatePasswordUpdate(requestDto, user));
+
+    verify(passwordEncoder).matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD);
+    verify(passwordEncoder, never()).matches(TEST_PASSWORD_NEW_VALID, TEST_ENCODED_PASSWORD);
   }
 }

--- a/user-service/src/test/java/com/tychewealth/service/helper/user/UserValidationHelperTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/helper/user/UserValidationHelperTest.java
@@ -1,0 +1,132 @@
+package com.tychewealth.service.helper.user;
+
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_ENCODED_PASSWORD;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_NEW_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static com.tychewealth.testhelper.MetricsTestHelper.counterValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.user.request.UserPasswordUpdateRequestDto;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.enums.UserMetricEnum;
+import com.tychewealth.error.exception.UserException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.monitoring.UserMetrics;
+import com.tychewealth.repository.UserRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserValidationHelperTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private SimpleMeterRegistry meterRegistry;
+  private UserValidationHelper userValidationHelper;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    userValidationHelper =
+        new UserValidationHelper(userRepository, passwordEncoder, new UserMetrics(meterRegistry));
+  }
+
+  @Test
+  void validateUsernameIsAvailableForUpdatePassesWhenUsernameBelongsToCurrentUser() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+
+    when(userRepository.findByUsernameAndDeletedAtIsNull(TEST_USERNAME_LAURA))
+        .thenReturn(Optional.of(user));
+
+    userValidationHelper.validateUsernameIsAvailableForUpdate(TEST_USERNAME_LAURA, TEST_USER_ID);
+
+    verify(userRepository).findByUsernameAndDeletedAtIsNull(TEST_USERNAME_LAURA);
+  }
+
+  @Test
+  void validateUsernameIsAvailableForUpdateThrowsConflictWhenUsernameBelongsToAnotherUser() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_VALID, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID + 1);
+
+    when(userRepository.findByUsernameAndDeletedAtIsNull(TEST_USERNAME_VALID))
+        .thenReturn(Optional.of(user));
+
+    UserException exception =
+        assertThrows(
+            UserException.class,
+            () ->
+                userValidationHelper.validateUsernameIsAvailableForUpdate(
+                    TEST_USERNAME_VALID, TEST_USER_ID));
+
+    assertEquals(ErrorDefinition.USER_USERNAME_CONFLICT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, UserMetricEnum.USERNAME_CONFLICT.metricName()));
+  }
+
+  @Test
+  void validateCurrentPasswordThrowsWhenPasswordDoesNotMatch() {
+    when(passwordEncoder.matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD)).thenReturn(false);
+
+    UserException exception =
+        assertThrows(
+            UserException.class,
+            () ->
+                userValidationHelper.validateCurrentPassword(
+                    TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD));
+
+    assertEquals(ErrorDefinition.USER_CURRENT_PASSWORD_INVALID, exception.getErrorDefinition());
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+    assertEquals(
+        1.0, counterValue(meterRegistry, UserMetricEnum.CURRENT_PASSWORD_INVALID.metricName()));
+  }
+
+  @Test
+  void validateNewPasswordIsDifferentThrowsWhenNewPasswordMatchesCurrentOne() {
+    when(passwordEncoder.matches(TEST_PASSWORD_NEW_VALID, TEST_ENCODED_PASSWORD)).thenReturn(true);
+
+    UserException exception =
+        assertThrows(
+            UserException.class,
+            () ->
+                userValidationHelper.validateNewPasswordIsDifferent(
+                    TEST_PASSWORD_NEW_VALID, TEST_ENCODED_PASSWORD));
+
+    assertEquals(
+        ErrorDefinition.USER_NEW_PASSWORD_MUST_BE_DIFFERENT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+    assertEquals(1.0, counterValue(meterRegistry, UserMetricEnum.NEW_PASSWORD_REUSED.metricName()));
+  }
+
+  @Test
+  void validatePasswordUpdateChecksCurrentAndNewPasswordRules() {
+    UserPasswordUpdateRequestDto requestDto =
+        new UserPasswordUpdateRequestDto(
+            TEST_PASSWORD_VALID, TEST_PASSWORD_NEW_VALID, TEST_PASSWORD_NEW_VALID);
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+
+    when(passwordEncoder.matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD)).thenReturn(true);
+    when(passwordEncoder.matches(TEST_PASSWORD_NEW_VALID, TEST_ENCODED_PASSWORD)).thenReturn(false);
+
+    userValidationHelper.validatePasswordUpdate(requestDto, user);
+
+    verify(passwordEncoder).matches(TEST_PASSWORD_VALID, TEST_ENCODED_PASSWORD);
+    verify(passwordEncoder).matches(TEST_PASSWORD_NEW_VALID, TEST_ENCODED_PASSWORD);
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/impl/UserServiceImplTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/impl/UserServiceImplTest.java
@@ -9,6 +9,7 @@ import static com.tychewealth.constants.TestConstants.TEST_UPDATE_USERNAME_REQUE
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -103,7 +104,7 @@ class UserServiceImplTest {
 
     Long result = userService.updatePassword(TEST_USER_ID, TEST_BEARER_ACCESS_TOKEN, requestDto);
 
-    assertSame(TEST_USER_ID, result);
+    assertEquals(TEST_USER_ID, result);
     verify(userValidationHelper).validatePasswordUpdate(requestDto, user);
     verify(userHelper).updatePassword(user, requestDto);
     verify(tokenStateStore, never()).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
@@ -141,7 +142,7 @@ class UserServiceImplTest {
 
     Long result = userService.delete(TEST_USER_ID, TEST_BEARER_ACCESS_TOKEN);
 
-    assertSame(TEST_USER_ID, result);
+    assertEquals(TEST_USER_ID, result);
     verify(userHelper).softDelete(user);
     verify(tokenStateStore, never()).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
 

--- a/user-service/src/test/java/com/tychewealth/service/impl/UserServiceImplTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/impl/UserServiceImplTest.java
@@ -1,0 +1,179 @@
+package com.tychewealth.service.impl;
+
+import static com.tychewealth.constants.TestConstants.TEST_BEARER_ACCESS_TOKEN;
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_ENCODED_PASSWORD;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_NEW_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_UPDATE_USERNAME_REQUEST;
+import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.dto.user.UserResponseDto;
+import com.tychewealth.dto.user.request.UserPasswordUpdateRequestDto;
+import com.tychewealth.dto.user.request.UserUpdateRequestDto;
+import com.tychewealth.entity.UserEntity;
+import com.tychewealth.mapper.user.UserMapper;
+import com.tychewealth.service.helper.user.UserHelper;
+import com.tychewealth.service.helper.user.UserValidationHelper;
+import com.tychewealth.service.token.TokenStateStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+  @Mock private UserMapper userMapper;
+  @Mock private UserHelper userHelper;
+  @Mock private UserValidationHelper userValidationHelper;
+  @Mock private TokenStateStore tokenStateStore;
+
+  @InjectMocks private UserServiceImpl userService;
+
+  @AfterEach
+  void tearDown() {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  void retrieveFindsActiveUserAndMapsToDto() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    UserResponseDto responseDto =
+        new UserResponseDto(TEST_USER_ID, TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, null);
+
+    when(userHelper.findActiveUser(TEST_USER_ID)).thenReturn(user);
+    when(userMapper.toDto(user)).thenReturn(responseDto);
+
+    UserResponseDto result = userService.retrieve(TEST_USER_ID);
+
+    assertSame(responseDto, result);
+    verify(userHelper).findActiveUser(TEST_USER_ID);
+    verify(userMapper).toDto(user);
+  }
+
+  @Test
+  void updateFindsValidatesUpdatesAndMapsUser() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+    UserUpdateRequestDto requestDto = new UserUpdateRequestDto(TEST_UPDATE_USERNAME_REQUEST);
+    UserEntity updatedUser =
+        buildUser(TEST_EMAIL_LAURA, TEST_UPDATE_USERNAME_REQUEST, TEST_ENCODED_PASSWORD);
+    UserResponseDto responseDto =
+        new UserResponseDto(TEST_USER_ID, TEST_EMAIL_LAURA, TEST_UPDATE_USERNAME_REQUEST, null);
+
+    when(userHelper.findActiveUser(TEST_USER_ID)).thenReturn(user);
+    when(userHelper.update(user, requestDto)).thenReturn(updatedUser);
+    when(userMapper.toDto(updatedUser)).thenReturn(responseDto);
+
+    UserResponseDto result = userService.update(TEST_USER_ID, requestDto);
+
+    assertSame(responseDto, result);
+    verify(userValidationHelper)
+        .validateUsernameIsAvailableForUpdate(requestDto.getUsername(), TEST_USER_ID);
+    verify(userHelper).update(user, requestDto);
+    verify(userMapper).toDto(updatedUser);
+  }
+
+  @Test
+  void updatePasswordValidatesSchedulesRevocationAndDelegatesToHelper() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+    UserPasswordUpdateRequestDto requestDto =
+        new UserPasswordUpdateRequestDto(
+            TEST_PASSWORD_VALID, TEST_PASSWORD_NEW_VALID, TEST_PASSWORD_NEW_VALID);
+
+    when(userHelper.findActiveUser(TEST_USER_ID)).thenReturn(user);
+    when(userHelper.updatePassword(user, requestDto)).thenReturn(TEST_USER_ID);
+
+    TransactionSynchronizationManager.initSynchronization();
+
+    Long result = userService.updatePassword(TEST_USER_ID, TEST_BEARER_ACCESS_TOKEN, requestDto);
+
+    assertSame(TEST_USER_ID, result);
+    verify(userValidationHelper).validatePasswordUpdate(requestDto, user);
+    verify(userHelper).updatePassword(user, requestDto);
+    verify(tokenStateStore, never()).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+
+    runAfterCommitCallbacks();
+
+    verify(tokenStateStore).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+  }
+
+  @Test
+  void updatePasswordRevokesImmediatelyWhenNoTransactionSynchronizationIsActive() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+    UserPasswordUpdateRequestDto requestDto =
+        new UserPasswordUpdateRequestDto(
+            TEST_PASSWORD_VALID, TEST_PASSWORD_NEW_VALID, TEST_PASSWORD_NEW_VALID);
+
+    when(userHelper.findActiveUser(TEST_USER_ID)).thenReturn(user);
+    when(userHelper.updatePassword(user, requestDto)).thenReturn(TEST_USER_ID);
+
+    userService.updatePassword(TEST_USER_ID, TEST_BEARER_ACCESS_TOKEN, requestDto);
+
+    verify(tokenStateStore).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+  }
+
+  @Test
+  void deleteFindsUserSchedulesRevocationAndDelegatesToHelper() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+
+    when(userHelper.findActiveUser(TEST_USER_ID)).thenReturn(user);
+    when(userHelper.softDelete(user)).thenReturn(TEST_USER_ID);
+
+    TransactionSynchronizationManager.initSynchronization();
+
+    Long result = userService.delete(TEST_USER_ID, TEST_BEARER_ACCESS_TOKEN);
+
+    assertSame(TEST_USER_ID, result);
+    verify(userHelper).softDelete(user);
+    verify(tokenStateStore, never()).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+
+    runAfterCommitCallbacks();
+
+    verify(tokenStateStore).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+  }
+
+  @Test
+  void deleteSwallowsErrorsWhenAfterCommitRevocationFails() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_ENCODED_PASSWORD);
+    user.setId(TEST_USER_ID);
+
+    when(userHelper.findActiveUser(TEST_USER_ID)).thenReturn(user);
+    when(userHelper.softDelete(user)).thenReturn(TEST_USER_ID);
+    doThrow(new IllegalStateException("redis unavailable"))
+        .when(tokenStateStore)
+        .revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+
+    TransactionSynchronizationManager.initSynchronization();
+
+    userService.delete(TEST_USER_ID, TEST_BEARER_ACCESS_TOKEN);
+
+    runAfterCommitCallbacks();
+
+    verify(tokenStateStore).revokeAccessTokenIfPresent(TEST_BEARER_ACCESS_TOKEN);
+  }
+
+  private void runAfterCommitCallbacks() {
+    for (TransactionSynchronization synchronization :
+        TransactionSynchronizationManager.getSynchronizations()) {
+      synchronization.afterCommit();
+    }
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/service/trusteddevice/TrustedDeviceManagerTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/trusteddevice/TrustedDeviceManagerTest.java
@@ -116,11 +116,12 @@ class TrustedDeviceManagerTest {
   void createTrustedDeviceCookieReusesExistingTrustedDeviceWhenCookieMatches() {
     UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
     user.setId(TRUSTED_DEVICE_USER_ID);
+    Instant now = Instant.now();
     TrustedDeviceEntity trustedDevice = new TrustedDeviceEntity();
     trustedDevice.setUser(user);
     trustedDevice.setTokenHash(Utils.sha256Hex(TEST_TRUSTED_DEVICE_TOKEN));
-    trustedDevice.setExpiresAt(Instant.parse("2026-04-01T10:15:30Z"));
-    trustedDevice.setLastUsedAt(Instant.parse("2026-04-01T09:15:30Z"));
+    trustedDevice.setExpiresAt(now.plus(Duration.ofDays(30)));
+    trustedDevice.setLastUsedAt(now.minus(Duration.ofHours(1)));
     setTrustedDeviceCookie();
 
     when(trustedDeviceRepository.findByUserIdAndTokenHashAndExpiresAtAfter(
@@ -175,8 +176,14 @@ class TrustedDeviceManagerTest {
     boolean result =
         trustedDeviceManager.hasReachedTrustedDeviceLimit(TRUSTED_DEVICE_LIMIT_USER_ID);
 
+    InOrder inOrder = inOrder(trustedDeviceRepository);
     assertTrue(result);
-    verify(trustedDeviceRepository).deleteByUserIdAndExpiresAtBefore(anyLong(), any(Instant.class));
+    inOrder
+        .verify(trustedDeviceRepository)
+        .deleteByUserIdAndExpiresAtBefore(anyLong(), any(Instant.class));
+    inOrder
+        .verify(trustedDeviceRepository)
+        .countByUserIdAndExpiresAtAfter(anyLong(), any(Instant.class));
   }
 
   @Test
@@ -208,10 +215,7 @@ class TrustedDeviceManagerTest {
 
   private void setTrustedDeviceCookie() {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setCookies(
-        new Cookie(
-            TEST_TRUSTED_DEVICE_COOKIE_NAME,
-            com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_TOKEN));
+    request.setCookies(new Cookie(TEST_TRUSTED_DEVICE_COOKIE_NAME, TEST_TRUSTED_DEVICE_TOKEN));
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
   }
 }

--- a/user-service/src/test/java/com/tychewealth/service/trusteddevice/TrustedDeviceManagerTest.java
+++ b/user-service/src/test/java/com/tychewealth/service/trusteddevice/TrustedDeviceManagerTest.java
@@ -1,11 +1,17 @@
 package com.tychewealth.service.trusteddevice;
 
+import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
 import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_COOKIE_NAME;
+import static com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_TOKEN;
+import static com.tychewealth.testdata.EntityBuilder.buildUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -17,6 +23,9 @@ import com.tychewealth.error.exception.AuthException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.TrustedDeviceRepository;
 import com.tychewealth.repository.UserRepository;
+import com.tychewealth.utils.Utils;
+import jakarta.servlet.http.Cookie;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -28,13 +37,16 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @ExtendWith(MockitoExtension.class)
 class TrustedDeviceManagerTest {
 
   private static final Long TRUSTED_DEVICE_USER_ID = 7L;
   private static final Long TRUSTED_DEVICE_LIMIT_USER_ID = 9L;
+  private static final Duration TEST_COOKIE_MAX_AGE = Duration.ofHours(1);
 
   @Mock private TrustedDeviceRepository trustedDeviceRepository;
   @Mock private UserRepository userRepository;
@@ -53,7 +65,7 @@ class TrustedDeviceManagerTest {
 
   @Test
   void createTrustedDeviceCookieLocksUserBeforeCheckingQuotaAndSaving() {
-    UserEntity user = new UserEntity();
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
     user.setId(TRUSTED_DEVICE_USER_ID);
 
     when(userRepository.findByIdForUpdate(user.getId())).thenReturn(Optional.of(user));
@@ -84,7 +96,7 @@ class TrustedDeviceManagerTest {
 
   @Test
   void createTrustedDeviceCookieThrowsConflictWhenQuotaIsReachedAfterLock() {
-    UserEntity user = new UserEntity();
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
     user.setId(TRUSTED_DEVICE_LIMIT_USER_ID);
 
     when(userRepository.findByIdForUpdate(user.getId())).thenReturn(Optional.of(user));
@@ -98,5 +110,108 @@ class TrustedDeviceManagerTest {
     assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
     assertEquals(ErrorDefinition.AUTH_TRUSTED_DEVICE_LIMIT_REACHED, exception.getErrorDefinition());
     verify(trustedDeviceRepository, never()).save(any(TrustedDeviceEntity.class));
+  }
+
+  @Test
+  void createTrustedDeviceCookieReusesExistingTrustedDeviceWhenCookieMatches() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
+    user.setId(TRUSTED_DEVICE_USER_ID);
+    TrustedDeviceEntity trustedDevice = new TrustedDeviceEntity();
+    trustedDevice.setUser(user);
+    trustedDevice.setTokenHash(Utils.sha256Hex(TEST_TRUSTED_DEVICE_TOKEN));
+    trustedDevice.setExpiresAt(Instant.parse("2026-04-01T10:15:30Z"));
+    trustedDevice.setLastUsedAt(Instant.parse("2026-04-01T09:15:30Z"));
+    setTrustedDeviceCookie();
+
+    when(trustedDeviceRepository.findByUserIdAndTokenHashAndExpiresAtAfter(
+            anyLong(), anyString(), any(Instant.class)))
+        .thenReturn(Optional.of(trustedDevice));
+
+    var cookie = trustedDeviceManager.createTrustedDeviceCookie(user);
+
+    assertEquals(TEST_TRUSTED_DEVICE_COOKIE_NAME, cookie.getName());
+    assertEquals(TEST_TRUSTED_DEVICE_TOKEN, cookie.getValue());
+    verify(trustedDeviceRepository).save(trustedDevice);
+    verify(userRepository, never()).findByIdForUpdate(anyLong());
+    verify(trustedDeviceRepository, never()).countByUserIdAndExpiresAtAfter(anyLong(), any());
+  }
+
+  @Test
+  void createTrustedDeviceCookieThrowsUnauthorizedWhenUserCannotBeLocked() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
+    user.setId(TRUSTED_DEVICE_USER_ID);
+
+    when(userRepository.findByIdForUpdate(TRUSTED_DEVICE_USER_ID)).thenReturn(Optional.empty());
+
+    AuthException exception =
+        assertThrows(
+            AuthException.class, () -> trustedDeviceManager.createTrustedDeviceCookie(user));
+
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+    assertEquals(ErrorDefinition.UNAUTHORIZED, exception.getErrorDefinition());
+    verify(trustedDeviceRepository, never()).save(any(TrustedDeviceEntity.class));
+  }
+
+  @Test
+  void buildTrustedDeviceCookieSetsExpectedSecurityAttributes() {
+    var cookie =
+        trustedDeviceManager.buildTrustedDeviceCookie(
+            TEST_TRUSTED_DEVICE_TOKEN, TEST_COOKIE_MAX_AGE);
+
+    assertEquals(TEST_TRUSTED_DEVICE_COOKIE_NAME, cookie.getName());
+    assertEquals(TEST_TRUSTED_DEVICE_TOKEN, cookie.getValue());
+    assertTrue(cookie.isHttpOnly());
+    assertTrue(cookie.isSecure());
+    assertEquals("Lax", cookie.getSameSite());
+    assertEquals("/", cookie.getPath());
+    assertEquals(TEST_COOKIE_MAX_AGE, cookie.getMaxAge());
+  }
+
+  @Test
+  void hasReachedTrustedDeviceLimitDeletesExpiredDevicesBeforeCounting() {
+    when(trustedDeviceRepository.countByUserIdAndExpiresAtAfter(anyLong(), any(Instant.class)))
+        .thenReturn(3L);
+
+    boolean result =
+        trustedDeviceManager.hasReachedTrustedDeviceLimit(TRUSTED_DEVICE_LIMIT_USER_ID);
+
+    assertTrue(result);
+    verify(trustedDeviceRepository).deleteByUserIdAndExpiresAtBefore(anyLong(), any(Instant.class));
+  }
+
+  @Test
+  void isTrustedCurrentDeviceReturnsTrueWhenCookieMatchesActiveTrustedDevice() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
+    user.setId(TRUSTED_DEVICE_USER_ID);
+    setTrustedDeviceCookie();
+
+    when(trustedDeviceRepository.findByUserIdAndTokenHashAndExpiresAtAfter(
+            anyLong(), anyString(), any(Instant.class)))
+        .thenReturn(Optional.of(new TrustedDeviceEntity()));
+
+    boolean result = trustedDeviceManager.isTrustedCurrentDevice(user);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void isTrustedCurrentDeviceReturnsFalseWhenNoCookieIsPresent() {
+    UserEntity user = buildUser(TEST_EMAIL_LAURA, null, null);
+    user.setId(TRUSTED_DEVICE_USER_ID);
+
+    boolean result = trustedDeviceManager.isTrustedCurrentDevice(user);
+
+    assertFalse(result);
+    verify(trustedDeviceRepository, never())
+        .findByUserIdAndTokenHashAndExpiresAtAfter(anyLong(), anyString(), any(Instant.class));
+  }
+
+  private void setTrustedDeviceCookie() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(
+        new Cookie(
+            TEST_TRUSTED_DEVICE_COOKIE_NAME,
+            com.tychewealth.constants.TestConstants.TEST_TRUSTED_DEVICE_TOKEN));
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
@@ -15,14 +15,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tychewealth.dto.auth.LoginResponseDto;
+import com.tychewealth.dto.auth.request.ForgotPasswordRequestDto;
 import com.tychewealth.dto.auth.request.LoginRequestDto;
 import com.tychewealth.dto.auth.request.RefreshTokenRequestDto;
 import com.tychewealth.dto.auth.request.RegisterRequestDto;
+import com.tychewealth.dto.auth.request.ResendVerificationEmailRequestDto;
 import com.tychewealth.entity.UserEntity;
 import com.tychewealth.repository.TrustedDeviceRepository;
 import jakarta.servlet.http.Cookie;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -142,6 +146,48 @@ public final class AuthTestHelper {
     return mockMvc.perform(requestBuilder);
   }
 
+  public static int forgotPasswordStatus(
+      MockMvc mockMvc, ObjectMapper objectMapper, ForgotPasswordRequestDto requestDto)
+      throws Exception {
+    return mockMvc
+        .perform(
+            get(AUTH_BASE_URL + "/forgot-password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+        .andReturn()
+        .getResponse()
+        .getStatus();
+  }
+
+  public static int resendVerificationStatus(
+      MockMvc mockMvc, ObjectMapper objectMapper, ResendVerificationEmailRequestDto requestDto)
+      throws Exception {
+    return mockMvc
+        .perform(
+            post(AUTH_BASE_URL + "/resend-verification")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+        .andReturn()
+        .getResponse()
+        .getStatus();
+  }
+
+  public static int verifyRegistrationStatus(MockMvc mockMvc, String token, Cookie trustedDevice)
+      throws Exception {
+    return verifyRegistrationRequest(mockMvc, token, trustedDevice)
+        .andReturn()
+        .getResponse()
+        .getStatus();
+  }
+
+  public static int verifyLoginDeviceStatus(MockMvc mockMvc, String token, Cookie trustedDevice)
+      throws Exception {
+    return verifyLoginDeviceRequest(mockMvc, token, trustedDevice)
+        .andReturn()
+        .getResponse()
+        .getStatus();
+  }
+
   public static String buildLongEmail() {
     String local = "a".repeat(64);
     String label63 = "b".repeat(63);
@@ -158,5 +204,12 @@ public final class AuthTestHelper {
     trustedDeviceRepository.save(trustedDevice);
 
     return new Cookie(TEST_TRUSTED_DEVICE_COOKIE_NAME, trustedDeviceToken);
+  }
+
+  public static String extractCookieValue(String setCookieHeader, String cookieName) {
+    Pattern cookiePattern = Pattern.compile(cookieName + "=([^;]+)");
+    Matcher matcher = cookiePattern.matcher(setCookieHeader);
+    org.junit.jupiter.api.Assertions.assertTrue(matcher.find());
+    return matcher.group(1);
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/AuthTestHelper.java
@@ -209,7 +209,12 @@ public final class AuthTestHelper {
   public static String extractCookieValue(String setCookieHeader, String cookieName) {
     Pattern cookiePattern = Pattern.compile(cookieName + "=([^;]+)");
     Matcher matcher = cookiePattern.matcher(setCookieHeader);
-    org.junit.jupiter.api.Assertions.assertTrue(matcher.find());
+    org.junit.jupiter.api.Assertions.assertTrue(
+        matcher.find(),
+        "Expected cookie '"
+            + cookieName
+            + "' in Set-Cookie header but was missing. Header: "
+            + setCookieHeader);
     return matcher.group(1);
   }
 }

--- a/user-service/src/test/java/com/tychewealth/testhelper/ConcurrentTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/ConcurrentTestHelper.java
@@ -1,0 +1,60 @@
+package com.tychewealth.testhelper;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public final class ConcurrentTestHelper {
+
+  private ConcurrentTestHelper() {}
+
+  @SafeVarargs
+  public static <T> List<T> runConcurrently(Callable<T>... tasks) throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(tasks.length);
+    CountDownLatch ready = new CountDownLatch(tasks.length);
+    CountDownLatch start = new CountDownLatch(1);
+    try {
+      List<Future<T>> futures = new ArrayList<>();
+      for (Callable<T> task : tasks) {
+        futures.add(
+            executorService.submit(
+                () -> {
+                  ready.countDown();
+                  start.await(5, TimeUnit.SECONDS);
+                  return task.call();
+                }));
+      }
+
+      assertTrue(ready.await(5, TimeUnit.SECONDS));
+      start.countDown();
+
+      List<T> results = new ArrayList<>();
+      for (Future<T> future : futures) {
+        results.add(getFutureValue(future));
+      }
+      return results;
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  private static <T> T getFutureValue(Future<T> future) throws Exception {
+    try {
+      return future.get(10, TimeUnit.SECONDS);
+    } catch (ExecutionException ex) {
+      Throwable cause = ex.getCause();
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      throw ex;
+    }
+  }
+}

--- a/user-service/src/test/java/com/tychewealth/testhelper/ConcurrentTestHelper.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/ConcurrentTestHelper.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public final class ConcurrentTestHelper {
 
@@ -28,7 +29,9 @@ public final class ConcurrentTestHelper {
             executorService.submit(
                 () -> {
                   ready.countDown();
-                  start.await(5, TimeUnit.SECONDS);
+                  if (!start.await(5, TimeUnit.SECONDS)) {
+                    throw new TimeoutException("Timed out waiting to start concurrent tasks");
+                  }
                   return task.call();
                 }));
       }

--- a/user-service/src/test/java/com/tychewealth/testhelper/TestRedisSupport.java
+++ b/user-service/src/test/java/com/tychewealth/testhelper/TestRedisSupport.java
@@ -3,6 +3,7 @@ package com.tychewealth.testhelper;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.mockito.Mockito;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -97,6 +98,15 @@ public final class TestRedisSupport {
             })
         .when(valueOperations)
         .set(Mockito.anyString(), Mockito.anyString());
+    Mockito.when(
+            valueOperations.setIfAbsent(
+                Mockito.anyString(), Mockito.anyString(), Mockito.any(Duration.class)))
+        .thenAnswer(
+            invocation ->
+                state.putIfAbsent(
+                    invocation.getArgument(0),
+                    invocation.getArgument(1),
+                    invocation.getArgument(2)));
     Mockito.when(valueOperations.get(Mockito.anyString()))
         .thenAnswer(invocation -> state.get(invocation.getArgument(0)));
 
@@ -108,6 +118,21 @@ public final class TestRedisSupport {
 
     public void set(String key, String value, Duration ttl) {
       entries.put(key, new StoredValue(value, expiresAt(ttl)));
+    }
+
+    public boolean putIfAbsent(String key, String value, Duration ttl) {
+      long now = System.currentTimeMillis();
+      AtomicBoolean inserted = new AtomicBoolean(false);
+      entries.compute(
+          key,
+          (ignored, current) -> {
+            if (current == null || current.isExpired(now)) {
+              inserted.set(true);
+              return new StoredValue(value, expiresAt(ttl));
+            }
+            return current;
+          });
+      return inserted.get();
     }
 
     public String get(String key) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive auth idempotency integration tests validating concurrent retries across multiple auth endpoints.
  * Added/expanded unit tests for user helper, validation, service impl, login/refresh helpers, trusted-device behaviors, and email workflow consistency.
  * Introduced concurrent test utility and enhanced test Redis support and auth test helpers for cookie/status extraction.
  * General improvements to test infrastructure, assertions, and reusable test constants for consistency.

Closes #65 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->