### PR TITLE
Feature/tyche 50 persist import assets in redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,14 +30,21 @@ services:
     env_file:
       - ./application-local.properties
     ports:
-      - "127.0.0.1:${PORTFOLIO_SERVICE_PORT:-8082}:8081"
+      - "127.0.0.1:${PORTFOLIO_SERVICE_PORT:-8082}:8082"
     volumes:
       - ./application-local.properties:/app/application-local.properties:ro
     environment:
       DB_URL_PORTFOLIO: ${DB_URL_PORTFOLIO:-jdbc:postgresql://postgres:5432/tyche_wealth_portfolio}
+      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://host.docker.internal:11434/v1}
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - tyche-network
 

--- a/services/portfolio-service/Dockerfile
+++ b/services/portfolio-service/Dockerfile
@@ -21,6 +21,6 @@ COPY --from=build /app/services/portfolio-service/target/*.jar app.jar
 RUN useradd --system --create-home --uid 10001 appuser
 USER 10001:10001
 
-EXPOSE 8081
+EXPOSE 8082
 
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/AssetPersistRedisDto.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/AssetPersistRedisDto.java
@@ -1,7 +1,7 @@
 package com.tychewealth.dto.asset;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.util.List;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +12,11 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class AssetImportResponseDto {
+public class AssetPersistRedisDto {
 
   private String importId;
-  private List<AssetImportCandidateDto> assets;
+  private Long userId;
+  private String fileName;
+  private Instant createdAt;
+  private AssetImportResponseDto result;
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetImportPayloadDto.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetImportPayloadDto.java
@@ -1,4 +1,4 @@
-package com.tychewealth.dto.asset;
+package com.tychewealth.dto.asset.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/ImportAssetsHelper.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/ImportAssetsHelper.java
@@ -33,6 +33,7 @@ import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutionException;
@@ -103,7 +104,8 @@ public class ImportAssetsHelper {
     try {
       cacheKey =
           IMPORT_CACHE_KEY_PREFIX
-              + Utils.sha256Hex(fileName.toLowerCase() + ":" + Utils.sha256Hex(file.getBytes()));
+              + Utils.sha256Hex(
+                  fileName.toLowerCase(Locale.ROOT) + ":" + Utils.sha256Hex(file.getBytes()));
     } catch (IOException ex) {
       throw new AssetImportException(
           ErrorDefinition.ASSET_IMPORT_EXTRACTION_FAILED, Map.of(), HttpStatus.BAD_REQUEST);
@@ -215,8 +217,8 @@ public class ImportAssetsHelper {
         return;
       }
 
-      boolean inflightExists = redisTemplate.hasKey(inflightKey);
-      if (!inflightExists) {
+      Boolean inflightExists = redisTemplate.hasKey(inflightKey);
+      if (!Boolean.TRUE.equals(inflightExists)) {
         return;
       }
 

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/ImportAssetsHelper.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/ImportAssetsHelper.java
@@ -23,7 +23,8 @@ import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tychewealth.dto.asset.AssetImportPayloadDto;
+import com.tychewealth.dto.asset.AssetPersistRedisDto;
+import com.tychewealth.dto.asset.request.AssetImportPayloadDto;
 import com.tychewealth.error.exception.AssetImportException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.utils.FileDataExtractor;
@@ -54,8 +55,10 @@ public class ImportAssetsHelper {
 
   private static final String IMPORT_CACHE_KEY_PREFIX = "asset-import:payload:";
   private static final String IMPORT_INFLIGHT_KEY_PREFIX = "asset-import:payload:inflight:";
+  private static final String IMPORT_RESULT_KEY_PREFIX = "asset-import:result:";
   private static final String CACHE_KEY_CONTEXT = " cacheKey={}";
   private static final Duration IMPORT_CACHE_TTL = Duration.ofHours(12);
+  private static final Duration IMPORT_RESULT_TTL = Duration.ofHours(12);
   private static final Duration IMPORT_QUEUE_OFFER_TIMEOUT = Duration.ofMillis(100);
   private static final Duration IMPORT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(5);
 
@@ -95,39 +98,32 @@ public class ImportAssetsHelper {
 
   public AssetImportPayloadDto buildImportPayload(MultipartFile file) {
     String fileName = Utils.resolveFileName(file);
-    String cacheKey = buildCacheKey(file, fileName);
-    String inflightKey = buildInflightKey(cacheKey);
+    String cacheKey;
+
+    try {
+      cacheKey =
+          IMPORT_CACHE_KEY_PREFIX
+              + Utils.sha256Hex(fileName.toLowerCase() + ":" + Utils.sha256Hex(file.getBytes()));
+    } catch (IOException ex) {
+      throw new AssetImportException(
+          ErrorDefinition.ASSET_IMPORT_EXTRACTION_FAILED, Map.of(), HttpStatus.BAD_REQUEST);
+    }
+
+    String inflightKey =
+        IMPORT_INFLIGHT_KEY_PREFIX + cacheKey.substring(IMPORT_CACHE_KEY_PREFIX.length());
     while (true) {
       AssetImportPayloadDto cachedResponse = readCachedResponse(cacheKey);
       if (cachedResponse != null) {
         return cachedResponse;
       }
 
-      if (tryAcquireInflightLock(inflightKey)) {
+      Boolean acquired = redisTemplate.opsForValue().setIfAbsent(inflightKey, "1", inflightLockTtl);
+      if (Boolean.TRUE.equals(acquired)) {
         return processImport(file, fileName, cacheKey, inflightKey);
       }
 
       waitForInflightResult(cacheKey, inflightKey);
     }
-  }
-
-  private String buildCacheKey(MultipartFile file, String fileName) {
-    try {
-      return IMPORT_CACHE_KEY_PREFIX
-          + Utils.sha256Hex(fileName.toLowerCase() + ":" + Utils.sha256Hex(file.getBytes()));
-    } catch (IOException ex) {
-      throw new AssetImportException(
-          ErrorDefinition.ASSET_IMPORT_EXTRACTION_FAILED, Map.of(), HttpStatus.BAD_REQUEST);
-    }
-  }
-
-  private String buildInflightKey(String cacheKey) {
-    return IMPORT_INFLIGHT_KEY_PREFIX + cacheKey.substring(IMPORT_CACHE_KEY_PREFIX.length());
-  }
-
-  private boolean tryAcquireInflightLock(String inflightKey) {
-    Boolean acquired = redisTemplate.opsForValue().setIfAbsent(inflightKey, "1", inflightLockTtl);
-    return Boolean.TRUE.equals(acquired);
   }
 
   private AssetImportPayloadDto processImport(
@@ -167,9 +163,7 @@ public class ImportAssetsHelper {
           ex);
       throw new IllegalStateException("Asset import processing was interrupted", ex);
     } catch (TimeoutException ex) {
-      if (future != null) {
-        future.cancel(true);
-      }
+      future.cancel(true);
       throw assetValidationHelper.extractionTimeoutExceeded(
           assetValidationHelper.extractionTimeoutSeconds());
     } catch (ExecutionException ex) {
@@ -221,8 +215,8 @@ public class ImportAssetsHelper {
         return;
       }
 
-      Boolean inflightExists = redisTemplate.hasKey(inflightKey);
-      if (!Boolean.TRUE.equals(inflightExists)) {
+      boolean inflightExists = redisTemplate.hasKey(inflightKey);
+      if (!inflightExists) {
         return;
       }
 
@@ -285,6 +279,30 @@ public class ImportAssetsHelper {
           "asset import cache write failed",
           cacheKey,
           ex);
+    }
+  }
+
+  public void savePersistedImportResult(AssetPersistRedisDto persistedImport) {
+    String redisKey =
+        IMPORT_RESULT_KEY_PREFIX
+            + persistedImport.getUserId()
+            + ":"
+            + persistedImport.getImportId();
+    try {
+      redisTemplate
+          .opsForValue()
+          .set(redisKey, objectMapper.writeValueAsString(persistedImport), IMPORT_RESULT_TTL);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("Unable to persist asset import result", ex);
+    } catch (RuntimeException ex) {
+      log.error(
+          REQUEST_CONFLICT + CACHE_KEY_CONTEXT,
+          ASSET,
+          IMPORT_ASSETS_ACTION,
+          "asset import result persistence failed",
+          redisKey,
+          ex);
+      throw ex;
     }
   }
 

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
@@ -15,6 +15,7 @@ import com.tychewealth.utils.Utils;
 import com.tychewealth.utils.prompts.AssetImportPromptUtils;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -42,7 +43,9 @@ public class AssetServiceImpl implements AssetService {
     try {
       importId =
           Utils.sha256Hex(
-              payload.getFileName().toLowerCase() + ":" + Utils.sha256Hex(file.getBytes()));
+              payload.getFileName().toLowerCase(Locale.ROOT)
+                  + ":"
+                  + Utils.sha256Hex(file.getBytes()));
     } catch (IOException ex) {
       throw new AssetImportException(
           ErrorDefinition.ASSET_IMPORT_EXTRACTION_FAILED, Map.of(), HttpStatus.BAD_REQUEST);

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
@@ -1,15 +1,23 @@
 package com.tychewealth.service.impl;
 
 import com.tychewealth.dto.ai.AiModelTypeEnum;
-import com.tychewealth.dto.asset.AssetImportPayloadDto;
 import com.tychewealth.dto.asset.AssetImportResponseDto;
+import com.tychewealth.dto.asset.AssetPersistRedisDto;
+import com.tychewealth.dto.asset.request.AssetImportPayloadDto;
+import com.tychewealth.error.exception.AssetImportException;
+import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.service.AssetService;
 import com.tychewealth.service.helper.asset.AssetValidationHelper;
 import com.tychewealth.service.helper.asset.ImportAssetsHelper;
 import com.tychewealth.service.helper.asset.ai.AiResponseParser;
 import com.tychewealth.service.helper.asset.ai.ImportAssetsAiHelper;
+import com.tychewealth.utils.Utils;
 import com.tychewealth.utils.prompts.AssetImportPromptUtils;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,7 +38,22 @@ public class AssetServiceImpl implements AssetService {
     AssetImportPayloadDto payload = importAssetsHelper.buildImportPayload(file);
     String prompt = AssetImportPromptUtils.buildAssetImportPrompt(payload.getExtractedText());
     String aiResponse = importAssetsAiHelper.prompt(prompt, AiModelTypeEnum.FAST);
-    return new AssetImportResponseDto(
-        aiResponseParser.parseAiAssets(payload.getExtractedText(), aiResponse));
+    String importId;
+    try {
+      importId =
+          Utils.sha256Hex(
+              payload.getFileName().toLowerCase() + ":" + Utils.sha256Hex(file.getBytes()));
+    } catch (IOException ex) {
+      throw new AssetImportException(
+          ErrorDefinition.ASSET_IMPORT_EXTRACTION_FAILED, Map.of(), HttpStatus.BAD_REQUEST);
+    }
+    AssetImportResponseDto response =
+        new AssetImportResponseDto(
+            importId, aiResponseParser.parseAiAssets(payload.getExtractedText(), aiResponse));
+
+    importAssetsHelper.savePersistedImportResult(
+        new AssetPersistRedisDto(importId, userId, payload.getFileName(), Instant.now(), response));
+
+    return response;
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/AssetApiControllerIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/AssetApiControllerIntegrationTest.java
@@ -29,8 +29,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tychewealth.config.AssetIntegrationTestConfig;
 import com.tychewealth.dto.ai.AiModelTypeEnum;
+import com.tychewealth.dto.asset.AssetPersistRedisDto;
 import com.tychewealth.enums.AssetTypeEnum;
 import com.tychewealth.enums.CurrencyCodeEnum;
 import com.tychewealth.error.handler.ErrorDefinition;
@@ -38,7 +41,9 @@ import com.tychewealth.repository.AssetRepository;
 import com.tychewealth.repository.PortfolioRepository;
 import com.tychewealth.service.helper.asset.ai.AiResponseParser;
 import com.tychewealth.service.helper.asset.ai.ImportAssetsAiHelper;
+import com.tychewealth.testhelper.TestRedisSupport.InMemoryRedisState;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +53,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @SpringBootTest(classes = AssetIntegrationTestConfig.class)
 @ContextConfiguration(initializers = AssetIntegrationTestConfig.Initializer.class)
@@ -57,6 +63,8 @@ class AssetApiControllerIntegrationTest {
   private static final int ATTACHMENT_SIZE_LIMIT_BYTES = 3_145_728;
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private InMemoryRedisState redisState;
   @Autowired private PortfolioRepository portfolioRepository;
   @Autowired private AssetRepository assetRepository;
 
@@ -67,6 +75,8 @@ class AssetApiControllerIntegrationTest {
   void setUp() {
     assetRepository.deleteAll();
     portfolioRepository.deleteAll();
+    Set<String> persistedImportKeys = redisState.keys("asset-import:result:*");
+    redisState.deleteAll(persistedImportKeys);
 
     when(importAssetsAiHelper.prompt(anyString(), eq(AiModelTypeEnum.FAST)))
         .thenReturn(AI_RESPONSE);
@@ -83,25 +93,43 @@ class AssetApiControllerIntegrationTest {
             TEST_ASSET_CONTENT_TYPE_CSV,
             TEST_ASSET_EXTRACTED_TEXT.getBytes(UTF_8));
 
-    mockMvc
-        .perform(
-            multipart(ASSET_IMPORT_URL)
-                .file(file)
-                .header(AUTHORIZATION_HEADER, createAuthorizationHeader(TEST_USER_ID)))
-        .andExpect(status().isOk())
-        .andExpect(header().string(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE))
-        .andExpect(header().string(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE))
-        .andExpect(jsonPath("$.fileName").doesNotExist())
-        .andExpect(jsonPath("$.extractedText").doesNotExist())
-        .andExpect(jsonPath("$.aiResponse").doesNotExist())
-        .andExpect(jsonPath("$.assets[0].name").value(TEST_ASSET_NAME_APPLE))
-        .andExpect(jsonPath("$.assets[0].symbol").value(TEST_ASSET_SYMBOL_AAPL))
-        .andExpect(jsonPath("$.assets[0].assetType").value(AssetTypeEnum.STOCK.name()))
-        .andExpect(jsonPath("$.assets[0].quantity").value(TEST_ASSET_RESPONSE_QUANTITY.intValue()))
-        .andExpect(
-            jsonPath("$.assets[0].averagePrice")
-                .value(TEST_ASSET_RESPONSE_AVERAGE_PRICE.doubleValue()))
-        .andExpect(jsonPath("$.assets[0].currency").value(CurrencyCodeEnum.USD.name()));
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                multipart(ASSET_IMPORT_URL)
+                    .file(file)
+                    .header(AUTHORIZATION_HEADER, createAuthorizationHeader(TEST_USER_ID)))
+            .andExpect(status().isOk())
+            .andExpect(header().string(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE))
+            .andExpect(header().string(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE))
+            .andExpect(jsonPath("$.fileName").doesNotExist())
+            .andExpect(jsonPath("$.extractedText").doesNotExist())
+            .andExpect(jsonPath("$.aiResponse").doesNotExist())
+            .andExpect(jsonPath("$.importId").isString())
+            .andExpect(jsonPath("$.assets[0].name").value(TEST_ASSET_NAME_APPLE))
+            .andExpect(jsonPath("$.assets[0].symbol").value(TEST_ASSET_SYMBOL_AAPL))
+            .andExpect(jsonPath("$.assets[0].assetType").value(AssetTypeEnum.STOCK.name()))
+            .andExpect(
+                jsonPath("$.assets[0].quantity").value(TEST_ASSET_RESPONSE_QUANTITY.intValue()))
+            .andExpect(
+                jsonPath("$.assets[0].averagePrice")
+                    .value(TEST_ASSET_RESPONSE_AVERAGE_PRICE.doubleValue()))
+            .andExpect(jsonPath("$.assets[0].currency").value(CurrencyCodeEnum.USD.name()))
+            .andReturn();
+
+    JsonNode responseBody = objectMapper.readTree(mvcResult.getResponse().getContentAsString());
+    String importId = responseBody.get("importId").asText();
+    String redisKey = "asset-import:result:" + TEST_USER_ID + ":" + importId;
+    String persistedImportJson = redisState.get(redisKey);
+    AssetPersistRedisDto persistedImport =
+        objectMapper.readValue(persistedImportJson, AssetPersistRedisDto.class);
+
+    org.junit.jupiter.api.Assertions.assertEquals(importId, persistedImport.getImportId());
+    org.junit.jupiter.api.Assertions.assertEquals(TEST_USER_ID, persistedImport.getUserId());
+    org.junit.jupiter.api.Assertions.assertEquals(
+        TEST_ASSET_FILE_NAME, persistedImport.getFileName());
+    org.junit.jupiter.api.Assertions.assertEquals(
+        TEST_ASSET_NAME_APPLE, persistedImport.getResult().getAssets().getFirst().getName());
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/helper/asset/ImportAssetsHelperTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/helper/asset/ImportAssetsHelperTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tychewealth.dto.asset.AssetImportPayloadDto;
+import com.tychewealth.dto.asset.request.AssetImportPayloadDto;
 import com.tychewealth.testhelper.TestRedisSupport;
 import com.tychewealth.testhelper.TestRedisSupport.InMemoryRedisState;
 import com.tychewealth.utils.Utils;

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/impl/AssetServiceImplTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/impl/AssetServiceImplTest.java
@@ -15,8 +15,9 @@ import static org.mockito.Mockito.*;
 
 import com.tychewealth.dto.ai.AiModelTypeEnum;
 import com.tychewealth.dto.asset.AssetImportCandidateDto;
-import com.tychewealth.dto.asset.AssetImportPayloadDto;
 import com.tychewealth.dto.asset.AssetImportResponseDto;
+import com.tychewealth.dto.asset.AssetPersistRedisDto;
+import com.tychewealth.dto.asset.request.AssetImportPayloadDto;
 import com.tychewealth.error.exception.AssetImportException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.service.helper.asset.AssetValidationHelper;
@@ -26,6 +27,7 @@ import com.tychewealth.service.helper.asset.ai.ImportAssetsAiHelper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -63,8 +65,15 @@ class AssetServiceImplTest {
         .thenReturn(parsedAssets);
 
     AssetImportResponseDto result = assetService.importAssets(TEST_USER_ID, file);
+    ArgumentCaptor<AssetPersistRedisDto> persistedImportCaptor =
+        ArgumentCaptor.forClass(AssetPersistRedisDto.class);
 
     assertEquals(parsedAssets, result.getAssets());
+    verify(importAssetsHelper).savePersistedImportResult(persistedImportCaptor.capture());
+    assertEquals(persistedImportCaptor.getValue().getImportId(), result.getImportId());
+    assertEquals(TEST_USER_ID, persistedImportCaptor.getValue().getUserId());
+    assertEquals(TEST_ASSET_FILE_NAME, persistedImportCaptor.getValue().getFileName());
+    assertEquals(result, persistedImportCaptor.getValue().getResult());
     verify(assetValidationHelper).validateImportRequest(TEST_USER_ID, file);
     verify(importAssetsHelper).buildImportPayload(file);
     verify(importAssetsAiHelper)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Asset import operations now generate unique tracking identifiers for each import batch.
  * Import results are persisted and retrievable for tracking purposes.

* **Tests**
  * Enhanced test coverage to validate import result persistence behavior.

* **Chores**
  * Updated service port configuration from 8081 to 8082.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ismaelperezdev/Tyche-Wealth/pull/91)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->