### PR TITLE
[TYCHE-52] create assets in batch

### DIFF
--- a/services/portfolio-service/src/main/java/com/tychewealth/constants/ApiConstants.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/constants/ApiConstants.java
@@ -9,12 +9,15 @@ public final class ApiConstants {
   public static final String URL_FOLDER_V1 = URL_FOLDER + VERSION_1;
   public static final String PORTFOLIO_ID_PATH = "portfolioId";
   public static final String ASSET_ID_PATH = "assetId";
+  public static final String IMPORT_ID_PATH = "importId";
   public static final String PORTFOLIO_BASE_URL = URL_FOLDER_V1 + "/portfolio";
   public static final String ASSET_BASE_URL = URL_FOLDER_V1 + "/assets";
   public static final String PORTFOLIO_ASSET_BASE_URL = URL_FOLDER_V1 + "/me/{portfolioId}/assets";
   public static final String PORTFOLIO_ASSET_BY_ID_URL = PORTFOLIO_ASSET_BASE_URL + "/{assetId}";
   public static final String ASSET_IMPORT_URL = ASSET_BASE_URL + "/import";
-  public static final String ASSET_IMPORT_BY_ID_URL = ASSET_IMPORT_URL + "/{importId}";
+  public static final String ASSET_IMPORT_BY_ID_URL =
+      ASSET_IMPORT_URL + "/{" + IMPORT_ID_PATH + "}";
+  public static final String PORTFOLIO_ASSET_BATCH_URL = PORTFOLIO_ASSET_BASE_URL + "/batch";
 
   public static final String REQUEST_PRODUCES = MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8";
   public static final String REQUEST_CONSUMES = MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8";

--- a/services/portfolio-service/src/main/java/com/tychewealth/constants/ValidationConstants.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/constants/ValidationConstants.java
@@ -6,6 +6,8 @@ public final class ValidationConstants {
   public static final String MUST_NOT_BE_NULL = "must not be null";
   public static final String MUST_BE_BETWEEN_3_AND_60_CHARACTERS =
       "must be between 3 and 60 characters";
+  public static final String MUST_BE_BETWEEN_3_AND_200_CHARACTERS =
+      "must be between 3 and 200 characters";
   public static final String MUST_BE_AT_MOST_20_CHARACTERS = "must be at most 20 characters";
   public static final String MUST_HAVE_UP_TO_1_INTEGER_DIGIT_AND_2_DECIMALS =
       "must have up to 1 integer digit and 2 decimals";

--- a/services/portfolio-service/src/main/java/com/tychewealth/controller/AssetApi.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/controller/AssetApi.java
@@ -3,8 +3,10 @@ package com.tychewealth.controller;
 import static com.tychewealth.constants.ApiConstants.ASSET_ID_PATH;
 import static com.tychewealth.constants.ApiConstants.ASSET_IMPORT_BY_ID_URL;
 import static com.tychewealth.constants.ApiConstants.ASSET_IMPORT_URL;
+import static com.tychewealth.constants.ApiConstants.IMPORT_ID_PATH;
 import static com.tychewealth.constants.ApiConstants.MULTIPART_FORM_DATA;
 import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BASE_URL;
+import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BATCH_URL;
 import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BY_ID_URL;
 import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ID_PATH;
 import static com.tychewealth.constants.ApiConstants.REQUEST_CONSUMES;
@@ -12,9 +14,11 @@ import static com.tychewealth.constants.ApiConstants.REQUEST_PRODUCES;
 
 import com.tychewealth.dto.asset.AssetImportResponseDto;
 import com.tychewealth.dto.asset.AssetResponseDto;
+import com.tychewealth.dto.asset.request.AssetBatchCreateRequestDto;
 import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,6 +49,15 @@ public interface AssetApi {
       @PathVariable(ASSET_ID_PATH) Long assetId);
 
   @PostMapping(
+      value = PORTFOLIO_ASSET_BATCH_URL,
+      consumes = REQUEST_CONSUMES,
+      produces = REQUEST_PRODUCES)
+  ResponseEntity<List<AssetResponseDto>> createBatchFromImportedAssets(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable(PORTFOLIO_ID_PATH) Long portfolioId,
+      @Valid @RequestBody AssetBatchCreateRequestDto request);
+
+  @PostMapping(
       value = ASSET_IMPORT_URL,
       consumes = MULTIPART_FORM_DATA,
       produces = REQUEST_PRODUCES)
@@ -53,5 +66,5 @@ public interface AssetApi {
 
   @GetMapping(value = ASSET_IMPORT_BY_ID_URL, produces = REQUEST_PRODUCES)
   ResponseEntity<AssetImportResponseDto> retrieveImportedAssets(
-      @AuthenticationPrincipal Long userId, @PathVariable String importId);
+      @AuthenticationPrincipal Long userId, @PathVariable(IMPORT_ID_PATH) String importId);
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/controller/impl/AssetApiController.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/controller/impl/AssetApiController.java
@@ -1,5 +1,6 @@
 package com.tychewealth.controller.impl;
 
+import static com.tychewealth.constants.ApiConstants.IMPORT_ID_PATH;
 import static com.tychewealth.constants.LogConstants.ASSET;
 import static com.tychewealth.constants.LogConstants.CREATE_ACTION;
 import static com.tychewealth.constants.LogConstants.IMPORT_ASSETS_ACTION;
@@ -13,11 +14,13 @@ import static com.tychewealth.utils.Utils.buildNoStoreBodyResponse;
 import com.tychewealth.controller.AssetApi;
 import com.tychewealth.dto.asset.AssetImportResponseDto;
 import com.tychewealth.dto.asset.AssetResponseDto;
+import com.tychewealth.dto.asset.request.AssetBatchCreateRequestDto;
 import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
 import com.tychewealth.ratelimit.RateLimitKey;
 import com.tychewealth.ratelimit.RateLimited;
 import com.tychewealth.service.AssetService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -63,6 +66,21 @@ public class AssetApiController implements AssetApi {
   }
 
   @Override
+  @RateLimited(RateLimitKey.ASSET_BATCH_CREATE)
+  public ResponseEntity<List<AssetResponseDto>> createBatchFromImportedAssets(
+      @AuthenticationPrincipal Long userId,
+      Long portfolioId,
+      @Valid @RequestBody AssetBatchCreateRequestDto request) {
+    log.info(REQUEST_START + PORTFOLIO_ID + USER_ID, ASSET, CREATE_ACTION, portfolioId, userId);
+
+    List<AssetResponseDto> response =
+        assetService.createBatchFromImportedAssets(userId, portfolioId, request);
+    log.info(REQUEST_SUCCESS + PORTFOLIO_ID + USER_ID, ASSET, CREATE_ACTION, portfolioId, userId);
+
+    return buildNoStoreBodyResponse(HttpStatus.CREATED, response);
+  }
+
+  @Override
   @RateLimited(RateLimitKey.ASSET_IMPORT)
   public ResponseEntity<AssetImportResponseDto> importAssets(
       @AuthenticationPrincipal Long userId, @RequestPart("file") MultipartFile file) {
@@ -77,7 +95,7 @@ public class AssetApiController implements AssetApi {
   @Override
   @RateLimited(RateLimitKey.ASSET_IMPORT_RETRIEVE)
   public ResponseEntity<AssetImportResponseDto> retrieveImportedAssets(
-      @AuthenticationPrincipal Long userId, @PathVariable String importId) {
+      @AuthenticationPrincipal Long userId, @PathVariable(IMPORT_ID_PATH) String importId) {
     log.info(REQUEST_START + USER_ID, ASSET, RETRIEVE_ACTION, userId);
 
     AssetImportResponseDto response = assetService.retrieveImportedAssets(userId, importId);

--- a/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetBatchCreateRequestDto.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetBatchCreateRequestDto.java
@@ -1,0 +1,26 @@
+package com.tychewealth.dto.asset.request;
+
+import static com.tychewealth.constants.ValidationConstants.MUST_NOT_BE_NULL;
+
+import com.tychewealth.enums.AssetBatchActionEnum;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssetBatchCreateRequestDto {
+
+  @NotNull(message = MUST_NOT_BE_NULL)
+  private AssetBatchActionEnum action;
+
+  private String importId;
+
+  @Valid private List<AssetCreateRequestDto> assets;
+}

--- a/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetCreateRequestDto.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetCreateRequestDto.java
@@ -1,7 +1,7 @@
 package com.tychewealth.dto.asset.request;
 
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_AT_MOST_20_CHARACTERS;
-import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_60_CHARACTERS;
+import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_200_CHARACTERS;
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_GREATER_THAN_0;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_11_INTEGER_DIGITS_AND_8_DECIMALS;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_15_INTEGER_DIGITS_AND_4_DECIMALS;
@@ -28,7 +28,7 @@ import lombok.Setter;
 public class AssetCreateRequestDto {
 
   @NotBlank(message = MUST_NOT_BE_BLANK)
-  @Size(min = 3, max = 60, message = MUST_BE_BETWEEN_3_AND_60_CHARACTERS)
+  @Size(min = 3, max = 200, message = MUST_BE_BETWEEN_3_AND_200_CHARACTERS)
   private String name;
 
   @NotBlank(message = MUST_NOT_BE_BLANK)

--- a/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetUpdateRequestDto.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/dto/asset/request/AssetUpdateRequestDto.java
@@ -1,7 +1,7 @@
 package com.tychewealth.dto.asset.request;
 
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_AT_MOST_20_CHARACTERS;
-import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_60_CHARACTERS;
+import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_200_CHARACTERS;
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_GREATER_THAN_0;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_11_INTEGER_DIGITS_AND_8_DECIMALS;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_15_INTEGER_DIGITS_AND_4_DECIMALS;
@@ -25,7 +25,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class AssetUpdateRequestDto {
 
-  @Size(min = 3, max = 60, message = MUST_BE_BETWEEN_3_AND_60_CHARACTERS)
+  @Size(min = 3, max = 200, message = MUST_BE_BETWEEN_3_AND_200_CHARACTERS)
   @Pattern(regexp = ".*\\S.*", message = MUST_NOT_BE_BLANK)
   private String name;
 

--- a/services/portfolio-service/src/main/java/com/tychewealth/entity/AssetEntity.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/entity/AssetEntity.java
@@ -1,7 +1,7 @@
 package com.tychewealth.entity;
 
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_AT_MOST_20_CHARACTERS;
-import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_60_CHARACTERS;
+import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_200_CHARACTERS;
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_GREATER_THAN_0;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_11_INTEGER_DIGITS_AND_8_DECIMALS;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_15_INTEGER_DIGITS_AND_4_DECIMALS;
@@ -52,9 +52,9 @@ public class AssetEntity {
   @NotNull(message = MUST_NOT_BE_NULL)
   private PortfolioEntity portfolio;
 
-  @Column(name = "name", nullable = false, length = 60)
+  @Column(name = "name", nullable = false, length = 200)
   @NotBlank(message = MUST_NOT_BE_BLANK)
-  @Size(min = 3, max = 60, message = MUST_BE_BETWEEN_3_AND_60_CHARACTERS)
+  @Size(min = 3, max = 200, message = MUST_BE_BETWEEN_3_AND_200_CHARACTERS)
   private String name;
 
   @Column(name = "symbol", nullable = false, length = 20)

--- a/services/portfolio-service/src/main/java/com/tychewealth/enums/AssetBatchActionEnum.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/enums/AssetBatchActionEnum.java
@@ -1,0 +1,6 @@
+package com.tychewealth.enums;
+
+public enum AssetBatchActionEnum {
+  CREATE,
+  DISCARD
+}

--- a/services/portfolio-service/src/main/java/com/tychewealth/ratelimit/RateLimitKey.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/ratelimit/RateLimitKey.java
@@ -7,6 +7,7 @@ public enum RateLimitKey {
   PORTFOLIO_RETRIEVE("rate-limit:portfolio:retrieve", 120, 60),
   PORTFOLIO_DELETE("rate-limit:portfolio:delete", 120, 60),
   ASSET_CREATE("rate-limit:asset:create", 40, 60),
+  ASSET_BATCH_CREATE("rate-limit:asset:batch:create", 10, 60),
   ASSET_RETRIEVE("rate-limit:asset:retrieve", 120, 60),
   ASSET_IMPORT("rate-limit:asset:import", 4, 60),
   ASSET_IMPORT_RETRIEVE("rate-limit:asset:import:retrieve", 120, 60);

--- a/services/portfolio-service/src/main/java/com/tychewealth/repository/AssetRepository.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/repository/AssetRepository.java
@@ -13,7 +13,7 @@ public interface AssetRepository extends JpaRepository<AssetEntity, Long> {
 
   List<AssetEntity> findByPortfolioId(Long portfolioId);
 
-  Boolean existsByPortfolioIdAndName(Long portfolioId, String name);
+  boolean existsByPortfolioIdAndName(Long portfolioId, String name);
 
   Optional<AssetEntity> findByPortfolioIdAndSymbol(Long portfolioId, String symbol);
 
@@ -23,5 +23,5 @@ public interface AssetRepository extends JpaRepository<AssetEntity, Long> {
 
   List<AssetEntity> findByAssetType(AssetTypeEnum assetType);
 
-  Boolean existsByPortfolioIdAndSymbol(Long portfolioId, String symbol);
+  boolean existsByPortfolioIdAndSymbol(Long portfolioId, String symbol);
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/AssetService.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/AssetService.java
@@ -2,7 +2,9 @@ package com.tychewealth.service;
 
 import com.tychewealth.dto.asset.AssetImportResponseDto;
 import com.tychewealth.dto.asset.AssetResponseDto;
+import com.tychewealth.dto.asset.request.AssetBatchCreateRequestDto;
 import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AssetService {
@@ -10,6 +12,9 @@ public interface AssetService {
   AssetResponseDto create(Long userId, Long portfolioId, AssetCreateRequestDto createRequest);
 
   AssetResponseDto retrieve(Long userId, Long portfolioId, Long assetId);
+
+  List<AssetResponseDto> createBatchFromImportedAssets(
+      Long userId, Long portfolioId, AssetBatchCreateRequestDto request);
 
   AssetImportResponseDto importAssets(Long userId, MultipartFile file);
 

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/AssetCreateHelper.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/AssetCreateHelper.java
@@ -6,6 +6,7 @@ import com.tychewealth.entity.AssetEntity;
 import com.tychewealth.entity.PortfolioEntity;
 import com.tychewealth.mapper.asset.AssetMapper;
 import com.tychewealth.repository.AssetRepository;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,5 +23,21 @@ public class AssetCreateHelper {
 
     AssetEntity persistedAsset = assetRepository.saveAndFlush(asset);
     return assetMapper.toDto(persistedAsset);
+  }
+
+  public List<AssetResponseDto> createBatch(
+      PortfolioEntity portfolio, List<AssetCreateRequestDto> createRequests) {
+    List<AssetEntity> assets =
+        createRequests.stream()
+            .map(
+                request -> {
+                  AssetEntity asset = assetMapper.create(request);
+                  asset.setPortfolio(portfolio);
+                  return asset;
+                })
+            .toList();
+
+    List<AssetEntity> persistedAssets = assetRepository.saveAllAndFlush(assets);
+    return persistedAssets.stream().map(assetMapper::toDto).toList();
   }
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/AssetValidationHelper.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/AssetValidationHelper.java
@@ -119,7 +119,7 @@ public class AssetValidationHelper {
       if (!normalizedNames.add(normalizedName)) {
         throw new PortfolioException(
             ASSET_NAME_CONFLICT,
-            Map.of(NAME, asset == null ? "" : Objects.requireNonNull(asset.getName())),
+            Map.of(NAME, asset == null || asset.getName() == null ? "" : asset.getName()),
             HttpStatus.CONFLICT);
       }
     }

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/AssetValidationHelper.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/helper/asset/AssetValidationHelper.java
@@ -18,11 +18,13 @@ import static com.tychewealth.error.handler.ErrorDefinition.ASSET_NAME_CONFLICT;
 import static com.tychewealth.error.handler.ErrorDefinition.ASSET_NOT_FOUND;
 import static com.tychewealth.error.handler.ErrorDefinition.ASSET_SYMBOL_CONFLICT;
 
+import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
 import com.tychewealth.entity.AssetEntity;
+import com.tychewealth.enums.AssetBatchActionEnum;
 import com.tychewealth.error.exception.PortfolioException;
 import com.tychewealth.repository.AssetRepository;
 import com.tychewealth.utils.Utils;
-import java.util.Map;
+import java.util.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -64,6 +66,82 @@ public class AssetValidationHelper {
         portfolioId);
     throw new PortfolioException(
         ASSET_NAME_CONFLICT, Map.of(NAME, assetName == null ? "" : assetName), HttpStatus.CONFLICT);
+  }
+
+  public void validateBatchCreateRequest(
+      AssetBatchActionEnum action, String importId, List<AssetCreateRequestDto> assets) {
+    if (action == null) {
+      throw Utils.genericBadRequest("Batch action is required");
+    }
+
+    if (action == AssetBatchActionEnum.DISCARD) {
+      if (Utils.trimToNull(importId) == null) {
+        throw Utils.genericBadRequest("importId is required when action is DISCARD");
+      }
+      if (assets != null && !assets.isEmpty()) {
+        throw Utils.genericBadRequest("assets must be empty when action is DISCARD");
+      }
+      return;
+    }
+
+    if (action == AssetBatchActionEnum.CREATE) {
+      if (assets == null || assets.isEmpty()) {
+        throw Utils.genericBadRequest("assets is required when action is CREATE");
+      }
+      return;
+    }
+
+    throw Utils.genericBadRequest("Unsupported batch action");
+  }
+
+  public void validateBatchCreateLimit(Long portfolioId, int incomingAssetsCount) {
+    long currentAssetCount = assetRepository.findByPortfolioId(portfolioId).size();
+    if (currentAssetCount + incomingAssetsCount > MAX_ASSETS_PER_PORTFOLIO) {
+      log.warn(
+          REQUEST_CONFLICT + PORTFOLIO_ID,
+          ASSET,
+          CREATE_ACTION,
+          ASSET_LIMIT_REACHED_MESSAGE,
+          portfolioId);
+      throw new PortfolioException(ASSET_LIMIT_REACHED, Map.of(), HttpStatus.CONFLICT);
+    }
+  }
+
+  public void validateBatchCreateRequestDuplicates(List<AssetCreateRequestDto> assets) {
+    if (assets == null || assets.isEmpty()) {
+      return;
+    }
+
+    Set<String> normalizedNames = new HashSet<>();
+    for (AssetCreateRequestDto asset : assets) {
+      String normalizedName =
+          asset == null || asset.getName() == null ? "" : asset.getName().trim().toLowerCase();
+      if (!normalizedNames.add(normalizedName)) {
+        throw new PortfolioException(
+            ASSET_NAME_CONFLICT,
+            Map.of(NAME, asset == null ? "" : Objects.requireNonNull(asset.getName())),
+            HttpStatus.CONFLICT);
+      }
+    }
+  }
+
+  public void validateBatchCreateDatabaseConflicts(
+      Long portfolioId, List<AssetCreateRequestDto> assets) {
+    if (assets == null || assets.isEmpty()) {
+      return;
+    }
+
+    for (AssetCreateRequestDto asset : assets) {
+      validateCreateNameConflict(portfolioId, asset == null ? null : asset.getName());
+      validateCreateSymbolConflict(portfolioId, asset == null ? null : asset.getSymbol());
+    }
+  }
+
+  public void validateCreateSymbolConflict(Long portfolioId, String symbol) {
+    if (symbol == null || !assetRepository.existsByPortfolioIdAndSymbol(portfolioId, symbol)) {
+      return;
+    }
+    throw new PortfolioException(ASSET_SYMBOL_CONFLICT, Map.of(NAME, symbol), HttpStatus.CONFLICT);
   }
 
   public AssetEntity validateRetrievedAssetExists(Long portfolioId, Long assetId) {

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
@@ -10,10 +10,12 @@ import com.tychewealth.dto.ai.AiModelTypeEnum;
 import com.tychewealth.dto.asset.AssetImportResponseDto;
 import com.tychewealth.dto.asset.AssetPersistRedisDto;
 import com.tychewealth.dto.asset.AssetResponseDto;
+import com.tychewealth.dto.asset.request.AssetBatchCreateRequestDto;
 import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
 import com.tychewealth.dto.asset.request.AssetImportPayloadDto;
 import com.tychewealth.entity.AssetEntity;
 import com.tychewealth.entity.PortfolioEntity;
+import com.tychewealth.enums.AssetBatchActionEnum;
 import com.tychewealth.error.exception.AssetImportException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.mapper.asset.AssetMapper;
@@ -29,6 +31,7 @@ import com.tychewealth.utils.Utils;
 import com.tychewealth.utils.prompts.AssetImportPromptUtils;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -64,6 +67,7 @@ public class AssetServiceImpl implements AssetService {
         commonValidationHelper.validateOwnedPortfolio(userId, portfolioId, CREATE_ACTION);
     assetValidationHelper.validateCreateLimit(portfolioId);
     assetValidationHelper.validateCreateNameConflict(portfolioId, createRequest.getName());
+    assetValidationHelper.validateCreateSymbolConflict(portfolioId, createRequest.getSymbol());
     try {
       return assetCreateHelper.create(portfolio, createRequest);
     } catch (DataIntegrityViolationException ex) {
@@ -79,6 +83,37 @@ public class AssetServiceImpl implements AssetService {
     commonValidationHelper.validateOwnedPortfolio(userId, portfolioId, RETRIEVE_ACTION);
     AssetEntity asset = assetValidationHelper.validateRetrievedAssetExists(portfolioId, assetId);
     return assetMapper.toDto(asset);
+  }
+
+  @Override
+  @Transactional(isolation = Isolation.SERIALIZABLE)
+  public List<AssetResponseDto> createBatchFromImportedAssets(
+      Long userId, Long portfolioId, AssetBatchCreateRequestDto request) {
+    commonValidationHelper.validateAuthenticatedUser(userId);
+    PortfolioEntity portfolio =
+        commonValidationHelper.validateOwnedPortfolio(userId, portfolioId, CREATE_ACTION);
+
+    assetValidationHelper.validateBatchCreateRequest(
+        request.getAction(), request.getImportId(), request.getAssets());
+
+    if (request.getAction() == AssetBatchActionEnum.DISCARD) {
+      cleanupImportedResult(userId, request.getImportId());
+      return List.of();
+    }
+
+    List<AssetCreateRequestDto> assets = request.getAssets();
+    assetValidationHelper.validateBatchCreateLimit(portfolioId, assets.size());
+    assetValidationHelper.validateBatchCreateRequestDuplicates(assets);
+    assetValidationHelper.validateBatchCreateDatabaseConflicts(portfolioId, assets);
+
+    try {
+      List<AssetResponseDto> createdAssets = assetCreateHelper.createBatch(portfolio, assets);
+      cleanupImportedResult(userId, request.getImportId());
+      return createdAssets;
+    } catch (DataIntegrityViolationException ex) {
+      String symbol = assets.isEmpty() ? null : assets.getFirst().getSymbol();
+      throw assetValidationHelper.translateSymbolPersistenceConflict(ex, portfolioId, symbol);
+    }
   }
 
   @Override
@@ -129,5 +164,13 @@ public class AssetServiceImpl implements AssetService {
     } catch (JsonProcessingException ex) {
       throw new IllegalStateException("Unable to read persisted asset import result", ex);
     }
+  }
+
+  private void cleanupImportedResult(Long userId, String importId) {
+    String sanitizedImportId = Utils.trimToNull(importId);
+    if (sanitizedImportId == null) {
+      return;
+    }
+    redisTemplate.delete(ASSET_IMPORT_RESULT_KEY_PREFIX + userId + ":" + sanitizedImportId);
   }
 }

--- a/services/portfolio-service/src/main/resources/db.changelog/asset-changelog/asset-changelog-dll.xml
+++ b/services/portfolio-service/src/main/resources/db.changelog/asset-changelog/asset-changelog-dll.xml
@@ -184,4 +184,18 @@
 
     </changeSet>
 
+    <changeSet id="alter-assets-name-length-to-200" author="tyche-wealth">
+
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <columnExists tableName="assets" columnName="name"/>
+        </preConditions>
+
+        <modifyDataType tableName="assets" columnName="name" newDataType="VARCHAR(200)"/>
+
+        <rollback>
+            <modifyDataType tableName="assets" columnName="name" newDataType="VARCHAR(60)"/>
+        </rollback>
+
+    </changeSet>
+
 </databaseChangeLog>

--- a/services/portfolio-service/src/test/java/com/tychewealth/constants/TestConstants.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/constants/TestConstants.java
@@ -21,6 +21,12 @@ public final class TestConstants {
   public static final String TEST_PORTFOLIO_ID_TEMPLATE = "{portfolioId}";
   public static final String TEST_ASSET_IMPORT_ID = "import-123";
   public static final String TEST_MISSING_ASSET_IMPORT_ID = "missing-import";
+  public static final String TEST_BATCH_ACTION_CREATE = "CREATE";
+  public static final String TEST_BATCH_ACTION_DISCARD = "DISCARD";
+  public static final String TEST_BATCH_FIELD_ACTION = "action";
+  public static final String TEST_BATCH_FIELD_IMPORT_ID = "importId";
+  public static final String TEST_BATCH_FIELD_ASSETS = "assets";
+  public static final String TEST_ASSET_IMPORT_RESULT_KEY_PREFIX = "asset-import:result:";
   public static final long TEST_ASSET_ID = 11L;
   public static final long TEST_USER_ID = 42L;
   public static final long TEST_OTHER_USER_ID = 84L;

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/AssetApiControllerIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/AssetApiControllerIntegrationTest.java
@@ -3,17 +3,25 @@ package com.tychewealth.controller;
 import static com.tychewealth.constants.ApiConstants.ASSET_IMPORT_BY_ID_URL;
 import static com.tychewealth.constants.ApiConstants.ASSET_IMPORT_URL;
 import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BASE_URL;
+import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BATCH_URL;
 import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
 import static com.tychewealth.constants.CommonConstants.DESCRIPTION;
 import static com.tychewealth.constants.SecurityConstants.CACHE_CONTROL_NO_STORE_HEADER_VALUE;
 import static com.tychewealth.constants.SecurityConstants.PRAGMA_NO_CACHE_HEADER_VALUE;
 import static com.tychewealth.constants.TestConstants.TEST_ASSET_IMPORT_ID;
+import static com.tychewealth.constants.TestConstants.TEST_ASSET_IMPORT_RESULT_KEY_PREFIX;
 import static com.tychewealth.constants.TestConstants.TEST_ASSET_SYMBOL_MSFT;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_ACTION_CREATE;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_ACTION_DISCARD;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_FIELD_ACTION;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_FIELD_ASSETS;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_FIELD_IMPORT_ID;
 import static com.tychewealth.constants.TestConstants.TEST_FILE_PART_NAME;
 import static com.tychewealth.constants.TestConstants.TEST_JSON_CODE_PATH;
 import static com.tychewealth.constants.TestConstants.TEST_JSON_TYPE_PATH;
 import static com.tychewealth.constants.TestConstants.TEST_MISSING_ASSET_IMPORT_ID;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.AiTestData.TEST_ASSET_NAME_MICROSOFT;
 import static com.tychewealth.testdata.AssetTestData.AI_RESPONSE;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_CONTENT_TYPE_CSV;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_EXTRACTED_TEXT;
@@ -30,6 +38,7 @@ import static com.tychewealth.testdata.AssetTestData.validImportedAssetCandidate
 import static com.tychewealth.testhelper.AuthTestHelper.createAuthorizationHeader;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -62,6 +71,7 @@ import com.tychewealth.service.helper.asset.ai.ImportAssetsAiHelper;
 import com.tychewealth.testhelper.TestRedisSupport.InMemoryRedisState;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -242,8 +252,138 @@ class AssetApiControllerIntegrationTest {
         .andExpect(jsonPath("$.symbol").value(TEST_ASSET_SYMBOL_AAPL))
         .andExpect(jsonPath("$.assetType").value(AssetTypeEnum.STOCK.name()))
         .andExpect(jsonPath("$.quantity").value(TEST_ASSET_RESPONSE_QUANTITY.intValue()))
-        .andExpect(jsonPath("$.averagePrice").value(123.4567))
+        .andExpect(jsonPath("$.averagePrice").value(existingAsset.getAveragePrice().doubleValue()))
         .andExpect(jsonPath("$.currency").value(CurrencyCodeEnum.USD.name()));
+  }
+
+  @Test
+  void createBatchReturnsCreatedWhenRequestIsValid() throws Exception {
+    PortfolioEntity portfolio = portfolioRepository.saveAndFlush(defaultPortfolioEntity());
+    String redisKey =
+        TEST_ASSET_IMPORT_RESULT_KEY_PREFIX + TEST_USER_ID + ":" + TEST_ASSET_IMPORT_ID;
+    redisState.set(redisKey, "{\"importId\":\"" + TEST_ASSET_IMPORT_ID + "\"}", null);
+
+    Map<String, Object> request =
+        Map.of(
+            TEST_BATCH_FIELD_ACTION,
+            TEST_BATCH_ACTION_CREATE,
+            TEST_BATCH_FIELD_IMPORT_ID,
+            TEST_ASSET_IMPORT_ID,
+            TEST_BATCH_FIELD_ASSETS,
+            List.of(
+                validCreateRequest(),
+                createRequestWithNameAndSymbol(TEST_ASSET_NAME_MICROSOFT, TEST_ASSET_SYMBOL_MSFT)));
+
+    mockMvc
+        .perform(
+            post(PORTFOLIO_ASSET_BATCH_URL, portfolio.getId())
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))
+                .header(AUTHORIZATION_HEADER, createAuthorizationHeader(TEST_USER_ID)))
+        .andExpect(status().isCreated())
+        .andExpect(header().string(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE))
+        .andExpect(header().string(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE))
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$[0].name").value(TEST_ASSET_NAME_APPLE))
+        .andExpect(jsonPath("$[0].symbol").value(TEST_ASSET_SYMBOL_AAPL))
+        .andExpect(jsonPath("$[1].name").value(TEST_ASSET_NAME_MICROSOFT))
+        .andExpect(jsonPath("$[1].symbol").value(TEST_ASSET_SYMBOL_MSFT));
+
+    org.junit.jupiter.api.Assertions.assertEquals(
+        2, assetRepository.findByPortfolioId(portfolio.getId()).size());
+    org.junit.jupiter.api.Assertions.assertNull(redisState.get(redisKey));
+  }
+
+  @Test
+  void createBatchDiscardReturnsCreatedAndDeletesPersistedImport() throws Exception {
+    PortfolioEntity portfolio = portfolioRepository.saveAndFlush(defaultPortfolioEntity());
+    String redisKey =
+        TEST_ASSET_IMPORT_RESULT_KEY_PREFIX + TEST_USER_ID + ":" + TEST_ASSET_IMPORT_ID;
+    redisState.set(redisKey, "{\"importId\":\"" + TEST_ASSET_IMPORT_ID + "\"}", null);
+
+    Map<String, Object> request =
+        Map.of(
+            TEST_BATCH_FIELD_ACTION,
+            TEST_BATCH_ACTION_DISCARD,
+            TEST_BATCH_FIELD_IMPORT_ID,
+            TEST_ASSET_IMPORT_ID,
+            TEST_BATCH_FIELD_ASSETS,
+            List.of());
+
+    mockMvc
+        .perform(
+            post(PORTFOLIO_ASSET_BATCH_URL, portfolio.getId())
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))
+                .header(AUTHORIZATION_HEADER, createAuthorizationHeader(TEST_USER_ID)))
+        .andExpect(status().isCreated())
+        .andExpect(header().string(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE))
+        .andExpect(header().string(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE))
+        .andExpect(jsonPath("$", hasSize(0)));
+
+    org.junit.jupiter.api.Assertions.assertEquals(
+        0, assetRepository.findByPortfolioId(portfolio.getId()).size());
+    org.junit.jupiter.api.Assertions.assertNull(redisState.get(redisKey));
+  }
+
+  @Test
+  void createBatchReturnsConflictWhenAssetSymbolAlreadyExistsInPortfolio() throws Exception {
+    PortfolioEntity portfolio = portfolioRepository.saveAndFlush(defaultPortfolioEntity());
+    AssetEntity existingAsset = defaultAssetEntity(portfolio);
+    assetRepository.saveAndFlush(existingAsset);
+
+    Map<String, Object> request =
+        Map.of(
+            TEST_BATCH_FIELD_ACTION,
+            TEST_BATCH_ACTION_CREATE,
+            TEST_BATCH_FIELD_ASSETS,
+            List.of(
+                createRequestWithNameAndSymbol(TEST_ASSET_NAME_MICROSOFT, TEST_ASSET_SYMBOL_AAPL)));
+
+    mockMvc
+        .perform(
+            post(PORTFOLIO_ASSET_BATCH_URL, portfolio.getId())
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))
+                .header(AUTHORIZATION_HEADER, createAuthorizationHeader(TEST_USER_ID)))
+        .andExpect(status().isConflict())
+        .andExpect(header().string(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE))
+        .andExpect(header().string(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE))
+        .andExpect(
+            jsonPath(TEST_JSON_CODE_PATH).value(ErrorDefinition.ASSET_SYMBOL_CONFLICT.getCode()))
+        .andExpect(
+            jsonPath(TEST_JSON_TYPE_PATH).value(ErrorDefinition.ASSET_SYMBOL_CONFLICT.getType()))
+        .andExpect(jsonPath("$." + DESCRIPTION).value(containsString(TEST_ASSET_SYMBOL_AAPL)));
+  }
+
+  @Test
+  void createBatchReturnsConflictWhenBatchContainsDuplicateNames() throws Exception {
+    PortfolioEntity portfolio = portfolioRepository.saveAndFlush(defaultPortfolioEntity());
+
+    Map<String, Object> request =
+        Map.of(
+            TEST_BATCH_FIELD_ACTION,
+            TEST_BATCH_ACTION_CREATE,
+            TEST_BATCH_FIELD_ASSETS,
+            List.of(
+                createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL),
+                createRequestWithNameAndSymbol(
+                    "  " + TEST_ASSET_NAME_APPLE + "  ", TEST_ASSET_SYMBOL_MSFT)));
+
+    mockMvc
+        .perform(
+            post(PORTFOLIO_ASSET_BATCH_URL, portfolio.getId())
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))
+                .header(AUTHORIZATION_HEADER, createAuthorizationHeader(TEST_USER_ID)))
+        .andExpect(status().isConflict())
+        .andExpect(header().string(CACHE_CONTROL, CACHE_CONTROL_NO_STORE_HEADER_VALUE))
+        .andExpect(header().string(PRAGMA, PRAGMA_NO_CACHE_HEADER_VALUE))
+        .andExpect(
+            jsonPath(TEST_JSON_CODE_PATH).value(ErrorDefinition.ASSET_NAME_CONFLICT.getCode()))
+        .andExpect(
+            jsonPath(TEST_JSON_TYPE_PATH).value(ErrorDefinition.ASSET_NAME_CONFLICT.getType()))
+        .andExpect(jsonPath("$." + DESCRIPTION).value(containsString(TEST_ASSET_NAME_APPLE)));
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/controller/IdempotencyIntegrationTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/controller/IdempotencyIntegrationTest.java
@@ -1,6 +1,9 @@
 package com.tychewealth.controller;
 
 import static com.tychewealth.constants.TestConstants.TEST_BASE_CURRENCY_EUR;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_ACTION_CREATE;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_FIELD_ACTION;
+import static com.tychewealth.constants.TestConstants.TEST_BATCH_FIELD_ASSETS;
 import static com.tychewealth.constants.TestConstants.TEST_INVESTMENT_HORIZON_LONG;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_DESCRIPTION_LONG_TERM;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_MAX_RISK;
@@ -8,6 +11,15 @@ import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_NAME_RETIRE
 import static com.tychewealth.constants.TestConstants.TEST_RISK_PROFILE_LOW;
 import static com.tychewealth.constants.TestConstants.TEST_STRATEGY_TYPE_INCOME;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_CONTENT_TYPE_CSV;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_EXTRACTED_TEXT;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_FILE_NAME;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_NAME_APPLE;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
+import static com.tychewealth.testdata.AssetTestData.createRequestWithNameAndSymbol;
+import static com.tychewealth.testdata.AssetTestData.defaultPortfolioEntity;
+import static com.tychewealth.testhelper.ConcurrentTestHelper.executeAssetBatchCreate;
+import static com.tychewealth.testhelper.ConcurrentTestHelper.executeAssetCreate;
 import static com.tychewealth.testhelper.ConcurrentTestHelper.executeCreate;
 import static com.tychewealth.testhelper.ConcurrentTestHelper.executeImport;
 import static com.tychewealth.testhelper.ConcurrentTestHelper.runConcurrently;
@@ -24,8 +36,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tychewealth.config.IdempotencyIntegrationTestConfig;
 import com.tychewealth.dto.ai.AiModelTypeEnum;
 import com.tychewealth.dto.asset.AssetImportCandidateDto;
+import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
+import com.tychewealth.entity.PortfolioEntity;
 import com.tychewealth.enums.AssetTypeEnum;
 import com.tychewealth.enums.CurrencyCodeEnum;
+import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.AssetRepository;
 import com.tychewealth.repository.PortfolioRepository;
 import com.tychewealth.service.helper.asset.ai.AiResponseParser;
@@ -33,6 +48,7 @@ import com.tychewealth.service.helper.asset.ai.ImportAssetsAiHelper;
 import com.tychewealth.testhelper.ConcurrentTestHelper.IntegrationResponse;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +63,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 class IdempotencyIntegrationTest {
 
-  private static final byte[] IMPORT_FILE_BYTES = "ticker,quantity\nAAPL,10".getBytes(UTF_8);
-  private static final String IMPORT_FILE_NAME = "positions.csv";
+  private static final byte[] IMPORT_FILE_BYTES = TEST_ASSET_EXTRACTED_TEXT.getBytes(UTF_8);
   private static final String IMPORT_ENDPOINT = "/tyche-wealth/portfolio-service/v1/assets/import";
   private static final String AI_RESPONSE = "[{\"name\":\"Apple Inc.\",\"symbol\":\"AAPL\"}]";
 
@@ -67,12 +82,12 @@ class IdempotencyIntegrationTest {
 
     when(importAssetsAiHelper.prompt(anyString(), eq(AiModelTypeEnum.FAST)))
         .thenReturn(AI_RESPONSE);
-    when(aiResponseParser.parseAiAssets("ticker,quantity\nAAPL,10", AI_RESPONSE))
+    when(aiResponseParser.parseAiAssets(TEST_ASSET_EXTRACTED_TEXT, AI_RESPONSE))
         .thenReturn(
             List.of(
                 new AssetImportCandidateDto(
-                    "Apple Inc.",
-                    "AAPL",
+                    TEST_ASSET_NAME_APPLE,
+                    TEST_ASSET_SYMBOL_AAPL,
                     AssetTypeEnum.STOCK,
                     new BigDecimal("10"),
                     new BigDecimal("150.00"),
@@ -106,7 +121,7 @@ class IdempotencyIntegrationTest {
         responses.stream()
             .filter(response -> response.status() == 409)
             .map(IntegrationResponse::body)
-            .anyMatch(body -> body.contains("PORTFOLIO_NAME_CONFLICT")));
+            .anyMatch(body -> body.contains(ErrorDefinition.PORTFOLIO_NAME_CONFLICT.getType())));
   }
 
   @Test
@@ -118,16 +133,16 @@ class IdempotencyIntegrationTest {
                     mockMvc,
                     TEST_USER_ID,
                     IMPORT_ENDPOINT,
-                    IMPORT_FILE_NAME,
-                    "text/csv",
+                    TEST_ASSET_FILE_NAME,
+                    TEST_ASSET_CONTENT_TYPE_CSV,
                     IMPORT_FILE_BYTES),
             () ->
                 executeImport(
                     mockMvc,
                     TEST_USER_ID,
                     IMPORT_ENDPOINT,
-                    IMPORT_FILE_NAME,
-                    "text/csv",
+                    TEST_ASSET_FILE_NAME,
+                    TEST_ASSET_CONTENT_TYPE_CSV,
                     IMPORT_FILE_BYTES));
 
     assertEquals(2, responses.size());
@@ -138,8 +153,57 @@ class IdempotencyIntegrationTest {
     JsonNode secondBody = objectMapper.readTree(responses.get(1).body());
 
     assertEquals(firstBody, secondBody);
-    assertEquals(1, firstBody.get("assets").size());
-    assertEquals("Apple Inc.", firstBody.get("assets").get(0).get("name").asText());
-    assertEquals("AAPL", firstBody.get("assets").get(0).get("symbol").asText());
+    assertEquals(1, firstBody.get(TEST_BATCH_FIELD_ASSETS).size());
+    assertEquals(
+        TEST_ASSET_NAME_APPLE, firstBody.get(TEST_BATCH_FIELD_ASSETS).get(0).get("name").asText());
+    assertEquals(
+        TEST_ASSET_SYMBOL_AAPL,
+        firstBody.get(TEST_BATCH_FIELD_ASSETS).get(0).get("symbol").asText());
+  }
+
+  @Test
+  void assetCreateHandlesConcurrentDuplicateRequestsWithSingleInsert() throws Exception {
+    PortfolioEntity portfolio = portfolioRepository.saveAndFlush(defaultPortfolioEntity());
+    AssetCreateRequestDto request =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL);
+    String requestBody = objectMapper.writeValueAsString(request);
+
+    List<IntegrationResponse> responses =
+        runConcurrently(
+            () -> executeAssetCreate(mockMvc, TEST_USER_ID, portfolio.getId(), requestBody),
+            () -> executeAssetCreate(mockMvc, TEST_USER_ID, portfolio.getId(), requestBody));
+
+    long createdCount = responses.stream().filter(response -> response.status() == 201).count();
+    long conflictCount = responses.stream().filter(response -> response.status() == 409).count();
+
+    assertEquals(1, createdCount);
+    assertEquals(1, conflictCount);
+    assertEquals(1, assetRepository.findByPortfolioId(portfolio.getId()).size());
+  }
+
+  @Test
+  void assetBatchCreateHandlesConcurrentDuplicateRequestsWithSingleInsert() throws Exception {
+    PortfolioEntity portfolio = portfolioRepository.saveAndFlush(defaultPortfolioEntity());
+    String requestBody =
+        objectMapper.writeValueAsString(
+            Map.of(
+                TEST_BATCH_FIELD_ACTION,
+                TEST_BATCH_ACTION_CREATE,
+                TEST_BATCH_FIELD_ASSETS,
+                List.of(
+                    createRequestWithNameAndSymbol(
+                        TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL))));
+
+    List<IntegrationResponse> responses =
+        runConcurrently(
+            () -> executeAssetBatchCreate(mockMvc, TEST_USER_ID, portfolio.getId(), requestBody),
+            () -> executeAssetBatchCreate(mockMvc, TEST_USER_ID, portfolio.getId(), requestBody));
+
+    long createdCount = responses.stream().filter(response -> response.status() == 201).count();
+    long conflictCount = responses.stream().filter(response -> response.status() == 409).count();
+
+    assertEquals(1, createdCount);
+    assertEquals(1, conflictCount);
+    assertEquals(1, assetRepository.findByPortfolioId(portfolio.getId()).size());
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/repository/AssetRepositoryTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/repository/AssetRepositoryTest.java
@@ -101,9 +101,9 @@ class AssetRepositoryTest {
     assetRepository.save(
         buildAsset(portfolio, "Tesla, Inc.", "TSLA", AssetTypeEnum.STOCK, CurrencyCodeEnum.USD));
 
-    Boolean exists = assetRepository.existsByPortfolioIdAndSymbol(portfolio.getId(), "TSLA");
+    boolean exists = assetRepository.existsByPortfolioIdAndSymbol(portfolio.getId(), "TSLA");
 
-    assertEquals(Boolean.TRUE, exists);
+    assertTrue(exists);
   }
 
   @Test
@@ -111,8 +111,8 @@ class AssetRepositoryTest {
     assetRepository.save(
         buildAsset(portfolio, "Tesla, Inc.", "TSLA", AssetTypeEnum.STOCK, CurrencyCodeEnum.USD));
 
-    Boolean exists = assetRepository.existsByPortfolioIdAndName(portfolio.getId(), "Tesla, Inc.");
+    boolean exists = assetRepository.existsByPortfolioIdAndName(portfolio.getId(), "Tesla, Inc.");
 
-    assertEquals(Boolean.TRUE, exists);
+    assertTrue(exists);
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/helper/asset/AssetCreateHelperTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/helper/asset/AssetCreateHelperTest.java
@@ -1,11 +1,13 @@
 package com.tychewealth.service.helper.asset;
 
+import static com.tychewealth.constants.TestConstants.TEST_ASSET_SYMBOL_MSFT;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_ID;
-import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
-import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_AVERAGE_PRICE;
+import static com.tychewealth.testdata.AiTestData.TEST_ASSET_NAME_MICROSOFT;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_NAME_APPLE;
-import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_QUANTITY;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
+import static com.tychewealth.testdata.AssetTestData.createRequestWithNameAndSymbol;
+import static com.tychewealth.testdata.AssetTestData.defaultPortfolioEntity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,14 +16,9 @@ import com.tychewealth.dto.asset.AssetResponseDto;
 import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
 import com.tychewealth.entity.AssetEntity;
 import com.tychewealth.entity.PortfolioEntity;
-import com.tychewealth.enums.AssetTypeEnum;
-import com.tychewealth.enums.CurrencyCodeEnum;
-import com.tychewealth.enums.InvestmentHorizonEnum;
-import com.tychewealth.enums.RiskProfileEnum;
-import com.tychewealth.enums.StrategyTypeEnum;
 import com.tychewealth.mapper.asset.AssetMapper;
 import com.tychewealth.repository.AssetRepository;
-import com.tychewealth.testdata.EntityBuilder;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -36,23 +33,10 @@ class AssetCreateHelperTest {
   @Test
   void createMapsAssignsPortfolioPersistsAndReturnsMappedResponse() {
     AssetCreateHelper helper = new AssetCreateHelper(assetRepository, assetMapper);
-    PortfolioEntity portfolio =
-        EntityBuilder.buildPortfolio(
-            TEST_USER_ID,
-            "Core",
-            CurrencyCodeEnum.USD,
-            RiskProfileEnum.MEDIUM,
-            StrategyTypeEnum.BALANCED,
-            InvestmentHorizonEnum.MEDIUM);
+    PortfolioEntity portfolio = defaultPortfolioEntity();
     portfolio.setId(TEST_PORTFOLIO_ID);
     AssetCreateRequestDto request =
-        new AssetCreateRequestDto(
-            TEST_ASSET_NAME_APPLE,
-            TEST_ASSET_SYMBOL_AAPL,
-            AssetTypeEnum.STOCK,
-            TEST_ASSET_QUANTITY,
-            TEST_ASSET_AVERAGE_PRICE,
-            CurrencyCodeEnum.USD);
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL);
     AssetEntity mappedAsset = new AssetEntity();
     AssetEntity persistedAsset = new AssetEntity();
     AssetResponseDto response = new AssetResponseDto();
@@ -68,5 +52,45 @@ class AssetCreateHelperTest {
     verify(assetMapper).create(request);
     verify(assetRepository).saveAndFlush(mappedAsset);
     verify(assetMapper).toDto(persistedAsset);
+  }
+
+  @Test
+  void createBatchMapsAssignsPortfolioPersistsAndReturnsMappedResponses() {
+    AssetCreateHelper helper = new AssetCreateHelper(assetRepository, assetMapper);
+    PortfolioEntity portfolio = defaultPortfolioEntity();
+    portfolio.setId(TEST_PORTFOLIO_ID);
+
+    AssetCreateRequestDto firstRequest =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL);
+    AssetCreateRequestDto secondRequest =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_MICROSOFT, TEST_ASSET_SYMBOL_MSFT);
+
+    AssetEntity firstMapped = new AssetEntity();
+    AssetEntity secondMapped = new AssetEntity();
+    AssetEntity firstPersisted = new AssetEntity();
+    AssetEntity secondPersisted = new AssetEntity();
+    AssetResponseDto firstResponse = new AssetResponseDto();
+    AssetResponseDto secondResponse = new AssetResponseDto();
+
+    when(assetMapper.create(firstRequest)).thenReturn(firstMapped);
+    when(assetMapper.create(secondRequest)).thenReturn(secondMapped);
+    when(assetRepository.saveAllAndFlush(List.of(firstMapped, secondMapped)))
+        .thenReturn(List.of(firstPersisted, secondPersisted));
+    when(assetMapper.toDto(firstPersisted)).thenReturn(firstResponse);
+    when(assetMapper.toDto(secondPersisted)).thenReturn(secondResponse);
+
+    List<AssetResponseDto> result =
+        helper.createBatch(portfolio, List.of(firstRequest, secondRequest));
+
+    assertEquals(2, result.size());
+    assertSame(firstResponse, result.getFirst());
+    assertSame(secondResponse, result.get(1));
+    assertSame(portfolio, firstMapped.getPortfolio());
+    assertSame(portfolio, secondMapped.getPortfolio());
+    verify(assetMapper).create(firstRequest);
+    verify(assetMapper).create(secondRequest);
+    verify(assetRepository).saveAllAndFlush(List.of(firstMapped, secondMapped));
+    verify(assetMapper).toDto(firstPersisted);
+    verify(assetMapper).toDto(secondPersisted);
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/helper/asset/AssetValidationHelperTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/helper/asset/AssetValidationHelperTest.java
@@ -1,19 +1,27 @@
 package com.tychewealth.service.helper.asset;
 
 import static com.tychewealth.constants.TestConstants.TEST_ASSET_ID;
+import static com.tychewealth.constants.TestConstants.TEST_ASSET_SYMBOL_MSFT;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_ID;
+import static com.tychewealth.testdata.AiTestData.TEST_ASSET_NAME_MICROSOFT;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_NAME_APPLE;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
+import static com.tychewealth.testdata.AssetTestData.createRequestWithNameAndSymbol;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
 import com.tychewealth.entity.AssetEntity;
+import com.tychewealth.enums.AssetBatchActionEnum;
 import com.tychewealth.error.exception.PortfolioException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.repository.AssetRepository;
 import java.util.Collections;
+import java.util.List;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,6 +64,155 @@ class AssetValidationHelperTest {
     assertEquals(ErrorDefinition.ASSET_NAME_CONFLICT, exception.getErrorDefinition());
     assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
     assertEquals(TEST_ASSET_NAME_APPLE, exception.getDescription().get("name"));
+  }
+
+  @Test
+  void validateBatchCreateRequestRequiresAction() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class, () -> helper.validateBatchCreateRequest(null, null, null));
+
+    assertEquals(ErrorDefinition.GENERIC_BAD_REQUEST, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+  }
+
+  @Test
+  void validateBatchCreateRequestForDiscardRequiresImportId() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+    List<AssetCreateRequestDto> emptyAssets = Collections.emptyList();
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class,
+            () ->
+                helper.validateBatchCreateRequest(
+                    AssetBatchActionEnum.DISCARD, "   ", emptyAssets));
+
+    assertEquals(ErrorDefinition.GENERIC_BAD_REQUEST, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+  }
+
+  @Test
+  void validateBatchCreateRequestForCreateRequiresAssets() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+    List<AssetCreateRequestDto> emptyAssets = Collections.emptyList();
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class,
+            () ->
+                helper.validateBatchCreateRequest(AssetBatchActionEnum.CREATE, null, emptyAssets));
+
+    assertEquals(ErrorDefinition.GENERIC_BAD_REQUEST, exception.getErrorDefinition());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+  }
+
+  @Test
+  void validateBatchCreateLimitThrowsConflictWhenCombinedCountExceedsMaximum() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+
+    when(assetRepository.findByPortfolioId(TEST_PORTFOLIO_ID))
+        .thenReturn(Collections.nCopies(199, new AssetEntity()));
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class, () -> helper.validateBatchCreateLimit(TEST_PORTFOLIO_ID, 2));
+
+    assertEquals(ErrorDefinition.ASSET_LIMIT_REACHED, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+  }
+
+  @Test
+  void validateBatchCreateRequestDuplicatesThrowsConflictWhenSameNameAppearsTwice() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+    AssetCreateRequestDto first =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL);
+    AssetCreateRequestDto second =
+        createRequestWithNameAndSymbol("  " + TEST_ASSET_NAME_APPLE + "  ", "AAPL-2");
+    List<AssetCreateRequestDto> assets = List.of(first, second);
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class, () -> helper.validateBatchCreateRequestDuplicates(assets));
+
+    assertEquals(ErrorDefinition.ASSET_NAME_CONFLICT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+  }
+
+  @Test
+  void validateBatchCreateRequestDuplicatesAllowsDifferentNames() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+    AssetCreateRequestDto first =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL);
+    AssetCreateRequestDto second =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_MICROSOFT, TEST_ASSET_SYMBOL_MSFT);
+
+    helper.validateBatchCreateRequestDuplicates(List.of(first, second));
+  }
+
+  @Test
+  void validateBatchCreateDatabaseConflictsThrowsNameConflictWhenNameExistsInPortfolio() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+    AssetCreateRequestDto asset =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL);
+    List<AssetCreateRequestDto> assets = List.of(asset);
+
+    when(assetRepository.existsByPortfolioIdAndName(TEST_PORTFOLIO_ID, TEST_ASSET_NAME_APPLE))
+        .thenReturn(true);
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class,
+            () -> helper.validateBatchCreateDatabaseConflicts(TEST_PORTFOLIO_ID, assets));
+
+    assertEquals(ErrorDefinition.ASSET_NAME_CONFLICT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    verify(assetRepository, never())
+        .existsByPortfolioIdAndSymbol(TEST_PORTFOLIO_ID, TEST_ASSET_SYMBOL_AAPL);
+  }
+
+  @Test
+  void validateBatchCreateDatabaseConflictsThrowsSymbolConflictWhenSymbolExistsInPortfolio() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+    AssetCreateRequestDto asset =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_MICROSOFT, TEST_ASSET_SYMBOL_MSFT);
+    List<AssetCreateRequestDto> assets = List.of(asset);
+
+    when(assetRepository.existsByPortfolioIdAndName(TEST_PORTFOLIO_ID, TEST_ASSET_NAME_MICROSOFT))
+        .thenReturn(false);
+    when(assetRepository.existsByPortfolioIdAndSymbol(TEST_PORTFOLIO_ID, TEST_ASSET_SYMBOL_MSFT))
+        .thenReturn(true);
+
+    PortfolioException exception =
+        assertThrows(
+            PortfolioException.class,
+            () -> helper.validateBatchCreateDatabaseConflicts(TEST_PORTFOLIO_ID, assets));
+
+    assertEquals(ErrorDefinition.ASSET_SYMBOL_CONFLICT, exception.getErrorDefinition());
+    assertEquals(HttpStatus.CONFLICT, exception.getHttpStatus());
+    assertEquals(TEST_ASSET_SYMBOL_MSFT, exception.getDescription().get("name"));
+  }
+
+  @Test
+  void validateBatchCreateDatabaseConflictsAllowsAssetsWhenNoConflictsExist() {
+    AssetValidationHelper helper = new AssetValidationHelper(assetRepository);
+    AssetCreateRequestDto first =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_APPLE, TEST_ASSET_SYMBOL_AAPL);
+    AssetCreateRequestDto second =
+        createRequestWithNameAndSymbol(TEST_ASSET_NAME_MICROSOFT, TEST_ASSET_SYMBOL_MSFT);
+
+    when(assetRepository.existsByPortfolioIdAndName(TEST_PORTFOLIO_ID, TEST_ASSET_NAME_APPLE))
+        .thenReturn(false);
+    when(assetRepository.existsByPortfolioIdAndSymbol(TEST_PORTFOLIO_ID, TEST_ASSET_SYMBOL_AAPL))
+        .thenReturn(false);
+    when(assetRepository.existsByPortfolioIdAndName(TEST_PORTFOLIO_ID, TEST_ASSET_NAME_MICROSOFT))
+        .thenReturn(false);
+    when(assetRepository.existsByPortfolioIdAndSymbol(TEST_PORTFOLIO_ID, TEST_ASSET_SYMBOL_MSFT))
+        .thenReturn(false);
+
+    helper.validateBatchCreateDatabaseConflicts(TEST_PORTFOLIO_ID, List.of(first, second));
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/impl/AssetServiceImplTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/impl/AssetServiceImplTest.java
@@ -6,15 +6,19 @@ import static com.tychewealth.constants.LogConstants.RETRIEVE_ACTION;
 import static com.tychewealth.constants.RedisConstants.ASSET_IMPORT_RESULT_KEY_PREFIX;
 import static com.tychewealth.constants.TestConstants.TEST_ASSET_ID;
 import static com.tychewealth.constants.TestConstants.TEST_ASSET_IMPORT_ID;
+import static com.tychewealth.constants.TestConstants.TEST_ASSET_SYMBOL_MSFT;
 import static com.tychewealth.constants.TestConstants.TEST_FILE_PART_NAME;
 import static com.tychewealth.constants.TestConstants.TEST_MISSING_ASSET_IMPORT_ID;
 import static com.tychewealth.constants.TestConstants.TEST_OTHER_USER_ID;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_ID;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.AiTestData.TEST_ASSET_NAME_MICROSOFT;
 import static com.tychewealth.testdata.AssetTestData.AI_RESPONSE;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_CONTENT_TYPE_CSV;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_EXTRACTED_TEXT;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_FILE_NAME;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_NAME_APPLE;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
 import static com.tychewealth.testdata.AssetTestData.validImportedAssetCandidate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -27,10 +31,12 @@ import com.tychewealth.dto.asset.AssetImportCandidateDto;
 import com.tychewealth.dto.asset.AssetImportResponseDto;
 import com.tychewealth.dto.asset.AssetPersistRedisDto;
 import com.tychewealth.dto.asset.AssetResponseDto;
+import com.tychewealth.dto.asset.request.AssetBatchCreateRequestDto;
 import com.tychewealth.dto.asset.request.AssetCreateRequestDto;
 import com.tychewealth.dto.asset.request.AssetImportPayloadDto;
 import com.tychewealth.entity.AssetEntity;
 import com.tychewealth.entity.PortfolioEntity;
+import com.tychewealth.enums.AssetBatchActionEnum;
 import com.tychewealth.error.exception.AssetImportException;
 import com.tychewealth.error.exception.PortfolioException;
 import com.tychewealth.error.handler.ErrorDefinition;
@@ -43,12 +49,14 @@ import com.tychewealth.service.helper.asset.ai.AiResponseParser;
 import com.tychewealth.service.helper.asset.ai.AssetAiValidationHelper;
 import com.tychewealth.service.helper.asset.ai.ImportAssetsAiHelper;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
@@ -70,65 +78,69 @@ class AssetServiceImplTest {
   @Mock private ObjectMapper objectMapper;
 
   @InjectMocks private AssetServiceImpl assetService;
+  private PortfolioEntity portfolio;
+
+  @BeforeEach
+  void setUp() {
+    portfolio = new PortfolioEntity();
+    portfolio.setId(TEST_PORTFOLIO_ID);
+  }
 
   @Test
   void createValidatesAndDelegatesToCreateHelper() {
-    Long portfolioId = 10L;
     AssetCreateRequestDto request = new AssetCreateRequestDto();
-    request.setName("Apple");
-    request.setSymbol("AAPL");
-    PortfolioEntity portfolio = new PortfolioEntity();
-    portfolio.setId(portfolioId);
+    request.setName(TEST_ASSET_NAME_APPLE);
+    request.setSymbol(TEST_ASSET_SYMBOL_AAPL);
     AssetResponseDto response = new AssetResponseDto();
     response.setId(20L);
 
-    when(commonValidationHelper.validateOwnedPortfolio(TEST_USER_ID, portfolioId, CREATE_ACTION))
+    when(commonValidationHelper.validateOwnedPortfolio(
+            TEST_USER_ID, TEST_PORTFOLIO_ID, CREATE_ACTION))
         .thenReturn(portfolio);
     when(assetCreateHelper.create(portfolio, request)).thenReturn(response);
 
-    AssetResponseDto result = assetService.create(TEST_USER_ID, portfolioId, request);
+    AssetResponseDto result = assetService.create(TEST_USER_ID, TEST_PORTFOLIO_ID, request);
 
     assertSame(response, result);
     verify(commonValidationHelper).validateAuthenticatedUser(TEST_USER_ID);
-    verify(commonValidationHelper).validateOwnedPortfolio(TEST_USER_ID, portfolioId, CREATE_ACTION);
-    verify(assetValidationHelper).validateCreateLimit(portfolioId);
-    verify(assetValidationHelper).validateCreateNameConflict(portfolioId, request.getName());
+    verify(commonValidationHelper)
+        .validateOwnedPortfolio(TEST_USER_ID, TEST_PORTFOLIO_ID, CREATE_ACTION);
+    verify(assetValidationHelper).validateCreateLimit(TEST_PORTFOLIO_ID);
+    verify(assetValidationHelper).validateCreateNameConflict(TEST_PORTFOLIO_ID, request.getName());
+    verify(assetValidationHelper)
+        .validateCreateSymbolConflict(TEST_PORTFOLIO_ID, request.getSymbol());
     verify(assetCreateHelper).create(portfolio, request);
   }
 
   @Test
   void createStopsWhenNameValidationFails() {
-    Long portfolioId = 10L;
     AssetCreateRequestDto request = new AssetCreateRequestDto();
-    request.setName("Apple");
-    PortfolioEntity portfolio = new PortfolioEntity();
-    portfolio.setId(portfolioId);
+    request.setName(TEST_ASSET_NAME_APPLE);
     PortfolioException conflict =
         new PortfolioException(
             ErrorDefinition.ASSET_NAME_CONFLICT, java.util.Map.of(), HttpStatus.CONFLICT);
 
-    when(commonValidationHelper.validateOwnedPortfolio(TEST_USER_ID, portfolioId, CREATE_ACTION))
+    when(commonValidationHelper.validateOwnedPortfolio(
+            TEST_USER_ID, TEST_PORTFOLIO_ID, CREATE_ACTION))
         .thenReturn(portfolio);
     doThrow(conflict)
         .when(assetValidationHelper)
-        .validateCreateNameConflict(portfolioId, request.getName());
+        .validateCreateNameConflict(TEST_PORTFOLIO_ID, request.getName());
 
     PortfolioException thrown =
         assertThrows(
             PortfolioException.class,
-            () -> assetService.create(TEST_USER_ID, portfolioId, request));
+            () -> assetService.create(TEST_USER_ID, TEST_PORTFOLIO_ID, request));
 
     assertSame(conflict, thrown);
-    verify(assetValidationHelper).validateCreateLimit(portfolioId);
-    verify(assetValidationHelper).validateCreateNameConflict(portfolioId, request.getName());
+    verify(assetValidationHelper).validateCreateLimit(TEST_PORTFOLIO_ID);
+    verify(assetValidationHelper).validateCreateNameConflict(TEST_PORTFOLIO_ID, request.getName());
     verifyNoInteractions(assetCreateHelper);
   }
 
   @Test
   void retrieveValidatesAndReturnsMappedAsset() {
     Long assetId = TEST_ASSET_ID;
-    PortfolioEntity portfolio = new PortfolioEntity();
-    portfolio.setId(TEST_PORTFOLIO_ID);
     AssetEntity asset = new AssetEntity();
     asset.setId(assetId);
     AssetResponseDto response = new AssetResponseDto();
@@ -154,8 +166,6 @@ class AssetServiceImplTest {
   @Test
   void retrieveStopsWhenAssetDoesNotExist() {
     Long assetId = TEST_ASSET_ID;
-    PortfolioEntity portfolio = new PortfolioEntity();
-    portfolio.setId(TEST_PORTFOLIO_ID);
     PortfolioException notFound =
         new PortfolioException(
             ErrorDefinition.ASSET_NOT_FOUND, java.util.Map.of(), HttpStatus.NOT_FOUND);
@@ -177,6 +187,99 @@ class AssetServiceImplTest {
         .validateOwnedPortfolio(TEST_USER_ID, TEST_PORTFOLIO_ID, RETRIEVE_ACTION);
     verify(assetValidationHelper).validateRetrievedAssetExists(TEST_PORTFOLIO_ID, assetId);
     verifyNoInteractions(assetMapper);
+  }
+
+  @Test
+  void createBatchFromImportedAssetsForCreateValidatesAndDelegatesToCreateHelper() {
+    AssetCreateRequestDto first = new AssetCreateRequestDto();
+    first.setName(TEST_ASSET_NAME_APPLE);
+    first.setSymbol(TEST_ASSET_SYMBOL_AAPL);
+    AssetCreateRequestDto second = new AssetCreateRequestDto();
+    second.setName(TEST_ASSET_NAME_MICROSOFT);
+    second.setSymbol(TEST_ASSET_SYMBOL_MSFT);
+    AssetBatchCreateRequestDto request =
+        new AssetBatchCreateRequestDto(
+            AssetBatchActionEnum.CREATE, TEST_ASSET_IMPORT_ID, List.of(first, second));
+    List<AssetResponseDto> created = List.of(new AssetResponseDto(), new AssetResponseDto());
+
+    when(commonValidationHelper.validateOwnedPortfolio(
+            TEST_USER_ID, TEST_PORTFOLIO_ID, CREATE_ACTION))
+        .thenReturn(portfolio);
+    when(assetCreateHelper.createBatch(portfolio, List.of(first, second))).thenReturn(created);
+
+    List<AssetResponseDto> result =
+        assetService.createBatchFromImportedAssets(TEST_USER_ID, TEST_PORTFOLIO_ID, request);
+
+    assertSame(created, result);
+    verify(commonValidationHelper).validateAuthenticatedUser(TEST_USER_ID);
+    verify(commonValidationHelper)
+        .validateOwnedPortfolio(TEST_USER_ID, TEST_PORTFOLIO_ID, CREATE_ACTION);
+    verify(assetValidationHelper)
+        .validateBatchCreateRequest(
+            AssetBatchActionEnum.CREATE, TEST_ASSET_IMPORT_ID, List.of(first, second));
+    verify(assetValidationHelper).validateBatchCreateLimit(TEST_PORTFOLIO_ID, 2);
+    verify(assetValidationHelper).validateBatchCreateRequestDuplicates(List.of(first, second));
+    verify(assetValidationHelper)
+        .validateBatchCreateDatabaseConflicts(TEST_PORTFOLIO_ID, List.of(first, second));
+    verify(assetCreateHelper).createBatch(portfolio, List.of(first, second));
+    verify(redisTemplate)
+        .delete(ASSET_IMPORT_RESULT_KEY_PREFIX + TEST_USER_ID + ":" + TEST_ASSET_IMPORT_ID);
+  }
+
+  @Test
+  void createBatchFromImportedAssetsForDiscardReturnsEmptyAndDeletesImport() {
+    AssetBatchCreateRequestDto request =
+        new AssetBatchCreateRequestDto(
+            AssetBatchActionEnum.DISCARD, TEST_ASSET_IMPORT_ID, List.of());
+
+    when(commonValidationHelper.validateOwnedPortfolio(
+            TEST_USER_ID, TEST_PORTFOLIO_ID, CREATE_ACTION))
+        .thenReturn(portfolio);
+
+    List<AssetResponseDto> result =
+        assetService.createBatchFromImportedAssets(TEST_USER_ID, TEST_PORTFOLIO_ID, request);
+
+    assertEquals(0, result.size());
+    verify(assetValidationHelper)
+        .validateBatchCreateRequest(AssetBatchActionEnum.DISCARD, TEST_ASSET_IMPORT_ID, List.of());
+    verify(redisTemplate)
+        .delete(ASSET_IMPORT_RESULT_KEY_PREFIX + TEST_USER_ID + ":" + TEST_ASSET_IMPORT_ID);
+    verify(assetCreateHelper, never()).createBatch(any(), any());
+  }
+
+  @Test
+  void createBatchFromImportedAssetsTranslatesDataIntegrityViolationException() {
+    AssetCreateRequestDto first = new AssetCreateRequestDto();
+    first.setName(TEST_ASSET_NAME_APPLE);
+    first.setSymbol(TEST_ASSET_SYMBOL_AAPL);
+    AssetBatchCreateRequestDto request =
+        new AssetBatchCreateRequestDto(
+            AssetBatchActionEnum.CREATE, TEST_ASSET_IMPORT_ID, List.of(first));
+    DataIntegrityViolationException dataException =
+        new DataIntegrityViolationException("duplicate symbol");
+    PortfolioException translated =
+        new PortfolioException(
+            ErrorDefinition.ASSET_SYMBOL_CONFLICT, java.util.Map.of(), HttpStatus.CONFLICT);
+
+    when(commonValidationHelper.validateOwnedPortfolio(
+            TEST_USER_ID, TEST_PORTFOLIO_ID, CREATE_ACTION))
+        .thenReturn(portfolio);
+    when(assetCreateHelper.createBatch(portfolio, List.of(first))).thenThrow(dataException);
+    when(assetValidationHelper.translateSymbolPersistenceConflict(
+            dataException, TEST_PORTFOLIO_ID, TEST_ASSET_SYMBOL_AAPL))
+        .thenReturn(translated);
+
+    PortfolioException thrown =
+        assertThrows(
+            PortfolioException.class,
+            () ->
+                assetService.createBatchFromImportedAssets(
+                    TEST_USER_ID, TEST_PORTFOLIO_ID, request));
+
+    assertSame(translated, thrown);
+    verify(assetValidationHelper)
+        .translateSymbolPersistenceConflict(
+            dataException, TEST_PORTFOLIO_ID, TEST_ASSET_SYMBOL_AAPL);
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/testdata/AssetTestData.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/testdata/AssetTestData.java
@@ -3,7 +3,7 @@ package com.tychewealth.testdata;
 import static com.tychewealth.constants.TestConstants.TEST_PORTFOLIO_NAME_CORE;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_AT_MOST_20_CHARACTERS;
-import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_60_CHARACTERS;
+import static com.tychewealth.constants.ValidationConstants.MUST_BE_BETWEEN_3_AND_200_CHARACTERS;
 import static com.tychewealth.constants.ValidationConstants.MUST_BE_GREATER_THAN_0;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_11_INTEGER_DIGITS_AND_8_DECIMALS;
 import static com.tychewealth.constants.ValidationConstants.MUST_HAVE_UP_TO_15_INTEGER_DIGITS_AND_4_DECIMALS;
@@ -65,7 +65,7 @@ public final class AssetTestData {
     return Stream.of(
         Arguments.of(invalidCreate(dto -> dto.setName(" ")), "name", MUST_NOT_BE_BLANK),
         Arguments.of(
-            invalidCreate(dto -> dto.setName("AB")), "name", MUST_BE_BETWEEN_3_AND_60_CHARACTERS),
+            invalidCreate(dto -> dto.setName("AB")), "name", MUST_BE_BETWEEN_3_AND_200_CHARACTERS),
         Arguments.of(
             invalidCreate(dto -> dto.setSymbol("X".repeat(21))),
             "symbol",
@@ -93,7 +93,7 @@ public final class AssetTestData {
         Arguments.of(invalidCreate(dto -> dto.setCurrency(null)), "currency", MUST_NOT_BE_NULL),
         Arguments.of(invalidUpdate(dto -> dto.setName(" ")), "name", MUST_NOT_BE_BLANK),
         Arguments.of(
-            invalidUpdate(dto -> dto.setName("AB")), "name", MUST_BE_BETWEEN_3_AND_60_CHARACTERS),
+            invalidUpdate(dto -> dto.setName("AB")), "name", MUST_BE_BETWEEN_3_AND_200_CHARACTERS),
         Arguments.of(invalidUpdate(dto -> dto.setSymbol(" ")), "symbol", MUST_NOT_BE_BLANK),
         Arguments.of(
             invalidUpdate(dto -> dto.setSymbol("X".repeat(21))),
@@ -121,7 +121,7 @@ public final class AssetTestData {
         Arguments.of(
             invalidEntity(entity -> entity.setName("AB")),
             "name",
-            MUST_BE_BETWEEN_3_AND_60_CHARACTERS),
+            MUST_BE_BETWEEN_3_AND_200_CHARACTERS),
         Arguments.of(invalidEntity(entity -> entity.setSymbol(" ")), "symbol", MUST_NOT_BE_BLANK),
         Arguments.of(
             invalidEntity(entity -> entity.setSymbol("X".repeat(21))),
@@ -205,6 +205,7 @@ public final class AssetTestData {
   }
 
   public static AssetResponseDto defaultAssetResponseDto(Long id) {
+    java.time.LocalDateTime now = java.time.LocalDateTime.now();
     return new AssetResponseDto(
         id,
         CurrencyCodeEnum.USD,
@@ -213,8 +214,8 @@ public final class AssetTestData {
         AssetTypeEnum.STOCK,
         TEST_ASSET_QUANTITY,
         TEST_ASSET_AVERAGE_PRICE,
-        java.time.LocalDateTime.now(),
-        java.time.LocalDateTime.now());
+        now,
+        now);
   }
 
   private static AssetUpdateRequestDto validUpdate() {

--- a/services/portfolio-service/src/test/java/com/tychewealth/testdata/EndpointTestData.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/testdata/EndpointTestData.java
@@ -3,6 +3,7 @@ package com.tychewealth.testdata;
 import static com.tychewealth.constants.ApiConstants.ASSET_IMPORT_BY_ID_URL;
 import static com.tychewealth.constants.ApiConstants.ASSET_IMPORT_URL;
 import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BASE_URL;
+import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BY_ID_URL;
 import static com.tychewealth.constants.ApiConstants.PORTFOLIO_BASE_URL;
 import static com.tychewealth.constants.CommonConstants.DELETE;
 import static com.tychewealth.constants.CommonConstants.GET;
@@ -65,10 +66,9 @@ public final class EndpointTestData {
             RateLimitKey.ASSET_RETRIEVE,
             new MockHttpServletRequest(
                 GET,
-                PORTFOLIO_ASSET_BASE_URL.replace(
-                        TEST_PORTFOLIO_ID_TEMPLATE, String.valueOf(TEST_PORTFOLIO_ID))
-                    + "/"
-                    + TEST_ASSET_ID),
+                PORTFOLIO_ASSET_BY_ID_URL
+                    .replace(TEST_PORTFOLIO_ID_TEMPLATE, String.valueOf(TEST_PORTFOLIO_ID))
+                    .replace("{assetId}", String.valueOf(TEST_ASSET_ID))),
             asset("retrieve", Long.class, Long.class, Long.class)),
         Arguments.of(
             RateLimitKey.ASSET_IMPORT,

--- a/services/portfolio-service/src/test/java/com/tychewealth/testhelper/ConcurrentTestHelper.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/testhelper/ConcurrentTestHelper.java
@@ -1,11 +1,14 @@
 package com.tychewealth.testhelper;
 
+import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BASE_URL;
+import static com.tychewealth.constants.ApiConstants.PORTFOLIO_ASSET_BATCH_URL;
 import static com.tychewealth.constants.AuthConstants.AUTHORIZATION_HEADER;
 import static com.tychewealth.constants.TestConstants.TEST_FILE_PART_NAME;
 import static com.tychewealth.testhelper.AuthTestHelper.createAuthorizationHeader;
 import static com.tychewealth.testhelper.PortfolioTestHelper.createRequest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -92,6 +96,36 @@ public final class ConcurrentTestHelper {
             .perform(
                 multipart(endpoint)
                     .file(file)
+                    .header(AUTHORIZATION_HEADER, createAuthorizationHeader(userId)))
+            .andReturn();
+
+    return new IntegrationResponse(
+        result.getResponse().getStatus(), result.getResponse().getContentAsString());
+  }
+
+  public static IntegrationResponse executeAssetCreate(
+      MockMvc mockMvc, long userId, long portfolioId, String requestBody) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post(PORTFOLIO_ASSET_BASE_URL, portfolioId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .header(AUTHORIZATION_HEADER, createAuthorizationHeader(userId)))
+            .andReturn();
+
+    return new IntegrationResponse(
+        result.getResponse().getStatus(), result.getResponse().getContentAsString());
+  }
+
+  public static IntegrationResponse executeAssetBatchCreate(
+      MockMvc mockMvc, long userId, long portfolioId, String requestBody) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                post(PORTFOLIO_ASSET_BATCH_URL, portfolioId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
                     .header(AUTHORIZATION_HEADER, createAuthorizationHeader(userId)))
             .andReturn();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch asset creation capability to efficiently create multiple portfolio assets in a single request.
  * Extended asset name field to support up to 200 characters (previously 60).

* **Chores**
  * Updated database schema to accommodate longer asset names.
  * Implemented rate limiting for batch asset operations (10 requests per minute).

Closes #93 

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ismaelperezdev/Tyche-Wealth/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->