### PR TITLE
[TYCHE-65] save on redis active users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ services/user-service/application-local.properties
 
 # IDEs and editors
 .idea/
+.ai/
 *.iml
 .vscode/
 .classpath

--- a/services/user-service/src/main/java/com/tychewealth/TycheWealthUserServiceApplication.java
+++ b/services/user-service/src/main/java/com/tychewealth/TycheWealthUserServiceApplication.java
@@ -3,8 +3,10 @@ package com.tychewealth;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = UserDetailsServiceAutoConfiguration.class)
+@EnableScheduling
 public class TycheWealthUserServiceApplication {
 
   public static void main(String[] args) {

--- a/services/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/services/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -23,6 +23,7 @@ public final class LogConstants {
   public static final String ACCESS_TOKEN_ACTION = "[access-token]";
   public static final String ERROR_HANDLER_ACTION = "[error-handler]";
   public static final String SEND_ACTION = "[send]";
+  public static final String ACTIVE_USER_SNAPSHOT_ACTION = "[active-user-snapshot]";
 
   public static final String REQUEST_START = BASE_LOG + " Request started";
   public static final String REQUEST_SUCCESS = BASE_LOG + " Request succeeded";
@@ -46,6 +47,9 @@ public final class LogConstants {
   public static final String RESEND_DELIVERY_FAILED_MESSAGE = "resend delivery failed";
   public static final String EMAIL_DAILY_QUOTA_SKIPPED_MESSAGE =
       "daily email quota exceeded; skipping send";
+  public static final String ACTIVE_USER_SNAPSHOT_SUCCESS_CONTEXT = " activeUsers={} durationMs={}";
+  public static final String ACTIVE_USER_SNAPSHOT_FAILURE_MESSAGE =
+      "active user snapshot refresh failed";
 
   private LogConstants() {}
 }

--- a/services/user-service/src/main/java/com/tychewealth/constants/RedisConstants.java
+++ b/services/user-service/src/main/java/com/tychewealth/constants/RedisConstants.java
@@ -6,6 +6,9 @@ public final class RedisConstants {
   public static final String EMAIL_DAILY_LIMIT_CLIENT_KEY = "global";
   public static final String AUTH_LOGIN_DEVICE_EMAIL_COOLDOWN_NAMESPACE =
       "cooldown:auth:login-device-email";
+  public static final String ACTIVE_USERS_KEY = "users:active";
+  public static final String ACTIVE_USERS_LAST_REFRESH_KEY = "users:active:last-refresh";
+  public static final String ACTIVE_USERS_TEMP_KEY_PREFIX = "users:active:tmp:";
 
   private RedisConstants() {}
 }

--- a/services/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
+++ b/services/user-service/src/main/java/com/tychewealth/repository/RefreshTokenRepository.java
@@ -2,6 +2,7 @@ package com.tychewealth.repository;
 
 import com.tychewealth.entity.RefreshTokenEntity;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,6 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
+
+  @Query(
+      """
+      select distinct rt.user.id
+        from RefreshTokenEntity rt
+       where rt.revoked = false
+         and rt.expiresAt > :currentTime
+      """)
+  List<Long> findDistinctUserIdsWithActiveTokens(@Param("currentTime") Instant currentTime);
 
   @Query("select rt from RefreshTokenEntity rt where rt.token = :token")
   Optional<RefreshTokenEntity> findByToken(@Param("token") String token);

--- a/services/user-service/src/main/java/com/tychewealth/scheduler/ActiveUserSnapshotScheduler.java
+++ b/services/user-service/src/main/java/com/tychewealth/scheduler/ActiveUserSnapshotScheduler.java
@@ -1,0 +1,59 @@
+package com.tychewealth.scheduler;
+
+import static com.tychewealth.constants.LogConstants.ACTIVE_USER_SNAPSHOT_ACTION;
+import static com.tychewealth.constants.LogConstants.ACTIVE_USER_SNAPSHOT_FAILURE_MESSAGE;
+import static com.tychewealth.constants.LogConstants.ACTIVE_USER_SNAPSHOT_SUCCESS_CONTEXT;
+import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
+import static com.tychewealth.constants.LogConstants.REQUEST_START;
+import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
+import static com.tychewealth.constants.LogConstants.SYSTEM;
+
+import com.tychewealth.service.activeuser.ActiveUserSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    value = "app.active-users.snapshot.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class ActiveUserSnapshotScheduler {
+
+  private final ActiveUserSnapshotService activeUserSnapshotService;
+
+  @Scheduled(
+      fixedDelayString = "${app.active-users.snapshot.fixed-delay:5m}",
+      initialDelayString = "${app.active-users.snapshot.initial-delay:0s}")
+  public void refreshActiveUsersSnapshot() {
+    long start = System.currentTimeMillis();
+    log.info(REQUEST_START, SYSTEM, ACTIVE_USER_SNAPSHOT_ACTION);
+
+    try {
+      int activeUsers = activeUserSnapshotService.refreshSnapshot().size();
+      log.info(
+          REQUEST_SUCCESS + ACTIVE_USER_SNAPSHOT_SUCCESS_CONTEXT,
+          SYSTEM,
+          ACTIVE_USER_SNAPSHOT_ACTION,
+          activeUsers,
+          System.currentTimeMillis() - start);
+      log.debug(
+          REQUEST_SUCCESS + ACTIVE_USER_SNAPSHOT_SUCCESS_CONTEXT,
+          SYSTEM,
+          ACTIVE_USER_SNAPSHOT_ACTION,
+          activeUsers,
+          System.currentTimeMillis() - start);
+    } catch (RuntimeException error) {
+      log.error(
+          REQUEST_CONFLICT,
+          SYSTEM,
+          ACTIVE_USER_SNAPSHOT_ACTION,
+          ACTIVE_USER_SNAPSHOT_FAILURE_MESSAGE,
+          error);
+    }
+  }
+}

--- a/services/user-service/src/main/java/com/tychewealth/service/activeuser/ActiveUserSnapshotService.java
+++ b/services/user-service/src/main/java/com/tychewealth/service/activeuser/ActiveUserSnapshotService.java
@@ -1,0 +1,26 @@
+package com.tychewealth.service.activeuser;
+
+import com.tychewealth.repository.RefreshTokenRepository;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActiveUserSnapshotService {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final ActiveUserStore activeUserStore;
+
+  public Set<Long> refreshSnapshot() {
+    Instant refreshedAt = Instant.now();
+    Set<Long> userIds =
+        new LinkedHashSet<>(
+            refreshTokenRepository.findDistinctUserIdsWithActiveTokens(refreshedAt));
+    activeUserStore.replaceAll(userIds);
+    activeUserStore.updateLastRefresh(refreshedAt);
+    return Set.copyOf(userIds);
+  }
+}

--- a/services/user-service/src/main/java/com/tychewealth/service/activeuser/ActiveUserStore.java
+++ b/services/user-service/src/main/java/com/tychewealth/service/activeuser/ActiveUserStore.java
@@ -1,0 +1,16 @@
+package com.tychewealth.service.activeuser;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+
+public interface ActiveUserStore {
+
+  void replaceAll(Set<Long> userIds);
+
+  Set<Long> findAll();
+
+  void updateLastRefresh(Instant refreshedAt);
+
+  Optional<Instant> findLastRefresh();
+}

--- a/services/user-service/src/main/java/com/tychewealth/service/activeuser/RedisActiveUserStore.java
+++ b/services/user-service/src/main/java/com/tychewealth/service/activeuser/RedisActiveUserStore.java
@@ -1,0 +1,74 @@
+package com.tychewealth.service.activeuser;
+
+import static com.tychewealth.constants.RedisConstants.ACTIVE_USERS_KEY;
+import static com.tychewealth.constants.RedisConstants.ACTIVE_USERS_LAST_REFRESH_KEY;
+import static com.tychewealth.constants.RedisConstants.ACTIVE_USERS_TEMP_KEY_PREFIX;
+
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisActiveUserStore implements ActiveUserStore {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  @Override
+  public void replaceAll(Set<Long> userIds) {
+    if (userIds == null || userIds.isEmpty()) {
+      redisTemplate.delete(ACTIVE_USERS_KEY);
+      return;
+    }
+
+    String tempKey = ACTIVE_USERS_TEMP_KEY_PREFIX + UUID.randomUUID();
+    try {
+      redisTemplate
+          .opsForSet()
+          .add(tempKey, userIds.stream().map(String::valueOf).toArray(String[]::new));
+      redisTemplate.rename(tempKey, ACTIVE_USERS_KEY);
+    } catch (RuntimeException ex) {
+      redisTemplate.delete(tempKey);
+      throw ex;
+    }
+  }
+
+  @Override
+  public Set<Long> findAll() {
+    Set<String> members = redisTemplate.opsForSet().members(ACTIVE_USERS_KEY);
+    if (members == null || members.isEmpty()) {
+      return Set.of();
+    }
+
+    Set<Long> userIds = new LinkedHashSet<>(members.size());
+    for (String member : members) {
+      userIds.add(Long.valueOf(member));
+    }
+    return Set.copyOf(userIds);
+  }
+
+  @Override
+  public void updateLastRefresh(Instant refreshedAt) {
+    if (refreshedAt == null) {
+      redisTemplate.delete(ACTIVE_USERS_LAST_REFRESH_KEY);
+      return;
+    }
+
+    redisTemplate.opsForValue().set(ACTIVE_USERS_LAST_REFRESH_KEY, refreshedAt.toString());
+  }
+
+  @Override
+  public Optional<Instant> findLastRefresh() {
+    String value = redisTemplate.opsForValue().get(ACTIVE_USERS_LAST_REFRESH_KEY);
+    if (value == null || value.isBlank()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(Instant.parse(value));
+  }
+}

--- a/services/user-service/src/main/resources/application.properties
+++ b/services/user-service/src/main/resources/application.properties
@@ -26,7 +26,7 @@ app.auth.jwt.access-token-ttl-seconds=${JWT_ACCESS_TOKEN_TTL_SECONDS:900}
 app.auth.jwt.verify-email-token-ttl-seconds=${JWT_VERIFY_EMAIL_TOKEN_TTL_SECONDS:86400}
 app.auth.jwt.verify-login-device-token-ttl-seconds=${JWT_VERIFY_LOGIN_DEVICE_TOKEN_TTL_SECONDS:86400}
 app.auth.jwt.forgot-password-token-ttl-seconds=${JWT_FORGOT_PASSWORD_TOKEN_TTL_SECONDS:86400}
-app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:1209600}
+app.auth.jwt.refresh-token-ttl-seconds=${JWT_REFRESH_TOKEN_TTL_SECONDS:86400}
 app.auth.jwt.refresh-token-pepper=${JWT_REFRESH_TOKEN_PEPPER}
 app.auth.verify-registration-url=${VERIFY_REGISTRATION_URL}
 app.auth.verify-login-device-url=${VERIFY_LOGIN_DEVICE_URL}
@@ -43,6 +43,11 @@ app.auth.login-rate-limit.window-seconds=${AUTH_LOGIN_RATE_LIMIT_WINDOW_SECONDS:
 # Refresh endpoint protections aligned with app.auth.jwt.refresh-token-ttl-seconds / JWT_REFRESH_TOKEN_TTL_SECONDS
 app.auth.refresh-rate-limit.max-requests=${AUTH_REFRESH_RATE_LIMIT_MAX_REQUESTS:60}
 app.auth.refresh-rate-limit.window-seconds=${AUTH_REFRESH_RATE_LIMIT_WINDOW_SECONDS:60}
+
+# Active user snapshot
+app.active-users.snapshot.enabled=${ACTIVE_USERS_SNAPSHOT_ENABLED:true}
+app.active-users.snapshot.fixed-delay=${ACTIVE_USERS_SNAPSHOT_FIXED_DELAY:5m}
+app.active-users.snapshot.initial-delay=${ACTIVE_USERS_SNAPSHOT_INITIAL_DELAY:0s}
 
 # Actuator / Prometheus
 management.endpoints.web.exposure.include=health,info,prometheus

--- a/services/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
+++ b/services/user-service/src/test/java/com/tychewealth/repository/RefreshTokenRepositoryTest.java
@@ -2,10 +2,12 @@ package com.tychewealth.repository;
 
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_LAURA;
 import static com.tychewealth.constants.TestConstants.TEST_EMAIL_VALID;
+import static com.tychewealth.constants.TestConstants.TEST_MISSING_EMAIL;
 import static com.tychewealth.constants.TestConstants.TEST_OCCUPIED_USERNAME;
 import static com.tychewealth.constants.TestConstants.TEST_OTHER_EMAIL;
 import static com.tychewealth.constants.TestConstants.TEST_PASSWORD_VALID;
 import static com.tychewealth.constants.TestConstants.TEST_REFRESH_TOKEN_PEPPER;
+import static com.tychewealth.constants.TestConstants.TEST_UPDATE_USERNAME_REQUEST;
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_LAURA;
 import static com.tychewealth.constants.TestConstants.TEST_USERNAME_VALID;
 import static com.tychewealth.testdata.EntityBuilder.buildRefreshToken;
@@ -19,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.tychewealth.entity.RefreshTokenEntity;
 import com.tychewealth.entity.UserEntity;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -166,5 +170,35 @@ class RefreshTokenRepositoryTest {
             .findByToken(hmacSha256Hex(REVOKED_REFRESH_TOKEN, TEST_REFRESH_TOKEN_PEPPER))
             .orElseThrow()
             .isRevoked());
+  }
+
+  @Test
+  void findDistinctUserIdsWithActiveTokensReturnsOnlyUsersWithNonRevokedNonExpiredTokens() {
+    UserEntity activeUser =
+        userRepository.save(buildUser(TEST_EMAIL_LAURA, TEST_USERNAME_LAURA, TEST_PASSWORD_VALID));
+    UserEntity secondActiveUser =
+        userRepository.save(
+            buildUser(TEST_OTHER_EMAIL, TEST_OCCUPIED_USERNAME, TEST_PASSWORD_VALID));
+    UserEntity expiredOnlyUser =
+        userRepository.save(
+            buildUser(TEST_MISSING_EMAIL, TEST_UPDATE_USERNAME_REQUEST, TEST_PASSWORD_VALID));
+    UserEntity revokedOnlyUser =
+        userRepository.save(buildUser(TEST_EMAIL_VALID, TEST_USERNAME_VALID, TEST_PASSWORD_VALID));
+    Instant now = Instant.now();
+
+    refreshTokenRepository.save(
+        buildRefreshToken("active-token-1", activeUser, now.plusSeconds(3600), false));
+    refreshTokenRepository.save(
+        buildRefreshToken("active-token-2", activeUser, now.plusSeconds(7200), false));
+    refreshTokenRepository.save(
+        buildRefreshToken("second-active-token", secondActiveUser, now.plusSeconds(3600), false));
+    refreshTokenRepository.save(
+        buildRefreshToken("expired-only-token", expiredOnlyUser, now.minusSeconds(5), false));
+    refreshTokenRepository.save(
+        buildRefreshToken("revoked-only-token", revokedOnlyUser, now.plusSeconds(3600), true));
+
+    List<Long> activeUserIds = refreshTokenRepository.findDistinctUserIdsWithActiveTokens(now);
+
+    assertEquals(Set.of(activeUser.getId(), secondActiveUser.getId()), Set.copyOf(activeUserIds));
   }
 }

--- a/services/user-service/src/test/java/com/tychewealth/scheduler/ActiveUserSnapshotSchedulerTest.java
+++ b/services/user-service/src/test/java/com/tychewealth/scheduler/ActiveUserSnapshotSchedulerTest.java
@@ -1,0 +1,46 @@
+package com.tychewealth.scheduler;
+
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.service.activeuser.ActiveUserSnapshotService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ActiveUserSnapshotSchedulerTest {
+
+  @Mock private ActiveUserSnapshotService activeUserSnapshotService;
+
+  private ActiveUserSnapshotScheduler activeUserSnapshotScheduler;
+
+  @BeforeEach
+  void setUp() {
+    activeUserSnapshotScheduler = new ActiveUserSnapshotScheduler(activeUserSnapshotService);
+  }
+
+  @Test
+  void refreshActiveUsersSnapshotDelegatesToSnapshotService() {
+    when(activeUserSnapshotService.refreshSnapshot()).thenReturn(Set.of(TEST_USER_ID));
+
+    activeUserSnapshotScheduler.refreshActiveUsersSnapshot();
+
+    verify(activeUserSnapshotService).refreshSnapshot();
+  }
+
+  @Test
+  void refreshActiveUsersSnapshotSwallowsRuntimeExceptionsFromSnapshotService() {
+    when(activeUserSnapshotService.refreshSnapshot())
+        .thenThrow(new IllegalStateException("snapshot failed"));
+
+    assertDoesNotThrow(() -> activeUserSnapshotScheduler.refreshActiveUsersSnapshot());
+
+    verify(activeUserSnapshotService).refreshSnapshot();
+  }
+}

--- a/services/user-service/src/test/java/com/tychewealth/service/activeuser/ActiveUserSnapshotServiceTest.java
+++ b/services/user-service/src/test/java/com/tychewealth/service/activeuser/ActiveUserSnapshotServiceTest.java
@@ -1,0 +1,53 @@
+package com.tychewealth.service.activeuser;
+
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.repository.RefreshTokenRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ActiveUserSnapshotServiceTest {
+
+  private static final Long TEST_SECOND_USER_ID = 7L;
+
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private ActiveUserStore activeUserStore;
+
+  private ActiveUserSnapshotService activeUserSnapshotService;
+
+  @BeforeEach
+  void setUp() {
+    activeUserSnapshotService =
+        new ActiveUserSnapshotService(refreshTokenRepository, activeUserStore);
+  }
+
+  @Test
+  void refreshSnapshotRebuildsActiveUsersUpdatesRefreshTimestampAndReturnsDistinctIds() {
+    when(refreshTokenRepository.findDistinctUserIdsWithActiveTokens(any(Instant.class)))
+        .thenReturn(List.of(TEST_USER_ID, TEST_SECOND_USER_ID, TEST_USER_ID));
+    ArgumentCaptor<Set<Long>> userIdsCaptor = ArgumentCaptor.forClass(Set.class);
+    ArgumentCaptor<Instant> refreshedAtCaptor = ArgumentCaptor.forClass(Instant.class);
+
+    Set<Long> result = activeUserSnapshotService.refreshSnapshot();
+
+    verify(refreshTokenRepository).findDistinctUserIdsWithActiveTokens(any(Instant.class));
+    verify(activeUserStore).replaceAll(userIdsCaptor.capture());
+    verify(activeUserStore).updateLastRefresh(refreshedAtCaptor.capture());
+    assertEquals(Set.of(TEST_USER_ID, TEST_SECOND_USER_ID), result);
+    assertEquals(Set.of(TEST_USER_ID, TEST_SECOND_USER_ID), userIdsCaptor.getValue());
+    assertNotNull(refreshedAtCaptor.getValue());
+  }
+}

--- a/services/user-service/src/test/java/com/tychewealth/service/activeuser/RedisActiveUserStoreTest.java
+++ b/services/user-service/src/test/java/com/tychewealth/service/activeuser/RedisActiveUserStoreTest.java
@@ -1,0 +1,145 @@
+package com.tychewealth.service.activeuser;
+
+import static com.tychewealth.constants.RedisConstants.ACTIVE_USERS_KEY;
+import static com.tychewealth.constants.RedisConstants.ACTIVE_USERS_LAST_REFRESH_KEY;
+import static com.tychewealth.constants.RedisConstants.ACTIVE_USERS_TEMP_KEY_PREFIX;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisActiveUserStoreTest {
+
+  private static final Long TEST_SECOND_USER_ID = 7L;
+
+  @Mock private RedisTemplate<String, String> redisTemplate;
+
+  private RedisActiveUserStore redisActiveUserStore;
+
+  @BeforeEach
+  void setUp() {
+    redisActiveUserStore = new RedisActiveUserStore(redisTemplate);
+  }
+
+  @Test
+  void replaceAllDeletesActiveUsersKeyWhenSetIsEmpty() {
+    redisActiveUserStore.replaceAll(Set.of());
+
+    verify(redisTemplate).delete(ACTIVE_USERS_KEY);
+    verify(redisTemplate, never()).rename(any(), any());
+  }
+
+  @Test
+  void replaceAllStoresUsersInTempSetAndRenamesItToActiveUsersKey() {
+    SetOperations<String, String> setOperations = mock(SetOperations.class);
+    when(redisTemplate.opsForSet()).thenReturn(setOperations);
+    ArgumentCaptor<String> tempKeyCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String[]> membersCaptor = ArgumentCaptor.forClass(String[].class);
+
+    redisActiveUserStore.replaceAll(Set.of(TEST_USER_ID, TEST_SECOND_USER_ID));
+
+    verify(setOperations).add(tempKeyCaptor.capture(), membersCaptor.capture());
+    String tempKey = tempKeyCaptor.getValue();
+    assertTrue(tempKey.startsWith(ACTIVE_USERS_TEMP_KEY_PREFIX));
+    assertEquals(
+        Set.of(String.valueOf(TEST_USER_ID), String.valueOf(TEST_SECOND_USER_ID)),
+        Set.copyOf(Arrays.asList(membersCaptor.getValue())));
+    verify(redisTemplate).rename(tempKey, ACTIVE_USERS_KEY);
+  }
+
+  @Test
+  void findAllReturnsEmptySetWhenRedisHasNoActiveUsers() {
+    SetOperations<String, String> setOperations = mock(SetOperations.class);
+    when(redisTemplate.opsForSet()).thenReturn(setOperations);
+    when(setOperations.members(ACTIVE_USERS_KEY)).thenReturn(Set.of());
+
+    Set<Long> result = redisActiveUserStore.findAll();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void findAllReturnsParsedActiveUserIds() {
+    SetOperations<String, String> setOperations = mock(SetOperations.class);
+    when(redisTemplate.opsForSet()).thenReturn(setOperations);
+    when(setOperations.members(ACTIVE_USERS_KEY))
+        .thenReturn(Set.of(String.valueOf(TEST_USER_ID), String.valueOf(TEST_SECOND_USER_ID)));
+
+    Set<Long> result = redisActiveUserStore.findAll();
+
+    assertEquals(Set.of(TEST_USER_ID, TEST_SECOND_USER_ID), result);
+  }
+
+  @Test
+  void updateLastRefreshDeletesRefreshKeyWhenTimestampIsNull() {
+    redisActiveUserStore.updateLastRefresh(null);
+
+    verify(redisTemplate).delete(ACTIVE_USERS_LAST_REFRESH_KEY);
+  }
+
+  @Test
+  void updateLastRefreshStoresIsoTimestamp() {
+    ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    Instant refreshedAt = Instant.parse("2026-06-18T20:00:00Z");
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    redisActiveUserStore.updateLastRefresh(refreshedAt);
+
+    verify(valueOperations).set(ACTIVE_USERS_LAST_REFRESH_KEY, refreshedAt.toString());
+  }
+
+  @Test
+  void findLastRefreshReturnsEmptyWhenKeyIsMissing() {
+    ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.get(ACTIVE_USERS_LAST_REFRESH_KEY)).thenReturn(null);
+
+    Optional<Instant> result = redisActiveUserStore.findLastRefresh();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void findLastRefreshReturnsParsedTimestamp() {
+    ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    Instant refreshedAt = Instant.parse("2026-06-18T20:00:00Z");
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.get(ACTIVE_USERS_LAST_REFRESH_KEY)).thenReturn(refreshedAt.toString());
+
+    Optional<Instant> result = redisActiveUserStore.findLastRefresh();
+
+    assertTrue(result.isPresent());
+    assertEquals(refreshedAt, result.orElseThrow());
+  }
+
+  @Test
+  void findLastRefreshReturnsEmptyWhenStoredValueIsBlank() {
+    ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.get(ACTIVE_USERS_LAST_REFRESH_KEY)).thenReturn(" ");
+
+    Optional<Instant> result = redisActiveUserStore.findLastRefresh();
+
+    assertFalse(result.isPresent());
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added active user snapshot functionality that periodically captures users with active sessions, enabled by default with a configurable refresh interval (default: 5 minutes).
  * Implemented Redis-backed storage for tracking active user data.

* **Chores**
  * Enabled Spring scheduling support in the application.
  * Adjusted JWT refresh token TTL default configuration.

Closed #114 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->