### PR TITLE
[TYCHE-43] add list portfolio endpoint

### DIFF
--- a/services/portfolio-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -8,6 +8,7 @@ public final class LogConstants {
   public static final String AUTH = "[auth]";
   public static final String SYSTEM = "[system]";
   public static final String CREATE_ACTION = "[create]";
+  public static final String LIST_PORTFOLIOS_ACTION = "[list-portfolios]";
   public static final String ERROR_HANDLER_ACTION = "[error-handler]";
   public static final String ACCESS_TOKEN_ACTION = "[access-token]";
   public static final String RATE_LIMIT_ACTION = "[rate-limit]";
@@ -23,6 +24,7 @@ public final class LogConstants {
   public static final String MISSING_AUTHENTICATED_USER_MESSAGE = "missing authenticated user";
   public static final String PORTFOLIO_NAME_ALREADY_EXISTS_MESSAGE =
       "portfolio name already exists for user";
+  public static final String PORTFOLIO_LIMIT_REACHED_MESSAGE = "portfolio limit reached for user";
   public static final String PORTFOLIO_PERSISTENCE_CONFLICT_MESSAGE =
       "portfolio conflict detected at persistence layer";
   public static final String UNKNOWN_PERSISTENCE_CONFLICT_MESSAGE = "unknown persistence conflict";

--- a/services/portfolio-service/src/main/java/com/tychewealth/controller/PortfolioApi.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/controller/PortfolioApi.java
@@ -8,8 +8,10 @@ import com.tychewealth.dto.portfolio.PortfolioResponseDto;
 import com.tychewealth.dto.portfolio.request.PortfolioCreateRequestDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping(value = PORTFOLIO_BASE_URL)
 @Tag(name = "Portfolio")
 public interface PortfolioApi {
+
+  @GetMapping(value = "/me", produces = REQUEST_PRODUCES)
+  ResponseEntity<List<PortfolioResponseDto>> listPortfolios(@AuthenticationPrincipal Long userId);
 
   @PostMapping(consumes = REQUEST_CONSUMES, produces = REQUEST_PRODUCES)
   ResponseEntity<PortfolioResponseDto> create(

--- a/services/portfolio-service/src/main/java/com/tychewealth/controller/impl/PortfolioApiController.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/controller/impl/PortfolioApiController.java
@@ -1,6 +1,7 @@
 package com.tychewealth.controller.impl;
 
 import static com.tychewealth.constants.LogConstants.CREATE_ACTION;
+import static com.tychewealth.constants.LogConstants.LIST_PORTFOLIOS_ACTION;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO_NAME;
 import static com.tychewealth.constants.LogConstants.REQUEST_START;
@@ -13,6 +14,7 @@ import com.tychewealth.dto.portfolio.PortfolioResponseDto;
 import com.tychewealth.dto.portfolio.request.PortfolioCreateRequestDto;
 import com.tychewealth.service.PortfolioService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -27,6 +29,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class PortfolioApiController implements PortfolioApi {
 
   private final PortfolioService portfolioService;
+
+  @Override
+  public ResponseEntity<List<PortfolioResponseDto>> listPortfolios(
+      @AuthenticationPrincipal Long userId) {
+    log.info(REQUEST_START + USER_ID, PORTFOLIO, LIST_PORTFOLIOS_ACTION, userId);
+
+    List<PortfolioResponseDto> response = portfolioService.listPortfolios(userId);
+    log.info(REQUEST_SUCCESS + USER_ID, PORTFOLIO, LIST_PORTFOLIOS_ACTION, userId);
+
+    return status(HttpStatus.OK).body(response);
+  }
 
   @Override
   public ResponseEntity<PortfolioResponseDto> create(

--- a/services/portfolio-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/error/handler/ErrorDefinition.java
@@ -17,7 +17,11 @@ public enum ErrorDefinition {
   PORTFOLIO_NAME_CONFLICT(
       "TYCHE-400",
       "PORTFOLIO_NAME_CONFLICT",
-      "A portfolio with name '${name:-}' already exists for this user");
+      "A portfolio with name '${name:-}' already exists for this user"),
+  PORTFOLIO_LIMIT_REACHED(
+      "TYCHE-401",
+      "PORTFOLIO_LIMIT_REACHED",
+      "The maximum number of portfolios allowed per user has been reached");
 
   private final String code;
   private final String type;

--- a/services/portfolio-service/src/main/java/com/tychewealth/repository/PortfolioRepository.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/repository/PortfolioRepository.java
@@ -15,6 +15,8 @@ public interface PortfolioRepository extends JpaRepository<PortfolioEntity, Long
 
   List<PortfolioEntity> findByUserId(Long userId);
 
+  long countByUserId(Long userId);
+
   Optional<PortfolioEntity> findByUserIdAndName(Long userId, String name);
 
   List<PortfolioEntity> findByBaseCurrency(CurrencyCodeEnum baseCurrency);

--- a/services/portfolio-service/src/main/java/com/tychewealth/repository/PortfolioRepository.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/repository/PortfolioRepository.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PortfolioRepository extends JpaRepository<PortfolioEntity, Long> {
 
-  List<PortfolioEntity> findByUserId(Long userId);
+  List<PortfolioEntity> findByUserIdOrderByCreatedAtAsc(Long userId);
 
   long countByUserId(Long userId);
 

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/PortfolioService.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/PortfolioService.java
@@ -2,8 +2,11 @@ package com.tychewealth.service;
 
 import com.tychewealth.dto.portfolio.PortfolioResponseDto;
 import com.tychewealth.dto.portfolio.request.PortfolioCreateRequestDto;
+import java.util.List;
 
 public interface PortfolioService {
+
+  List<PortfolioResponseDto> listPortfolios(Long userId);
 
   PortfolioResponseDto create(Long userId, PortfolioCreateRequestDto createRequest);
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/helper/portfolio/PortfolioValidationHelper.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/helper/portfolio/PortfolioValidationHelper.java
@@ -4,6 +4,7 @@ import static com.tychewealth.constants.CommonConstants.*;
 import static com.tychewealth.constants.LogConstants.CREATE_ACTION;
 import static com.tychewealth.constants.LogConstants.MISSING_AUTHENTICATED_USER_MESSAGE;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO;
+import static com.tychewealth.constants.LogConstants.PORTFOLIO_LIMIT_REACHED_MESSAGE;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO_NAME;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO_NAME_ALREADY_EXISTS_MESSAGE;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO_PERSISTENCE_CONFLICT_MESSAGE;
@@ -11,6 +12,7 @@ import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
 import static com.tychewealth.constants.LogConstants.UNKNOWN_PERSISTENCE_CONFLICT_MESSAGE;
 import static com.tychewealth.constants.LogConstants.USER_ID;
 import static com.tychewealth.error.handler.ErrorDefinition.GENERIC_BAD_REQUEST;
+import static com.tychewealth.error.handler.ErrorDefinition.PORTFOLIO_LIMIT_REACHED;
 import static com.tychewealth.error.handler.ErrorDefinition.PORTFOLIO_NAME_CONFLICT;
 
 import com.tychewealth.dto.portfolio.request.PortfolioCreateRequestDto;
@@ -29,33 +31,59 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class PortfolioValidationHelper {
 
+  private static final long MAX_PORTFOLIOS_PER_USER = 5L;
   private static final String PORTFOLIO_UNIQUE_CONSTRAINT = "uq_portfolio_user_id_name";
 
   private final PortfolioRepository portfolioRepository;
 
   public void validateCreateRequest(Long userId, PortfolioCreateRequestDto createRequest) {
-    if (userId == null) {
-      log.warn(REQUEST_CONFLICT, PORTFOLIO, CREATE_ACTION, MISSING_AUTHENTICATED_USER_MESSAGE);
-      throw new PortfolioException(
-          GENERIC_BAD_REQUEST,
-          Map.of(ERROR, MISSING_AUTHENTICATED_USER_MESSAGE),
-          HttpStatus.BAD_REQUEST);
+    String portfolioName = createRequest == null ? null : createRequest.getName();
+    validateAuthenticatedUser(userId);
+    validateCreateLimit(userId);
+    validateCreateNameConflict(userId, portfolioName);
+  }
+
+  public void validateAuthenticatedUser(Long userId) {
+    if (userId != null) {
+      return;
     }
 
-    String portfolioName = createRequest == null ? null : createRequest.getName();
-    if (portfolioRepository.existsByUserIdAndName(userId, portfolioName)) {
+    log.warn(REQUEST_CONFLICT, PORTFOLIO, CREATE_ACTION, MISSING_AUTHENTICATED_USER_MESSAGE);
+    throw new PortfolioException(
+        GENERIC_BAD_REQUEST,
+        Map.of(ERROR, MISSING_AUTHENTICATED_USER_MESSAGE),
+        HttpStatus.BAD_REQUEST);
+  }
+
+  public void validateCreateLimit(Long userId) {
+    long currentPortfolioCount = portfolioRepository.countByUserId(userId);
+    if (currentPortfolioCount >= MAX_PORTFOLIOS_PER_USER) {
       log.warn(
-          REQUEST_CONFLICT + PORTFOLIO_NAME + USER_ID,
+          REQUEST_CONFLICT + USER_ID,
           PORTFOLIO,
           CREATE_ACTION,
-          PORTFOLIO_NAME_ALREADY_EXISTS_MESSAGE,
-          portfolioName,
+          PORTFOLIO_LIMIT_REACHED_MESSAGE,
           userId);
-      throw new PortfolioException(
-          PORTFOLIO_NAME_CONFLICT,
-          Map.of(NAME, portfolioName == null ? "" : portfolioName),
-          HttpStatus.CONFLICT);
+      throw new PortfolioException(PORTFOLIO_LIMIT_REACHED, Map.of(), HttpStatus.CONFLICT);
     }
+  }
+
+  public void validateCreateNameConflict(Long userId, String portfolioName) {
+    if (!portfolioRepository.existsByUserIdAndName(userId, portfolioName)) {
+      return;
+    }
+
+    log.warn(
+        REQUEST_CONFLICT + PORTFOLIO_NAME + USER_ID,
+        PORTFOLIO,
+        CREATE_ACTION,
+        PORTFOLIO_NAME_ALREADY_EXISTS_MESSAGE,
+        portfolioName,
+        userId);
+    throw new PortfolioException(
+        PORTFOLIO_NAME_CONFLICT,
+        Map.of(NAME, portfolioName == null ? "" : portfolioName),
+        HttpStatus.CONFLICT);
   }
 
   public PortfolioException validateCreatePersistenceConflict(

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -24,11 +25,13 @@ public class PortfolioServiceImpl implements PortfolioService {
   @Override
   @Transactional(readOnly = true)
   public List<PortfolioResponseDto> listPortfolios(Long userId) {
-    return portfolioRepository.findByUserId(userId).stream().map(portfolioMapper::toDto).toList();
+    return portfolioRepository.findByUserIdOrderByCreatedAtAsc(userId).stream()
+        .map(portfolioMapper::toDto)
+        .toList();
   }
 
   @Override
-  @Transactional
+  @Transactional(isolation = Isolation.SERIALIZABLE)
   public PortfolioResponseDto create(Long userId, PortfolioCreateRequestDto createRequest) {
     portfolioValidationHelper.validateCreateRequest(userId, createRequest);
 

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
@@ -7,6 +7,7 @@ import com.tychewealth.mapper.portfolio.PortfolioMapper;
 import com.tychewealth.repository.PortfolioRepository;
 import com.tychewealth.service.PortfolioService;
 import com.tychewealth.service.helper.portfolio.PortfolioValidationHelper;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,12 @@ public class PortfolioServiceImpl implements PortfolioService {
   private final PortfolioRepository portfolioRepository;
   private final PortfolioMapper portfolioMapper;
   private final PortfolioValidationHelper portfolioValidationHelper;
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<PortfolioResponseDto> listPortfolios(Long userId) {
+    return portfolioRepository.findByUserId(userId).stream().map(portfolioMapper::toDto).toList();
+  }
 
   @Override
   @Transactional

--- a/services/portfolio-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -16,6 +16,8 @@ public final class TestConstants {
   public static final String TEST_PASSWORD_VALID = "Secret123!";
   public static final long TEST_USER_ID = 42L;
   public static final long TEST_OTHER_USER_ID = 84L;
+  public static final long TEST_MAX_PORTFOLIOS_PER_USER = 5L;
+  public static final String TEST_PORTFOLIO_NAME_CORE = "Core";
   public static final String TEST_PORTFOLIO_NAME_RETIREMENT = "Retirement";
   public static final String TEST_PORTFOLIO_DESCRIPTION_LONG_TERM = "Long term portfolio";
   public static final String TEST_PORTFOLIO_DESCRIPTION_ANOTHER = "Another description";

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioApiControllerIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioApiControllerIntegrationTest.java
@@ -159,7 +159,8 @@ class PortfolioApiControllerIntegrationTest {
         .andExpect(jsonPath("$.createdAt").exists())
         .andExpect(jsonPath("$.updatedAt").exists());
 
-    List<PortfolioEntity> portfolios = portfolioRepository.findByUserId(TEST_USER_ID);
+    List<PortfolioEntity> portfolios =
+        portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_USER_ID);
     assertEquals(1, portfolios.size());
     assertEquals(TEST_PORTFOLIO_NAME_RETIREMENT, portfolios.getFirst().getName());
     assertNotNull(portfolios.getFirst().getCreatedAt());
@@ -314,7 +315,7 @@ class PortfolioApiControllerIntegrationTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$." + NAME).value(TEST_PORTFOLIO_NAME_RETIREMENT));
 
-    assertEquals(1, portfolioRepository.findByUserId(TEST_USER_ID).size());
-    assertEquals(1, portfolioRepository.findByUserId(TEST_OTHER_USER_ID).size());
+    assertEquals(1, portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_USER_ID).size());
+    assertEquals(1, portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_OTHER_USER_ID).size());
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioApiControllerIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioApiControllerIntegrationTest.java
@@ -13,11 +13,13 @@ import static com.tychewealth.constants.TestConstants.TEST_BASE_CURRENCY_EUR;
 import static com.tychewealth.constants.TestConstants.TEST_BASE_CURRENCY_USD;
 import static com.tychewealth.constants.TestConstants.TEST_INVESTMENT_HORIZON_LONG;
 import static com.tychewealth.constants.TestConstants.TEST_INVESTMENT_HORIZON_MEDIUM;
+import static com.tychewealth.constants.TestConstants.TEST_MAX_PORTFOLIOS_PER_USER;
 import static com.tychewealth.constants.TestConstants.TEST_OTHER_USER_ID;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_DESCRIPTION_ANOTHER;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_DESCRIPTION_LONG_TERM;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_DESCRIPTION_OTHER_OWNER;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_MAX_RISK;
+import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_NAME_CORE;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_NAME_RETIREMENT;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_OTHER_MAX_RISK;
 import static com.tychewealth.constants.TestConstants.TEST_RISK_PROFILE_LOW;
@@ -29,7 +31,9 @@ import static com.tychewealth.testdata.EntityBuilder.buildPortfolio;
 import static com.tychewealth.testhelper.AuthTestHelper.createAuthorizationHeader;
 import static com.tychewealth.testhelper.PortfolioTestHelper.createRequest;
 import static com.tychewealth.testhelper.PortfolioTestHelper.createRequestBody;
+import static com.tychewealth.testhelper.PortfolioTestHelper.retrieveMeRequest;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -77,6 +81,57 @@ class PortfolioApiControllerIntegrationTest {
   void setUp() {
     assetRepository.deleteAll();
     portfolioRepository.deleteAll();
+  }
+
+  @Test
+  void retrieveReturnsOkWithAuthenticatedUserPortfoliosOnly() throws Exception {
+    portfolioRepository.saveAndFlush(
+        buildPortfolio(
+            TEST_USER_ID,
+            TEST_PORTFOLIO_NAME_CORE,
+            CurrencyCodeEnum.USD,
+            RiskProfileEnum.MEDIUM,
+            StrategyTypeEnum.BALANCED,
+            InvestmentHorizonEnum.MEDIUM));
+    portfolioRepository.saveAndFlush(
+        buildPortfolio(
+            TEST_USER_ID,
+            TEST_PORTFOLIO_NAME_RETIREMENT,
+            CurrencyCodeEnum.EUR,
+            RiskProfileEnum.LOW,
+            StrategyTypeEnum.INCOME,
+            InvestmentHorizonEnum.LONG));
+    portfolioRepository.saveAndFlush(
+        buildPortfolio(
+            TEST_OTHER_USER_ID,
+            "Other User Portfolio",
+            CurrencyCodeEnum.EUR,
+            RiskProfileEnum.LOW,
+            StrategyTypeEnum.INCOME,
+            InvestmentHorizonEnum.LONG));
+
+    retrieveMeRequest(mockMvc, String.valueOf(TEST_USER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$[0].name").value(TEST_PORTFOLIO_NAME_CORE))
+        .andExpect(jsonPath("$[1].name").value(TEST_PORTFOLIO_NAME_RETIREMENT));
+  }
+
+  @Test
+  void retrieveReturnsEmptyListWhenAuthenticatedUserHasNoPortfolios() throws Exception {
+    retrieveMeRequest(mockMvc, String.valueOf(TEST_USER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(0)));
+  }
+
+  @Test
+  void retrieveReturnsUnauthorizedWhenAuthenticatedUserIsMissing() throws Exception {
+    retrieveMeRequest(mockMvc, null)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
+        .andExpect(
+            jsonPath("$." + DESCRIPTION).value(ErrorDefinition.UNAUTHORIZED.getDescription()));
   }
 
   @Test
@@ -196,7 +251,42 @@ class PortfolioApiControllerIntegrationTest {
         .andExpect(jsonPath("$.type").value(ErrorDefinition.PORTFOLIO_NAME_CONFLICT.getType()))
         .andExpect(
             jsonPath("$." + DESCRIPTION)
-                .value("A portfolio with name 'Retirement' already exists for this user"));
+                .value(
+                    ErrorDefinition.PORTFOLIO_NAME_CONFLICT
+                        .getDescription()
+                        .replace("${name:-}", TEST_PORTFOLIO_NAME_RETIREMENT)));
+  }
+
+  @Test
+  void createReturnsConflictWhenUserAlreadyHasMaximumPortfolios() throws Exception {
+    for (int index = 0; index < TEST_MAX_PORTFOLIOS_PER_USER; index++) {
+      portfolioRepository.saveAndFlush(
+          buildPortfolio(
+              TEST_USER_ID,
+              "Portfolio " + index,
+              CurrencyCodeEnum.EUR,
+              RiskProfileEnum.LOW,
+              StrategyTypeEnum.INCOME,
+              InvestmentHorizonEnum.LONG));
+    }
+
+    String requestBody =
+        createRequestBody(
+            TEST_PORTFOLIO_NAME_RETIREMENT,
+            TEST_PORTFOLIO_DESCRIPTION_LONG_TERM,
+            TEST_BASE_CURRENCY_EUR,
+            TEST_RISK_PROFILE_LOW,
+            TEST_INVESTMENT_HORIZON_LONG,
+            TEST_STRATEGY_TYPE_INCOME,
+            TEST_PORTFOLIO_MAX_RISK);
+
+    createRequest(mockMvc, String.valueOf(TEST_USER_ID), objectMapper, requestBody)
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(ErrorDefinition.PORTFOLIO_LIMIT_REACHED.getCode()))
+        .andExpect(jsonPath("$.type").value(ErrorDefinition.PORTFOLIO_LIMIT_REACHED.getType()))
+        .andExpect(
+            jsonPath("$." + DESCRIPTION)
+                .value(ErrorDefinition.PORTFOLIO_LIMIT_REACHED.getDescription()));
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioConcurrencyIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioConcurrencyIntegrationTest.java
@@ -64,7 +64,7 @@ class PortfolioConcurrencyIntegrationTest {
 
     assertEquals(1, createdCount);
     assertEquals(1, conflictCount);
-    assertEquals(1, portfolioRepository.findByUserId(TEST_USER_ID).size());
+    assertEquals(1, portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_USER_ID).size());
     assertTrue(
         responses.stream()
             .filter(response -> response.status() == 409)

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/impl/PortfolioApiControllerTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/impl/PortfolioApiControllerTest.java
@@ -8,6 +8,7 @@ import com.tychewealth.dto.portfolio.PortfolioResponseDto;
 import com.tychewealth.dto.portfolio.request.PortfolioCreateRequestDto;
 import com.tychewealth.enums.CurrencyCodeEnum;
 import com.tychewealth.service.PortfolioService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +23,27 @@ class PortfolioApiControllerTest {
   @Mock private PortfolioService portfolioService;
 
   @InjectMocks private PortfolioApiController portfolioApiController;
+
+  @Test
+  void listPortfoliosReturnsOkResponse() {
+    PortfolioResponseDto firstPortfolio = new PortfolioResponseDto();
+    firstPortfolio.setId(7L);
+    firstPortfolio.setName("Core");
+
+    PortfolioResponseDto secondPortfolio = new PortfolioResponseDto();
+    secondPortfolio.setId(8L);
+    secondPortfolio.setName("Retirement");
+
+    List<PortfolioResponseDto> response = List.of(firstPortfolio, secondPortfolio);
+
+    when(portfolioService.listPortfolios(42L)).thenReturn(response);
+
+    ResponseEntity<List<PortfolioResponseDto>> result = portfolioApiController.listPortfolios(42L);
+
+    assertEquals(HttpStatus.OK, result.getStatusCode());
+    assertEquals(response, result.getBody());
+    verify(portfolioService).listPortfolios(42L);
+  }
 
   @Test
   void createReturnsCreatedResponse() {

--- a/services/portfolio-service/src/test/java/com/tychewealth/repository/PortfolioRepositoryTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/repository/PortfolioRepositoryTest.java
@@ -15,7 +15,6 @@ import com.tychewealth.enums.StrategyTypeEnum;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -28,11 +27,8 @@ class PortfolioRepositoryTest {
 
   @Autowired private PortfolioRepository portfolioRepository;
 
-  @BeforeEach
-  void setUp() {}
-
   @Test
-  void findByUserIdOrderByCreatedAtAscReturnsPortfoliosInCreationOrder() {
+  void findByUserIdOrderByCreatedAtAscReturnsPortfoliosOrderedByCreatedAt() {
     PortfolioEntity retirementPortfolio =
         portfolioRepository.saveAndFlush(
             buildPortfolio(
@@ -52,8 +48,8 @@ class PortfolioRepositoryTest {
                 StrategyTypeEnum.INCOME,
                 InvestmentHorizonEnum.LONG));
 
-    retirementPortfolio.setCreatedAt(LocalDateTime.now().minusDays(1));
-    corePortfolio.setCreatedAt(LocalDateTime.now());
+    retirementPortfolio.setCreatedAt(LocalDateTime.now());
+    corePortfolio.setCreatedAt(LocalDateTime.now().minusDays(1));
     portfolioRepository.saveAndFlush(retirementPortfolio);
     portfolioRepository.saveAndFlush(corePortfolio);
 
@@ -62,8 +58,9 @@ class PortfolioRepositoryTest {
 
     assertNotNull(result);
     assertEquals(2, result.size());
-    assertEquals("Retirement", result.get(0).getName());
-    assertEquals("Core", result.get(1).getName());
+    assertEquals("Core", result.get(0).getName());
+    assertEquals("Retirement", result.get(1).getName());
+    assertTrue(result.get(0).getCreatedAt().isBefore(result.get(1).getCreatedAt()));
   }
 
   @Test
@@ -117,7 +114,7 @@ class PortfolioRepositoryTest {
 
     assertNotNull(result);
     assertEquals(1, result.size());
-    assertEquals("Spec", result.get(0).getName());
+    assertEquals("Spec", result.getFirst().getName());
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/repository/PortfolioRepositoryTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/repository/PortfolioRepositoryTest.java
@@ -12,6 +12,7 @@ import com.tychewealth.enums.CurrencyCodeEnum;
 import com.tychewealth.enums.InvestmentHorizonEnum;
 import com.tychewealth.enums.RiskProfileEnum;
 import com.tychewealth.enums.StrategyTypeEnum;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,21 +32,38 @@ class PortfolioRepositoryTest {
   void setUp() {}
 
   @Test
-  void findByUserIdReturnsPortfolio() {
-    portfolioRepository.save(
-        buildPortfolio(
-            TEST_USER_ID,
-            "Core",
-            CurrencyCodeEnum.EUR,
-            RiskProfileEnum.MEDIUM,
-            StrategyTypeEnum.BALANCED,
-            InvestmentHorizonEnum.MEDIUM));
+  void findByUserIdOrderByCreatedAtAscReturnsPortfoliosInCreationOrder() {
+    PortfolioEntity retirementPortfolio =
+        portfolioRepository.saveAndFlush(
+            buildPortfolio(
+                TEST_USER_ID,
+                "Retirement",
+                CurrencyCodeEnum.EUR,
+                RiskProfileEnum.MEDIUM,
+                StrategyTypeEnum.BALANCED,
+                InvestmentHorizonEnum.MEDIUM));
+    PortfolioEntity corePortfolio =
+        portfolioRepository.saveAndFlush(
+            buildPortfolio(
+                TEST_USER_ID,
+                "Core",
+                CurrencyCodeEnum.USD,
+                RiskProfileEnum.LOW,
+                StrategyTypeEnum.INCOME,
+                InvestmentHorizonEnum.LONG));
 
-    List<PortfolioEntity> result = portfolioRepository.findByUserId(TEST_USER_ID);
+    retirementPortfolio.setCreatedAt(LocalDateTime.now().minusDays(1));
+    corePortfolio.setCreatedAt(LocalDateTime.now());
+    portfolioRepository.saveAndFlush(retirementPortfolio);
+    portfolioRepository.saveAndFlush(corePortfolio);
+
+    List<PortfolioEntity> result =
+        portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_USER_ID);
 
     assertNotNull(result);
-    assertEquals(1, result.size());
-    assertEquals("Core", result.get(0).getName());
+    assertEquals(2, result.size());
+    assertEquals("Retirement", result.get(0).getName());
+    assertEquals("Core", result.get(1).getName());
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/helper/portfolio/PortfolioValidationHelperTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/helper/portfolio/PortfolioValidationHelperTest.java
@@ -3,6 +3,7 @@ package com.tychewealth.service.helper.portfolio;
 import static com.tychewealth.constants.CommonConstants.ERROR;
 import static com.tychewealth.constants.CommonConstants.NAME;
 import static com.tychewealth.constants.LogConstants.MISSING_AUTHENTICATED_USER_MESSAGE;
+import static com.tychewealth.constants.TestConstants.TEST_MAX_PORTFOLIOS_PER_USER;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_NAME_RETIREMENT;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,11 +35,13 @@ class PortfolioValidationHelperTest {
     request.setName(TEST_PORTFOLIO_NAME_RETIREMENT);
     PortfolioValidationHelper helper = new PortfolioValidationHelper(portfolioRepository);
 
+    when(portfolioRepository.countByUserId(TEST_USER_ID)).thenReturn(0L);
     when(portfolioRepository.existsByUserIdAndName(TEST_USER_ID, TEST_PORTFOLIO_NAME_RETIREMENT))
         .thenReturn(false);
 
     helper.validateCreateRequest(TEST_USER_ID, request);
 
+    verify(portfolioRepository).countByUserId(TEST_USER_ID);
     verify(portfolioRepository).existsByUserIdAndName(TEST_USER_ID, TEST_PORTFOLIO_NAME_RETIREMENT);
   }
 
@@ -57,11 +60,24 @@ class PortfolioValidationHelperTest {
   }
 
   @Test
+  void validateAuthenticatedUserThrowsBadRequestWhenAuthenticatedUserIsMissing() {
+    PortfolioValidationHelper helper = new PortfolioValidationHelper(portfolioRepository);
+
+    PortfolioException exception =
+        assertThrows(PortfolioException.class, () -> helper.validateAuthenticatedUser(null));
+
+    assertEquals(ErrorDefinition.GENERIC_BAD_REQUEST, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+    assertEquals(MISSING_AUTHENTICATED_USER_MESSAGE, exception.getMetadata().get(ERROR));
+  }
+
+  @Test
   void validateCreateRequestThrowsConflictWhenPortfolioNameAlreadyExists() {
     PortfolioCreateRequestDto request = new PortfolioCreateRequestDto();
     request.setName(TEST_PORTFOLIO_NAME_RETIREMENT);
     PortfolioValidationHelper helper = new PortfolioValidationHelper(portfolioRepository);
 
+    when(portfolioRepository.countByUserId(TEST_USER_ID)).thenReturn(0L);
     when(portfolioRepository.existsByUserIdAndName(TEST_USER_ID, TEST_PORTFOLIO_NAME_RETIREMENT))
         .thenReturn(true);
 
@@ -72,6 +88,36 @@ class PortfolioValidationHelperTest {
     assertEquals(ErrorDefinition.PORTFOLIO_NAME_CONFLICT, exception.getErrorDefinition());
     assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
     assertEquals(TEST_PORTFOLIO_NAME_RETIREMENT, exception.getMetadata().get(NAME));
+  }
+
+  @Test
+  void validateCreateNameConflictThrowsConflictWhenPortfolioNameAlreadyExists() {
+    PortfolioValidationHelper helper = new PortfolioValidationHelper(portfolioRepository);
+
+    when(portfolioRepository.existsByUserIdAndName(TEST_USER_ID, TEST_PORTFOLIO_NAME_RETIREMENT))
+        .thenReturn(true);
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class,
+            () -> helper.validateCreateNameConflict(TEST_USER_ID, TEST_PORTFOLIO_NAME_RETIREMENT));
+
+    assertEquals(ErrorDefinition.PORTFOLIO_NAME_CONFLICT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    assertEquals(TEST_PORTFOLIO_NAME_RETIREMENT, exception.getMetadata().get(NAME));
+  }
+
+  @Test
+  void validateCreateLimitThrowsConflictWhenUserAlreadyHasMaximumPortfolios() {
+    PortfolioValidationHelper helper = new PortfolioValidationHelper(portfolioRepository);
+
+    when(portfolioRepository.countByUserId(TEST_USER_ID)).thenReturn(TEST_MAX_PORTFOLIOS_PER_USER);
+
+    PortfolioException exception =
+        assertThrows(PortfolioException.class, () -> helper.validateCreateLimit(TEST_USER_ID));
+
+    assertEquals(ErrorDefinition.PORTFOLIO_LIMIT_REACHED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/impl/PortfolioServiceImplTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/impl/PortfolioServiceImplTest.java
@@ -43,7 +43,7 @@ class PortfolioServiceImplTest {
   @InjectMocks private PortfolioServiceImpl portfolioService;
 
   @Test
-  void listPortfoliosReturnsMappedPortfoliosForUser() {
+  void listPortfoliosReturnsMappedPortfoliosForUserInCreatedAtOrder() {
     PortfolioEntity firstPortfolio =
         buildPortfolio(
             TEST_USER_ID,
@@ -72,7 +72,7 @@ class PortfolioServiceImplTest {
     secondResponse.setId(8L);
     secondResponse.setName(TEST_PORTFOLIO_NAME_RETIREMENT);
 
-    when(portfolioRepository.findByUserId(TEST_USER_ID))
+    when(portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_USER_ID))
         .thenReturn(List.of(firstPortfolio, secondPortfolio));
     when(portfolioMapper.toDto(firstPortfolio)).thenReturn(firstResponse);
     when(portfolioMapper.toDto(secondPortfolio)).thenReturn(secondResponse);
@@ -81,7 +81,7 @@ class PortfolioServiceImplTest {
 
     assertEquals(2, result.size());
     assertEquals(List.of(firstResponse, secondResponse), result);
-    verify(portfolioRepository).findByUserId(TEST_USER_ID);
+    verify(portfolioRepository).findByUserIdOrderByCreatedAtAsc(TEST_USER_ID);
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/impl/PortfolioServiceImplTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/impl/PortfolioServiceImplTest.java
@@ -3,6 +3,8 @@ package com.tychewealth.service.impl;
 import static com.tychewealth.constants.CommonConstants.NAME;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_MAX_RISK;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_NAME_RETIREMENT;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.EntityBuilder.buildPortfolio;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,10 +16,15 @@ import com.tychewealth.dto.portfolio.PortfolioResponseDto;
 import com.tychewealth.dto.portfolio.request.PortfolioCreateRequestDto;
 import com.tychewealth.entity.PortfolioEntity;
 import com.tychewealth.enums.CurrencyCodeEnum;
+import com.tychewealth.enums.InvestmentHorizonEnum;
+import com.tychewealth.enums.RiskProfileEnum;
+import com.tychewealth.enums.StrategyTypeEnum;
 import com.tychewealth.error.exception.PortfolioException;
+import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.mapper.portfolio.PortfolioMapper;
 import com.tychewealth.repository.PortfolioRepository;
 import com.tychewealth.service.helper.portfolio.PortfolioValidationHelper;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -34,6 +41,48 @@ class PortfolioServiceImplTest {
   @Mock private PortfolioValidationHelper portfolioValidationHelper;
 
   @InjectMocks private PortfolioServiceImpl portfolioService;
+
+  @Test
+  void listPortfoliosReturnsMappedPortfoliosForUser() {
+    PortfolioEntity firstPortfolio =
+        buildPortfolio(
+            TEST_USER_ID,
+            "Core",
+            CurrencyCodeEnum.USD,
+            RiskProfileEnum.MEDIUM,
+            StrategyTypeEnum.BALANCED,
+            InvestmentHorizonEnum.MEDIUM);
+    firstPortfolio.setId(7L);
+
+    PortfolioEntity secondPortfolio =
+        buildPortfolio(
+            TEST_USER_ID,
+            TEST_PORTFOLIO_NAME_RETIREMENT,
+            CurrencyCodeEnum.EUR,
+            RiskProfileEnum.LOW,
+            StrategyTypeEnum.INCOME,
+            InvestmentHorizonEnum.LONG);
+    secondPortfolio.setId(8L);
+
+    PortfolioResponseDto firstResponse = new PortfolioResponseDto();
+    firstResponse.setId(7L);
+    firstResponse.setName("Core");
+
+    PortfolioResponseDto secondResponse = new PortfolioResponseDto();
+    secondResponse.setId(8L);
+    secondResponse.setName(TEST_PORTFOLIO_NAME_RETIREMENT);
+
+    when(portfolioRepository.findByUserId(TEST_USER_ID))
+        .thenReturn(List.of(firstPortfolio, secondPortfolio));
+    when(portfolioMapper.toDto(firstPortfolio)).thenReturn(firstResponse);
+    when(portfolioMapper.toDto(secondPortfolio)).thenReturn(secondResponse);
+
+    List<PortfolioResponseDto> result = portfolioService.listPortfolios(TEST_USER_ID);
+
+    assertEquals(2, result.size());
+    assertEquals(List.of(firstResponse, secondResponse), result);
+    verify(portfolioRepository).findByUserId(TEST_USER_ID);
+  }
 
   @Test
   void createPersistsPortfolioAndReturnsResponse() {
@@ -95,7 +144,10 @@ class PortfolioServiceImplTest {
         assertThrows(PortfolioException.class, () -> portfolioService.create(42L, request));
 
     assertEquals(
-        "A portfolio with name 'Retirement' already exists for this user", expected.getMessage());
+        ErrorDefinition.PORTFOLIO_NAME_CONFLICT
+            .getDescription()
+            .replace("${name:-}", TEST_PORTFOLIO_NAME_RETIREMENT),
+        expected.getMessage());
     verify(portfolioValidationHelper)
         .validateCreatePersistenceConflict(
             eq(persistenceException), eq(TEST_PORTFOLIO_NAME_RETIREMENT));

--- a/services/portfolio-service/src/test/java/com/tychewealth/testhelper/PortfolioTestHelper.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/testhelper/PortfolioTestHelper.java
@@ -42,6 +42,14 @@ public final class PortfolioTestHelper {
     return mockMvc.perform(builder);
   }
 
+  public static ResultActions retrieveMeRequest(MockMvc mockMvc, String userId) throws Exception {
+    MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(PORTFOLIO_BASE_URL + "/me");
+    if (userId != null) {
+      builder.header(AUTHORIZATION_HEADER, createAuthorizationHeader(Long.parseLong(userId)));
+    }
+    return mockMvc.perform(builder);
+  }
+
   public static String createRequestBody(
       String name,
       String description,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoint to list a user's portfolios, returned in creation order
  * Enforced per-user portfolio cap (maximum 5); returns a clear conflict error when limit reached

* **Bug Fixes / Improvements**
  * Improved validation to require authenticated user for create requests

* **Tests**
  * Added and updated integration and unit tests covering listing, ordering, and limit enforcement

Closes #78 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->