### PR TITLE
[TYCHE-65] publish on kafka user activity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
     volumes:
       - kafka-data:/var/lib/kafka/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,14 @@ services:
       DB_URL_USER: ${DB_URL_USER:-jdbc:postgresql://postgres:5432/tyche_wealth_user}
       REDIS_HOST: ${REDIS_HOST:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
+      KAFKA_ENABLED: ${KAFKA_ENABLED:-true}
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
     depends_on:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      kafka:
         condition: service_healthy
     networks:
       - tyche-network
@@ -94,6 +98,57 @@ services:
     networks:
       - tyche-network
 
+  kafka:
+    image: apache/kafka:3.8.1
+    container_name: tyche-kafka
+    hostname: kafka
+    ports:
+      - "127.0.0.1:${KAFKA_PORT:-9092}:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENERS: PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list > /dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
+    networks:
+      - tyche-network
+
+  akhq:
+    image: tchiotludo/akhq:0.25.1
+    container_name: tyche-akhq
+    ports:
+      - "127.0.0.1:${AKHQ_PORT:-8085}:8080"
+    environment:
+      AKHQ_CONFIGURATION: |
+        akhq:
+          connections:
+            tyche-kafka:
+              properties:
+                bootstrap.servers: "kafka:29092"
+    depends_on:
+      kafka:
+        condition: service_healthy
+    networks:
+      - tyche-network
+
   prometheus:
     image: prom/prometheus:latest
     container_name: tyche-prometheus
@@ -137,5 +192,6 @@ networks:
 
 volumes:
   grafana-data:
+  kafka-data:
   postgres-data:
   redis-data:

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>

--- a/services/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/services/user-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -35,6 +35,8 @@ public final class LogConstants {
   public static final String LOGIN_REQUEST_FIELDS = " email={}";
   public static final String UPDATE_REQUEST_FIELDS = " username={}";
   public static final String USER_ID = " userId={}";
+  public static final String TOPIC = " topic={}";
+  public static final String ACTIVE_USERS_EVENT_SUCCESS_CONTEXT = TOPIC + " activeUsers={}";
 
   public static final String INVALID_LOGIN_CREDENTIALS_MESSAGE = "invalid login credentials";
   public static final String INVALID_PASSWORD_FORMAT_MESSAGE = "invalid password format";
@@ -50,6 +52,8 @@ public final class LogConstants {
   public static final String ACTIVE_USER_SNAPSHOT_SUCCESS_CONTEXT = " activeUsers={} durationMs={}";
   public static final String ACTIVE_USER_SNAPSHOT_FAILURE_MESSAGE =
       "active user snapshot refresh failed";
+  public static final String ACTIVE_USERS_EVENT_PUBLISH_FAILURE_MESSAGE =
+      "active users event publishing failed";
 
   private LogConstants() {}
 }

--- a/services/user-service/src/main/java/com/tychewealth/error/exception/EventPublishingException.java
+++ b/services/user-service/src/main/java/com/tychewealth/error/exception/EventPublishingException.java
@@ -1,0 +1,56 @@
+package com.tychewealth.error.exception;
+
+import com.tychewealth.error.handler.ErrorDefinition;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class EventPublishingException extends RuntimeException {
+
+  private final ErrorDefinition errorDefinition;
+  private final Map<String, String> metadata;
+  private final HttpStatus httpStatus;
+
+  public EventPublishingException(
+      ErrorDefinition errorDefinition, Map<String, String> metadata, HttpStatus httpStatus) {
+    this(resolve(errorDefinition), metadata, httpStatus);
+  }
+
+  public static EventPublishingException of(
+      ErrorDefinition errorDefinition, Map<String, String> metadata, HttpStatus httpStatus) {
+    return new EventPublishingException(errorDefinition, metadata, httpStatus);
+  }
+
+  private EventPublishingException(
+      ResolvedError resolvedError, Map<String, String> metadata, HttpStatus httpStatus) {
+    super(resolvedError.errorDefinition().getDescription());
+
+    this.errorDefinition = resolvedError.errorDefinition();
+    this.metadata = sanitizeMetadata(metadata);
+    this.httpStatus = httpStatus == null ? HttpStatus.INTERNAL_SERVER_ERROR : httpStatus;
+  }
+
+  private static ResolvedError resolve(ErrorDefinition errorDefinition) {
+    return new ResolvedError(
+        errorDefinition == null ? ErrorDefinition.GENERIC_INTERNAL_ERROR : errorDefinition);
+  }
+
+  private Map<String, String> sanitizeMetadata(Map<String, String> metadata) {
+    if (metadata == null || metadata.isEmpty()) {
+      return Map.of();
+    }
+
+    Map<String, String> sanitizedMetadata = new HashMap<>();
+    metadata.forEach(
+        (key, value) -> {
+          if (key != null && value != null) {
+            sanitizedMetadata.put(key, value);
+          }
+        });
+    return sanitizedMetadata.isEmpty() ? Map.of() : Map.copyOf(sanitizedMetadata);
+  }
+
+  private record ResolvedError(ErrorDefinition errorDefinition) {}
+}

--- a/services/user-service/src/main/java/com/tychewealth/kafka/events/ActiveUsersEvent.java
+++ b/services/user-service/src/main/java/com/tychewealth/kafka/events/ActiveUsersEvent.java
@@ -1,0 +1,6 @@
+package com.tychewealth.kafka.events;
+
+import java.time.Instant;
+import java.util.Set;
+
+public record ActiveUsersEvent(Instant occurredAt, Set<Long> userIds) {}

--- a/services/user-service/src/main/java/com/tychewealth/kafka/publishers/ActiveUsersEventPublisher.java
+++ b/services/user-service/src/main/java/com/tychewealth/kafka/publishers/ActiveUsersEventPublisher.java
@@ -11,11 +11,16 @@ import com.tychewealth.error.exception.EventPublishingException;
 import com.tychewealth.error.handler.ErrorDefinition;
 import com.tychewealth.kafka.events.ActiveUsersEvent;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -28,31 +33,43 @@ public class ActiveUsersEventPublisher {
   @Value("${app.kafka.topics.active-users}")
   private String activeUsersTopic;
 
+  @Value("${spring.kafka.producer.properties.delivery.timeout.ms:30000}")
+  private long publishTimeoutMs;
+
   public ActiveUsersEventPublisher(KafkaTemplate<String, ActiveUsersEvent> kafkaTemplate) {
     this.kafkaTemplate = kafkaTemplate;
   }
 
   public void publish(ActiveUsersEvent event) {
     try {
-      kafkaTemplate.send(activeUsersTopic, event);
+      CompletableFuture<SendResult<String, ActiveUsersEvent>> sendFuture =
+          kafkaTemplate.send(activeUsersTopic, event);
+      sendFuture.get(publishTimeoutMs, TimeUnit.MILLISECONDS);
       log.info(
           REQUEST_SUCCESS + ACTIVE_USERS_EVENT_SUCCESS_CONTEXT,
           SYSTEM,
           SEND_ACTION,
           activeUsersTopic,
           event.userIds().size());
-    } catch (RuntimeException error) {
-      log.error(
-          REQUEST_CONFLICT + com.tychewealth.constants.LogConstants.TOPIC,
-          SYSTEM,
-          SEND_ACTION,
-          ACTIVE_USERS_EVENT_PUBLISH_FAILURE_MESSAGE,
-          activeUsersTopic,
-          error);
-      throw EventPublishingException.of(
-          ErrorDefinition.GENERIC_INTERNAL_ERROR,
-          Map.of("topic", activeUsersTopic),
-          HttpStatus.INTERNAL_SERVER_ERROR);
+    } catch (InterruptedException error) {
+      Thread.currentThread().interrupt();
+      throw publishFailure(event, error);
+    } catch (ExecutionException | TimeoutException | RuntimeException error) {
+      throw publishFailure(event, error);
     }
+  }
+
+  private EventPublishingException publishFailure(ActiveUsersEvent event, Exception error) {
+    log.error(
+        REQUEST_CONFLICT + com.tychewealth.constants.LogConstants.TOPIC,
+        SYSTEM,
+        SEND_ACTION,
+        ACTIVE_USERS_EVENT_PUBLISH_FAILURE_MESSAGE,
+        activeUsersTopic,
+        error);
+    return EventPublishingException.of(
+        ErrorDefinition.GENERIC_INTERNAL_ERROR,
+        Map.of("topic", activeUsersTopic, "activeUsers", String.valueOf(event.userIds().size())),
+        HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/services/user-service/src/main/java/com/tychewealth/kafka/publishers/ActiveUsersEventPublisher.java
+++ b/services/user-service/src/main/java/com/tychewealth/kafka/publishers/ActiveUsersEventPublisher.java
@@ -1,0 +1,58 @@
+package com.tychewealth.kafka.publishers;
+
+import static com.tychewealth.constants.LogConstants.ACTIVE_USERS_EVENT_PUBLISH_FAILURE_MESSAGE;
+import static com.tychewealth.constants.LogConstants.ACTIVE_USERS_EVENT_SUCCESS_CONTEXT;
+import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
+import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
+import static com.tychewealth.constants.LogConstants.SEND_ACTION;
+import static com.tychewealth.constants.LogConstants.SYSTEM;
+
+import com.tychewealth.error.exception.EventPublishingException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.kafka.events.ActiveUsersEvent;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class ActiveUsersEventPublisher {
+
+  private final KafkaTemplate<String, ActiveUsersEvent> kafkaTemplate;
+
+  @Value("${app.kafka.topics.active-users}")
+  private String activeUsersTopic;
+
+  public ActiveUsersEventPublisher(KafkaTemplate<String, ActiveUsersEvent> kafkaTemplate) {
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  public void publish(ActiveUsersEvent event) {
+    try {
+      kafkaTemplate.send(activeUsersTopic, event);
+      log.info(
+          REQUEST_SUCCESS + ACTIVE_USERS_EVENT_SUCCESS_CONTEXT,
+          SYSTEM,
+          SEND_ACTION,
+          activeUsersTopic,
+          event.userIds().size());
+    } catch (RuntimeException error) {
+      log.error(
+          REQUEST_CONFLICT + com.tychewealth.constants.LogConstants.TOPIC,
+          SYSTEM,
+          SEND_ACTION,
+          ACTIVE_USERS_EVENT_PUBLISH_FAILURE_MESSAGE,
+          activeUsersTopic,
+          error);
+      throw EventPublishingException.of(
+          ErrorDefinition.GENERIC_INTERNAL_ERROR,
+          Map.of("topic", activeUsersTopic),
+          HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/services/user-service/src/main/java/com/tychewealth/scheduler/ActiveUserSnapshotScheduler.java
+++ b/services/user-service/src/main/java/com/tychewealth/scheduler/ActiveUserSnapshotScheduler.java
@@ -8,7 +8,11 @@ import static com.tychewealth.constants.LogConstants.REQUEST_START;
 import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
 import static com.tychewealth.constants.LogConstants.SYSTEM;
 
+import com.tychewealth.kafka.events.ActiveUsersEvent;
+import com.tychewealth.kafka.publishers.ActiveUsersEventPublisher;
 import com.tychewealth.service.activeuser.ActiveUserSnapshotService;
+import java.time.Instant;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -25,6 +29,7 @@ import org.springframework.stereotype.Component;
 public class ActiveUserSnapshotScheduler {
 
   private final ActiveUserSnapshotService activeUserSnapshotService;
+  private final ActiveUsersEventPublisher activeUsersEventPublisher;
 
   @Scheduled(
       fixedDelayString = "${app.active-users.snapshot.fixed-delay:5m}",
@@ -34,7 +39,9 @@ public class ActiveUserSnapshotScheduler {
     log.info(REQUEST_START, SYSTEM, ACTIVE_USER_SNAPSHOT_ACTION);
 
     try {
-      int activeUsers = activeUserSnapshotService.refreshSnapshot().size();
+      Set<Long> userIds = activeUserSnapshotService.refreshSnapshot();
+      activeUsersEventPublisher.publish(new ActiveUsersEvent(Instant.now(), userIds));
+      int activeUsers = userIds.size();
       log.info(
           REQUEST_SUCCESS + ACTIVE_USER_SNAPSHOT_SUCCESS_CONTEXT,
           SYSTEM,

--- a/services/user-service/src/main/java/com/tychewealth/scheduler/ActiveUserSnapshotScheduler.java
+++ b/services/user-service/src/main/java/com/tychewealth/scheduler/ActiveUserSnapshotScheduler.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Component;
     value = "app.active-users.snapshot.enabled",
     havingValue = "true",
     matchIfMissing = true)
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true", matchIfMissing = false)
 public class ActiveUserSnapshotScheduler {
 
   private final ActiveUserSnapshotService activeUserSnapshotService;

--- a/services/user-service/src/main/java/com/tychewealth/service/activeuser/RedisActiveUserStore.java
+++ b/services/user-service/src/main/java/com/tychewealth/service/activeuser/RedisActiveUserStore.java
@@ -45,7 +45,7 @@ public class RedisActiveUserStore implements ActiveUserStore {
       return Set.of();
     }
 
-    Set<Long> userIds = new LinkedHashSet<>(members.size());
+    Set<Long> userIds = LinkedHashSet.newLinkedHashSet(members.size());
     for (String member : members) {
       userIds.add(Long.valueOf(member));
     }

--- a/services/user-service/src/main/resources/application.properties
+++ b/services/user-service/src/main/resources/application.properties
@@ -74,6 +74,7 @@ spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
 spring.kafka.producer.client-id=${KAFKA_PRODUCER_CLIENT_ID:user-service}
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+spring.kafka.producer.properties.delivery.timeout.ms=${KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS:30000}
 app.kafka.topics.active-users=${KAFKA_TOPIC_ACTIVE_USERS:active-users}
 
 # Email / Resend

--- a/services/user-service/src/main/resources/application.properties
+++ b/services/user-service/src/main/resources/application.properties
@@ -68,6 +68,14 @@ spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
 spring.data.redis.timeout=${REDIS_TIMEOUT:2s}
 
+# Kafka
+kafka.enabled=${KAFKA_ENABLED:true}
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+spring.kafka.producer.client-id=${KAFKA_PRODUCER_CLIENT_ID:user-service}
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+app.kafka.topics.active-users=${KAFKA_TOPIC_ACTIVE_USERS:active-users}
+
 # Email / Resend
 app.email.daily-limit=${EMAIL_DAILY_LIMIT:80}
 app.email.resend.enabled=${EMAIL_RESEND_ENABLED:false}

--- a/services/user-service/src/test/java/com/tychewealth/kafka/publishers/ActiveUsersEventPublisherTest.java
+++ b/services/user-service/src/test/java/com/tychewealth/kafka/publishers/ActiveUsersEventPublisherTest.java
@@ -1,0 +1,65 @@
+package com.tychewealth.kafka.publishers;
+
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.error.exception.EventPublishingException;
+import com.tychewealth.kafka.events.ActiveUsersEvent;
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ActiveUsersEventPublisherTest {
+
+  @Mock private KafkaTemplate<String, ActiveUsersEvent> kafkaTemplate;
+
+  private ActiveUsersEventPublisher activeUsersEventPublisher;
+
+  @BeforeEach
+  void setUp() {
+    activeUsersEventPublisher = new ActiveUsersEventPublisher(kafkaTemplate);
+    ReflectionTestUtils.setField(activeUsersEventPublisher, "activeUsersTopic", "active-users");
+    ReflectionTestUtils.setField(activeUsersEventPublisher, "publishTimeoutMs", 1_000L);
+  }
+
+  @Test
+  void publishLogsSuccessOnlyAfterBrokerAcknowledgement() {
+    ActiveUsersEvent event = new ActiveUsersEvent(Instant.now(), Set.of(TEST_USER_ID));
+    CompletableFuture<SendResult<String, ActiveUsersEvent>> sendFuture =
+        CompletableFuture.completedFuture(null);
+    when(kafkaTemplate.send("active-users", event)).thenReturn(sendFuture);
+
+    assertDoesNotThrow(() -> activeUsersEventPublisher.publish(event));
+
+    verify(kafkaTemplate).send("active-users", event);
+  }
+
+  @Test
+  void publishWrapsDeliveryFailuresWithEventContext() {
+    ActiveUsersEvent event = new ActiveUsersEvent(Instant.now(), Set.of(TEST_USER_ID));
+    CompletableFuture<SendResult<String, ActiveUsersEvent>> sendFuture = new CompletableFuture<>();
+    sendFuture.completeExceptionally(new IllegalStateException("broker unavailable"));
+    when(kafkaTemplate.send("active-users", event)).thenReturn(sendFuture);
+
+    EventPublishingException exception =
+        assertThrows(
+            EventPublishingException.class, () -> activeUsersEventPublisher.publish(event));
+
+    assertEquals("active-users", exception.getMetadata().get("topic"));
+    assertEquals("1", exception.getMetadata().get("activeUsers"));
+    verify(kafkaTemplate).send("active-users", event);
+  }
+}

--- a/services/user-service/src/test/java/com/tychewealth/scheduler/ActiveUserSnapshotSchedulerTest.java
+++ b/services/user-service/src/test/java/com/tychewealth/scheduler/ActiveUserSnapshotSchedulerTest.java
@@ -2,14 +2,20 @@ package com.tychewealth.scheduler;
 
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.tychewealth.kafka.events.ActiveUsersEvent;
+import com.tychewealth.kafka.publishers.ActiveUsersEventPublisher;
 import com.tychewealth.service.activeuser.ActiveUserSnapshotService;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -17,21 +23,29 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ActiveUserSnapshotSchedulerTest {
 
   @Mock private ActiveUserSnapshotService activeUserSnapshotService;
+  @Mock private ActiveUsersEventPublisher activeUsersEventPublisher;
 
   private ActiveUserSnapshotScheduler activeUserSnapshotScheduler;
 
   @BeforeEach
   void setUp() {
-    activeUserSnapshotScheduler = new ActiveUserSnapshotScheduler(activeUserSnapshotService);
+    activeUserSnapshotScheduler =
+        new ActiveUserSnapshotScheduler(activeUserSnapshotService, activeUsersEventPublisher);
   }
 
   @Test
-  void refreshActiveUsersSnapshotDelegatesToSnapshotService() {
-    when(activeUserSnapshotService.refreshSnapshot()).thenReturn(Set.of(TEST_USER_ID));
+  void refreshActiveUsersSnapshotDelegatesToSnapshotServiceAndPublishesEvent() {
+    Set<Long> userIds = Set.of(TEST_USER_ID);
+    when(activeUserSnapshotService.refreshSnapshot()).thenReturn(userIds);
 
     activeUserSnapshotScheduler.refreshActiveUsersSnapshot();
 
+    ArgumentCaptor<ActiveUsersEvent> eventCaptor = ArgumentCaptor.forClass(ActiveUsersEvent.class);
+
     verify(activeUserSnapshotService).refreshSnapshot();
+    verify(activeUsersEventPublisher).publish(eventCaptor.capture());
+    assertEquals(userIds, eventCaptor.getValue().userIds());
+    assertNotNull(eventCaptor.getValue().occurredAt());
   }
 
   @Test
@@ -42,5 +56,6 @@ class ActiveUserSnapshotSchedulerTest {
     assertDoesNotThrow(() -> activeUserSnapshotScheduler.refreshActiveUsersSnapshot());
 
     verify(activeUserSnapshotService).refreshSnapshot();
+    verify(activeUsersEventPublisher, never()).publish(org.mockito.ArgumentMatchers.any());
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kafka support for publishing active-user snapshot events.
  * Active-user refreshes now include the current user IDs and timestamp.
  * Added Kafka monitoring through the AKHQ interface.
* **Bug Fixes**
  * Added error handling for failed event publishing, including appropriate server-error responses.
* **Tests**
  * Updated scheduler tests to verify event publishing and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->