### PR TITLE
[TYCHE-44] create delete portfolio endpoint

### DIFF
--- a/services/portfolio-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -8,6 +8,7 @@ public final class LogConstants {
   public static final String AUTH = "[auth]";
   public static final String SYSTEM = "[system]";
   public static final String CREATE_ACTION = "[create]";
+  public static final String DELETE_ACTION = "[delete]";
   public static final String LIST_PORTFOLIOS_ACTION = "[list-portfolios]";
   public static final String ERROR_HANDLER_ACTION = "[error-handler]";
   public static final String ACCESS_TOKEN_ACTION = "[access-token]";
@@ -18,6 +19,7 @@ public final class LogConstants {
   public static final String REQUEST_CONFLICT = BASE_LOG + " Request rejected: {}";
   public static final String REQUEST_CONFLICT_WITH_URI = REQUEST_CONFLICT + " uri={}";
   public static final String PORTFOLIO_NAME = " portfolioName={}";
+  public static final String PORTFOLIO_ID = " portfolioId={}";
   public static final String USER_ID = " userId={}";
   public static final String UNHANDLED_EXCEPTION_MESSAGE =
       "unhandled exception reached global error handler";

--- a/services/portfolio-service/src/main/java/com/tychewealth/controller/PortfolioApi.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/controller/PortfolioApi.java
@@ -11,7 +11,9 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,4 +29,7 @@ public interface PortfolioApi {
   ResponseEntity<PortfolioResponseDto> create(
       @AuthenticationPrincipal Long userId,
       @Valid @RequestBody PortfolioCreateRequestDto createRequest);
+
+  @DeleteMapping(value = "/me/{portfolioId}")
+  ResponseEntity<Void> delete(@AuthenticationPrincipal Long userId, @PathVariable Long portfolioId);
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/controller/impl/PortfolioApiController.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/controller/impl/PortfolioApiController.java
@@ -1,8 +1,10 @@
 package com.tychewealth.controller.impl;
 
 import static com.tychewealth.constants.LogConstants.CREATE_ACTION;
+import static com.tychewealth.constants.LogConstants.DELETE_ACTION;
 import static com.tychewealth.constants.LogConstants.LIST_PORTFOLIOS_ACTION;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO;
+import static com.tychewealth.constants.LogConstants.PORTFOLIO_ID;
 import static com.tychewealth.constants.LogConstants.PORTFOLIO_NAME;
 import static com.tychewealth.constants.LogConstants.REQUEST_START;
 import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
@@ -20,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -56,5 +59,17 @@ public class PortfolioApiController implements PortfolioApi {
     log.info(REQUEST_SUCCESS + USER_ID, PORTFOLIO, CREATE_ACTION, userId);
 
     return status(HttpStatus.CREATED).body(response);
+  }
+
+  @Override
+  public ResponseEntity<Void> delete(
+      @AuthenticationPrincipal Long userId, @PathVariable("portfolioId") Long portfolioId) {
+    log.info(REQUEST_START + PORTFOLIO_ID + USER_ID, PORTFOLIO, DELETE_ACTION, portfolioId, userId);
+
+    portfolioService.delete(userId, portfolioId);
+    log.info(
+        REQUEST_SUCCESS + PORTFOLIO_ID + USER_ID, PORTFOLIO, DELETE_ACTION, portfolioId, userId);
+
+    return status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/entity/PortfolioEntity.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/entity/PortfolioEntity.java
@@ -11,6 +11,7 @@ import com.tychewealth.enums.CurrencyCodeEnum;
 import com.tychewealth.enums.InvestmentHorizonEnum;
 import com.tychewealth.enums.RiskProfileEnum;
 import com.tychewealth.enums.StrategyTypeEnum;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -56,7 +57,7 @@ public class PortfolioEntity {
   @NotNull(message = MUST_NOT_BE_NULL)
   private Long userId;
 
-  @OneToMany(mappedBy = "portfolio")
+  @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<AssetEntity> assets = new ArrayList<>();
 
   @Column(name = "name", nullable = false, length = 60)

--- a/services/portfolio-service/src/main/java/com/tychewealth/repository/PortfolioRepository.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/repository/PortfolioRepository.java
@@ -17,6 +17,8 @@ public interface PortfolioRepository extends JpaRepository<PortfolioEntity, Long
 
   long countByUserId(Long userId);
 
+  Optional<PortfolioEntity> findByIdAndUserId(Long id, Long userId);
+
   Optional<PortfolioEntity> findByUserIdAndName(Long userId, String name);
 
   List<PortfolioEntity> findByBaseCurrency(CurrencyCodeEnum baseCurrency);

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/PortfolioService.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/PortfolioService.java
@@ -9,4 +9,6 @@ public interface PortfolioService {
   List<PortfolioResponseDto> listPortfolios(Long userId);
 
   PortfolioResponseDto create(Long userId, PortfolioCreateRequestDto createRequest);
+
+  void delete(Long userId, Long portfolioId);
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
@@ -45,4 +45,13 @@ public class PortfolioServiceImpl implements PortfolioService {
           ex, createRequest.getName());
     }
   }
+
+  @Override
+  @Transactional
+  public void delete(Long userId, Long portfolioId) {
+    portfolioValidationHelper.validateAuthenticatedUser(userId);
+    portfolioRepository
+        .findByIdAndUserId(portfolioId, userId)
+        .ifPresent(portfolioRepository::delete);
+  }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioApiControllerIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioApiControllerIntegrationTest.java
@@ -27,10 +27,12 @@ import static com.tychewealth.constants.TestConstants.TEST_RISK_PROFILE_MEDIUM;
 import static com.tychewealth.constants.TestConstants.TEST_STRATEGY_TYPE_BALANCED;
 import static com.tychewealth.constants.TestConstants.TEST_STRATEGY_TYPE_INCOME;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.EntityBuilder.buildAsset;
 import static com.tychewealth.testdata.EntityBuilder.buildPortfolio;
 import static com.tychewealth.testhelper.AuthTestHelper.createAuthorizationHeader;
 import static com.tychewealth.testhelper.PortfolioTestHelper.createRequest;
 import static com.tychewealth.testhelper.PortfolioTestHelper.createRequestBody;
+import static com.tychewealth.testhelper.PortfolioTestHelper.deleteMeRequest;
 import static com.tychewealth.testhelper.PortfolioTestHelper.retrieveMeRequest;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
@@ -42,6 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tychewealth.config.PortfolioIntegrationTestConfig;
 import com.tychewealth.entity.PortfolioEntity;
+import com.tychewealth.enums.AssetTypeEnum;
 import com.tychewealth.enums.CurrencyCodeEnum;
 import com.tychewealth.enums.InvestmentHorizonEnum;
 import com.tychewealth.enums.RiskProfileEnum;
@@ -146,7 +149,7 @@ class PortfolioApiControllerIntegrationTest {
             TEST_STRATEGY_TYPE_INCOME,
             TEST_PORTFOLIO_MAX_RISK);
 
-    createRequest(mockMvc, String.valueOf(TEST_USER_ID), objectMapper, requestBody)
+    createRequest(mockMvc, String.valueOf(TEST_USER_ID), requestBody)
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").isNumber())
         .andExpect(jsonPath("$." + NAME).value(TEST_PORTFOLIO_NAME_RETIREMENT))
@@ -178,7 +181,7 @@ class PortfolioApiControllerIntegrationTest {
             TEST_STRATEGY_TYPE_INCOME,
             TEST_PORTFOLIO_MAX_RISK);
 
-    createRequest(mockMvc, null, objectMapper, requestBody)
+    createRequest(mockMvc, null, requestBody)
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.UNAUTHORIZED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.UNAUTHORIZED.getType()))
@@ -190,7 +193,7 @@ class PortfolioApiControllerIntegrationTest {
   @MethodSource("com.tychewealth.testdata.PortfolioTestData#invalidCreateRequests")
   void createReturnsBadRequestForInvalidPayload(String requestBody, String expectedMessage)
       throws Exception {
-    createRequest(mockMvc, String.valueOf(TEST_USER_ID), objectMapper, requestBody)
+    createRequest(mockMvc, String.valueOf(TEST_USER_ID), requestBody)
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.GENERIC_VALIDATION_ERROR.getType()))
@@ -246,7 +249,7 @@ class PortfolioApiControllerIntegrationTest {
             TEST_STRATEGY_TYPE_INCOME,
             TEST_PORTFOLIO_MAX_RISK);
 
-    createRequest(mockMvc, String.valueOf(TEST_USER_ID), objectMapper, requestBody)
+    createRequest(mockMvc, String.valueOf(TEST_USER_ID), requestBody)
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.PORTFOLIO_NAME_CONFLICT.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.PORTFOLIO_NAME_CONFLICT.getType()))
@@ -281,7 +284,7 @@ class PortfolioApiControllerIntegrationTest {
             TEST_STRATEGY_TYPE_INCOME,
             TEST_PORTFOLIO_MAX_RISK);
 
-    createRequest(mockMvc, String.valueOf(TEST_USER_ID), objectMapper, requestBody)
+    createRequest(mockMvc, String.valueOf(TEST_USER_ID), requestBody)
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value(ErrorDefinition.PORTFOLIO_LIMIT_REACHED.getCode()))
         .andExpect(jsonPath("$.type").value(ErrorDefinition.PORTFOLIO_LIMIT_REACHED.getType()))
@@ -311,11 +314,65 @@ class PortfolioApiControllerIntegrationTest {
             TEST_STRATEGY_TYPE_BALANCED,
             TEST_PORTFOLIO_OTHER_MAX_RISK);
 
-    createRequest(mockMvc, String.valueOf(TEST_OTHER_USER_ID), objectMapper, requestBody)
+    createRequest(mockMvc, String.valueOf(TEST_OTHER_USER_ID), requestBody)
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$." + NAME).value(TEST_PORTFOLIO_NAME_RETIREMENT));
 
     assertEquals(1, portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_USER_ID).size());
     assertEquals(1, portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_OTHER_USER_ID).size());
+  }
+
+  @Test
+  void deleteReturnsNoContentAndRemovesOwnedPortfolioWithAssets() throws Exception {
+    PortfolioEntity portfolio =
+        portfolioRepository.saveAndFlush(
+            buildPortfolio(
+                TEST_USER_ID,
+                TEST_PORTFOLIO_NAME_RETIREMENT,
+                CurrencyCodeEnum.EUR,
+                RiskProfileEnum.LOW,
+                StrategyTypeEnum.INCOME,
+                InvestmentHorizonEnum.LONG));
+    assetRepository.saveAndFlush(
+        buildAsset(portfolio, "AAPL", AssetTypeEnum.STOCK, CurrencyCodeEnum.USD));
+
+    deleteMeRequest(mockMvc, String.valueOf(TEST_USER_ID), portfolio.getId())
+        .andExpect(status().isNoContent());
+
+    assertEquals(0, portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_USER_ID).size());
+    assertEquals(0, assetRepository.findByPortfolioId(portfolio.getId()).size());
+  }
+
+  @Test
+  void deleteReturnsNoContentWhenPortfolioBelongsToAnotherUser() throws Exception {
+    PortfolioEntity otherUsersPortfolio =
+        portfolioRepository.saveAndFlush(
+            buildPortfolio(
+                TEST_OTHER_USER_ID,
+                TEST_PORTFOLIO_NAME_RETIREMENT,
+                CurrencyCodeEnum.EUR,
+                RiskProfileEnum.LOW,
+                StrategyTypeEnum.INCOME,
+                InvestmentHorizonEnum.LONG));
+
+    deleteMeRequest(mockMvc, String.valueOf(TEST_USER_ID), otherUsersPortfolio.getId())
+        .andExpect(status().isNoContent());
+
+    assertEquals(1, portfolioRepository.findByUserIdOrderByCreatedAtAsc(TEST_OTHER_USER_ID).size());
+  }
+
+  @Test
+  void deleteReturnsUnauthorizedWhenAuthenticatedUserIsMissing() throws Exception {
+    PortfolioEntity portfolio =
+        portfolioRepository.saveAndFlush(
+            buildPortfolio(
+                TEST_USER_ID,
+                TEST_PORTFOLIO_NAME_RETIREMENT,
+                CurrencyCodeEnum.EUR,
+                RiskProfileEnum.LOW,
+                StrategyTypeEnum.INCOME,
+                InvestmentHorizonEnum.LONG));
+
+    deleteMeRequest(mockMvc, null, portfolio.getId()).andExpect(status().isUnauthorized());
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioConcurrencyIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/PortfolioConcurrencyIntegrationTest.java
@@ -74,7 +74,7 @@ class PortfolioConcurrencyIntegrationTest {
 
   private IntegrationResponse executeCreate(String requestBody) throws Exception {
     MvcResult result =
-        createRequest(mockMvc, String.valueOf(TEST_USER_ID), objectMapper, requestBody).andReturn();
+        createRequest(mockMvc, String.valueOf(TEST_USER_ID), requestBody).andReturn();
     return new IntegrationResponse(
         result.getResponse().getStatus(), result.getResponse().getContentAsString());
   }

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/impl/PortfolioApiControllerTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/impl/PortfolioApiControllerTest.java
@@ -63,4 +63,12 @@ class PortfolioApiControllerTest {
     assertEquals(response, result.getBody());
     verify(portfolioService).create(42L, request);
   }
+
+  @Test
+  void deleteReturnsNoContentResponse() {
+    ResponseEntity<Void> result = portfolioApiController.delete(42L, 7L);
+
+    assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+    verify(portfolioService).delete(42L, 7L);
+  }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/impl/PortfolioServiceImplTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/impl/PortfolioServiceImplTest.java
@@ -7,8 +7,8 @@ import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static com.tychewealth.testdata.EntityBuilder.buildPortfolio;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,6 +25,7 @@ import com.tychewealth.mapper.portfolio.PortfolioMapper;
 import com.tychewealth.repository.PortfolioRepository;
 import com.tychewealth.service.helper.portfolio.PortfolioValidationHelper;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -137,8 +138,7 @@ class PortfolioServiceImplTest {
                 java.util.Map.of(NAME, TEST_PORTFOLIO_NAME_RETIREMENT),
                 HttpStatus.CONFLICT))
         .when(portfolioValidationHelper)
-        .validateCreatePersistenceConflict(
-            eq(persistenceException), eq(TEST_PORTFOLIO_NAME_RETIREMENT));
+        .validateCreatePersistenceConflict(persistenceException, TEST_PORTFOLIO_NAME_RETIREMENT);
 
     PortfolioException expected =
         assertThrows(PortfolioException.class, () -> portfolioService.create(42L, request));
@@ -149,7 +149,31 @@ class PortfolioServiceImplTest {
             .replace("${name:-}", TEST_PORTFOLIO_NAME_RETIREMENT),
         expected.getMessage());
     verify(portfolioValidationHelper)
-        .validateCreatePersistenceConflict(
-            eq(persistenceException), eq(TEST_PORTFOLIO_NAME_RETIREMENT));
+        .validateCreatePersistenceConflict(persistenceException, TEST_PORTFOLIO_NAME_RETIREMENT);
+  }
+
+  @Test
+  void deleteRemovesOwnedPortfolio() {
+    PortfolioEntity portfolio = new PortfolioEntity();
+    portfolio.setId(7L);
+    portfolio.setUserId(TEST_USER_ID);
+
+    when(portfolioRepository.findByIdAndUserId(7L, TEST_USER_ID))
+        .thenReturn(Optional.of(portfolio));
+
+    portfolioService.delete(TEST_USER_ID, 7L);
+
+    verify(portfolioValidationHelper).validateAuthenticatedUser(TEST_USER_ID);
+    verify(portfolioRepository).delete(portfolio);
+  }
+
+  @Test
+  void deleteDoesNothingWhenPortfolioDoesNotBelongToUser() {
+    when(portfolioRepository.findByIdAndUserId(7L, TEST_USER_ID)).thenReturn(Optional.empty());
+
+    portfolioService.delete(TEST_USER_ID, 7L);
+
+    verify(portfolioValidationHelper).validateAuthenticatedUser(TEST_USER_ID);
+    verify(portfolioRepository, never()).delete(org.mockito.ArgumentMatchers.any());
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/testhelper/PortfolioTestHelper.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/testhelper/PortfolioTestHelper.java
@@ -29,8 +29,7 @@ public final class PortfolioTestHelper {
 
   private PortfolioTestHelper() {}
 
-  public static ResultActions createRequest(
-      MockMvc mockMvc, String userId, ObjectMapper objectMapper, String requestBody)
+  public static ResultActions createRequest(MockMvc mockMvc, String userId, String requestBody)
       throws Exception {
     MockHttpServletRequestBuilder builder =
         MockMvcRequestBuilders.post(PORTFOLIO_BASE_URL)
@@ -44,6 +43,16 @@ public final class PortfolioTestHelper {
 
   public static ResultActions retrieveMeRequest(MockMvc mockMvc, String userId) throws Exception {
     MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(PORTFOLIO_BASE_URL + "/me");
+    if (userId != null) {
+      builder.header(AUTHORIZATION_HEADER, createAuthorizationHeader(Long.parseLong(userId)));
+    }
+    return mockMvc.perform(builder);
+  }
+
+  public static ResultActions deleteMeRequest(MockMvc mockMvc, String userId, Long portfolioId)
+      throws Exception {
+    MockHttpServletRequestBuilder builder =
+        MockMvcRequestBuilders.delete(PORTFOLIO_BASE_URL + "/me/" + portfolioId);
     if (userId != null) {
       builder.header(AUTHORIZATION_HEADER, createAuthorizationHeader(Long.parseLong(userId)));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DELETE endpoint so users can remove their portfolios; associated assets are now removed automatically and deletion operations produce improved logs.

* **Tests**
  * Added unit and integration tests for portfolio deletion, including authorization cases and asset-cleanup verification.

Closes #44 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->