### PR TITLE
[TYCHE-67] publish active symbols update

### DIFF
--- a/services/portfolio-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -17,6 +17,7 @@ public final class LogConstants {
   public static final String IMPORT_ASSETS_ACTION = "[import-assets]";
   public static final String ERROR_HANDLER_ACTION = "[error-handler]";
   public static final String ACCESS_TOKEN_ACTION = "[access-token]";
+  public static final String SEND_ACTION = "[send]";
   public static final String RATE_LIMIT_ACTION = "[rate-limit]";
 
   public static final String REQUEST_START = BASE_LOG + " Request started";

--- a/services/portfolio-service/src/main/java/com/tychewealth/constants/RedisConstants.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/constants/RedisConstants.java
@@ -2,7 +2,8 @@ package com.tychewealth.constants;
 
 public final class RedisConstants {
 
-  public static final String ASSET_IMPORT_AI_CACHE_KEY_PREFIX = "asset-import:ai:";
+  public static final String ACTIVE_SYMBOLS_KEY = "active-symbols";
+  public static final String ACTIVE_SYMBOLS_TEMP_KEY_PREFIX = "active-symbols:temp:";
   public static final String ASSET_IMPORT_PAYLOAD_CACHE_KEY_PREFIX = "asset-import:payload:";
   public static final String ASSET_IMPORT_INFLIGHT_KEY_PREFIX = "asset-import:payload:inflight:";
   public static final String ASSET_IMPORT_RESULT_KEY_PREFIX = "asset-import:result:";

--- a/services/portfolio-service/src/main/java/com/tychewealth/error/exception/EventPublishingException.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/error/exception/EventPublishingException.java
@@ -1,0 +1,56 @@
+package com.tychewealth.error.exception;
+
+import com.tychewealth.error.handler.ErrorDefinition;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class EventPublishingException extends RuntimeException {
+
+  private final ErrorDefinition errorDefinition;
+  private final Map<String, String> metadata;
+  private final HttpStatus httpStatus;
+
+  public EventPublishingException(
+      ErrorDefinition errorDefinition, Map<String, String> metadata, HttpStatus httpStatus) {
+    this(resolve(errorDefinition), metadata, httpStatus);
+  }
+
+  public static EventPublishingException of(
+      ErrorDefinition errorDefinition, Map<String, String> metadata, HttpStatus httpStatus) {
+    return new EventPublishingException(errorDefinition, metadata, httpStatus);
+  }
+
+  private EventPublishingException(
+      ResolvedError resolvedError, Map<String, String> metadata, HttpStatus httpStatus) {
+    super(resolvedError.errorDefinition().getDescription());
+
+    this.errorDefinition = resolvedError.errorDefinition();
+    this.metadata = sanitizeMetadata(metadata);
+    this.httpStatus = httpStatus == null ? HttpStatus.INTERNAL_SERVER_ERROR : httpStatus;
+  }
+
+  private static ResolvedError resolve(ErrorDefinition errorDefinition) {
+    return new ResolvedError(
+        errorDefinition == null ? ErrorDefinition.GENERIC_INTERNAL_ERROR : errorDefinition);
+  }
+
+  private Map<String, String> sanitizeMetadata(Map<String, String> metadata) {
+    if (metadata == null || metadata.isEmpty()) {
+      return Map.of();
+    }
+
+    Map<String, String> sanitizedMetadata = new HashMap<>();
+    metadata.forEach(
+        (key, value) -> {
+          if (key != null && value != null) {
+            sanitizedMetadata.put(key, value);
+          }
+        });
+    return sanitizedMetadata.isEmpty() ? Map.of() : Map.copyOf(sanitizedMetadata);
+  }
+
+  private record ResolvedError(ErrorDefinition errorDefinition) {}
+}

--- a/services/portfolio-service/src/main/java/com/tychewealth/kafka/consumers/ActiveUsersEventConsumer.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/kafka/consumers/ActiveUsersEventConsumer.java
@@ -5,6 +5,9 @@ import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
 import static com.tychewealth.constants.LogConstants.SYSTEM;
 
 import com.tychewealth.kafka.events.ActiveUsersEvent;
+import com.tychewealth.service.activesymbol.ActiveSymbolService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -14,10 +17,13 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 @ConditionalOnProperty(name = "kafka.enabled", havingValue = "true", matchIfMissing = false)
 public class ActiveUsersEventConsumer {
 
   private static final String ACTIVE_USERS_EVENT_ACTION = "[active-users-event]";
+
+  private final ActiveSymbolService activeSymbolService;
 
   @KafkaListener(
       topics = "${app.kafka.topics.active-users}",
@@ -32,5 +38,6 @@ public class ActiveUsersEventConsumer {
         ACTIVE_USERS_EVENT_ACTION,
         receivedTopic,
         activeUsers);
+    activeSymbolService.synchronizeSymbols(event == null ? Set.of() : event.userIds());
   }
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/kafka/events/ActiveSymbolChanges.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/kafka/events/ActiveSymbolChanges.java
@@ -1,0 +1,5 @@
+package com.tychewealth.kafka.events;
+
+import java.util.Set;
+
+public record ActiveSymbolChanges(Set<String> addedSymbols, Set<String> removedSymbols) {}

--- a/services/portfolio-service/src/main/java/com/tychewealth/kafka/publishers/ActiveSymbolChangesEventPublisher.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/kafka/publishers/ActiveSymbolChangesEventPublisher.java
@@ -1,0 +1,78 @@
+package com.tychewealth.kafka.publishers;
+
+import static com.tychewealth.constants.LogConstants.REQUEST_CONFLICT;
+import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
+import static com.tychewealth.constants.LogConstants.SEND_ACTION;
+import static com.tychewealth.constants.LogConstants.SYSTEM;
+
+import com.tychewealth.error.exception.EventPublishingException;
+import com.tychewealth.error.handler.ErrorDefinition;
+import com.tychewealth.kafka.events.ActiveSymbolChanges;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class ActiveSymbolChangesEventPublisher {
+
+  private final KafkaTemplate<String, ActiveSymbolChanges> kafkaTemplate;
+
+  @Value("${app.kafka.topics.active-symbol-changes}")
+  private String activeSymbolChangesTopic;
+
+  @Value("${spring.kafka.producer.properties.delivery.timeout.ms:30000}")
+  private long publishTimeoutMs;
+
+  public ActiveSymbolChangesEventPublisher(
+      KafkaTemplate<String, ActiveSymbolChanges> kafkaTemplate) {
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  public void publish(ActiveSymbolChanges event) {
+    try {
+      CompletableFuture<SendResult<String, ActiveSymbolChanges>> sendFuture =
+          kafkaTemplate.send(activeSymbolChangesTopic, event);
+      sendFuture.get(publishTimeoutMs, TimeUnit.MILLISECONDS);
+      log.info(
+          REQUEST_SUCCESS + " topic={} addedSymbols={} removedSymbols={}",
+          SYSTEM,
+          SEND_ACTION,
+          activeSymbolChangesTopic,
+          event.addedSymbols().size(),
+          event.removedSymbols().size());
+    } catch (InterruptedException error) {
+      Thread.currentThread().interrupt();
+      throw publishFailure(event, error);
+    } catch (ExecutionException | TimeoutException | RuntimeException error) {
+      throw publishFailure(event, error);
+    }
+  }
+
+  private EventPublishingException publishFailure(ActiveSymbolChanges event, Exception error) {
+    log.error(
+        REQUEST_CONFLICT + " topic={}",
+        SYSTEM,
+        SEND_ACTION,
+        "active symbol changes event publish failed",
+        activeSymbolChangesTopic,
+        error);
+    return EventPublishingException.of(
+        ErrorDefinition.GENERIC_INTERNAL_ERROR,
+        Map.of(
+            "topic", activeSymbolChangesTopic,
+            "addedSymbols", String.valueOf(event.addedSymbols().size()),
+            "removedSymbols", String.valueOf(event.removedSymbols().size())),
+        HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/services/portfolio-service/src/main/java/com/tychewealth/repository/AssetRepository.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/repository/AssetRepository.java
@@ -3,11 +3,14 @@ package com.tychewealth.repository;
 import com.tychewealth.entity.AssetEntity;
 import com.tychewealth.enums.AssetTypeEnum;
 import com.tychewealth.enums.CurrencyCodeEnum;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -30,4 +33,15 @@ public interface AssetRepository extends JpaRepository<AssetEntity, Long> {
   List<AssetEntity> findByAssetType(AssetTypeEnum assetType);
 
   boolean existsByPortfolioIdAndSymbol(Long portfolioId, String symbol);
+
+  @Query(
+      """
+      select distinct a.symbol
+      from AssetEntity a
+      join a.portfolio p
+      where p.userId in :userIds
+        and a.symbol is not null
+        and a.symbol <> ''
+      """)
+  List<String> findDistinctSymbolsByUserIds(@Param("userIds") Collection<Long> userIds);
 }

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/ActiveSymbolService.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/ActiveSymbolService.java
@@ -7,6 +7,7 @@ import static com.tychewealth.constants.LogConstants.SYSTEM;
 import com.tychewealth.kafka.events.ActiveSymbolChanges;
 import com.tychewealth.kafka.publishers.ActiveSymbolChangesEventPublisher;
 import com.tychewealth.repository.AssetRepository;
+import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -14,11 +15,13 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true", matchIfMissing = false)
 public class ActiveSymbolService {
 
   private static final String ACTIVE_SYMBOL_ACTION = "[active-symbol-sync]";
@@ -30,6 +33,14 @@ public class ActiveSymbolService {
   @Value("${app.active-symbol.user-id-batch-size:600}")
   private int userIdBatchSize;
 
+  @PostConstruct
+  void validateUserIdBatchSize() {
+    if (userIdBatchSize <= 0) {
+      throw new IllegalStateException(
+          "app.active-symbol.user-id-batch-size must be greater than zero");
+    }
+  }
+
   public void synchronizeSymbols(Set<Long> userIds) {
     log.info(REQUEST_START, SYSTEM, ACTIVE_SYMBOL_ACTION);
 
@@ -37,13 +48,13 @@ public class ActiveSymbolService {
     Set<String> previousSymbols = activeSymbolStore.findAll();
     ActiveSymbolChanges changes = resolveSymbolChanges(previousSymbols, currentSymbols);
 
-    activeSymbolStore.replaceAll(currentSymbols);
-    log.info(
-        REQUEST_SUCCESS + " activeSymbols={}", SYSTEM, ACTIVE_SYMBOL_ACTION, currentSymbols.size());
-
     if (!changes.addedSymbols().isEmpty() || !changes.removedSymbols().isEmpty()) {
       activeSymbolChangesEventPublisher.publish(changes);
     }
+
+    activeSymbolStore.replaceAll(currentSymbols);
+    log.info(
+        REQUEST_SUCCESS + " activeSymbols={}", SYSTEM, ACTIVE_SYMBOL_ACTION, currentSymbols.size());
   }
 
   private Set<String> resolveActiveSymbols(Set<Long> userIds) {

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/ActiveSymbolService.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/ActiveSymbolService.java
@@ -1,0 +1,79 @@
+package com.tychewealth.service.activesymbol;
+
+import static com.tychewealth.constants.LogConstants.REQUEST_START;
+import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
+import static com.tychewealth.constants.LogConstants.SYSTEM;
+
+import com.tychewealth.kafka.events.ActiveSymbolChanges;
+import com.tychewealth.kafka.publishers.ActiveSymbolChangesEventPublisher;
+import com.tychewealth.repository.AssetRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ActiveSymbolService {
+
+  private static final String ACTIVE_SYMBOL_ACTION = "[active-symbol-sync]";
+
+  private final AssetRepository assetRepository;
+  private final ActiveSymbolStore activeSymbolStore;
+  private final ActiveSymbolChangesEventPublisher activeSymbolChangesEventPublisher;
+
+  @Value("${app.active-symbol.user-id-batch-size:600}")
+  private int userIdBatchSize;
+
+  public void synchronizeSymbols(Set<Long> userIds) {
+    log.info(REQUEST_START, SYSTEM, ACTIVE_SYMBOL_ACTION);
+
+    Set<String> currentSymbols = resolveActiveSymbols(userIds);
+    Set<String> previousSymbols = activeSymbolStore.findAll();
+    ActiveSymbolChanges changes = resolveSymbolChanges(previousSymbols, currentSymbols);
+
+    activeSymbolStore.replaceAll(currentSymbols);
+    log.info(
+        REQUEST_SUCCESS + " activeSymbols={}", SYSTEM, ACTIVE_SYMBOL_ACTION, currentSymbols.size());
+
+    if (!changes.addedSymbols().isEmpty() || !changes.removedSymbols().isEmpty()) {
+      activeSymbolChangesEventPublisher.publish(changes);
+    }
+  }
+
+  private Set<String> resolveActiveSymbols(Set<Long> userIds) {
+    if (userIds == null || userIds.isEmpty()) {
+      return Set.of();
+    }
+
+    List<Long> userIdList = new ArrayList<>(userIds);
+    Set<String> symbols = new LinkedHashSet<>();
+
+    for (int batchStart = 0; batchStart < userIdList.size(); batchStart += userIdBatchSize) {
+      int batchEnd = Math.min(batchStart + userIdBatchSize, userIdList.size());
+      List<Long> userIdBatch = userIdList.subList(batchStart, batchEnd);
+      symbols.addAll(assetRepository.findDistinctSymbolsByUserIds(userIdBatch));
+    }
+
+    return Set.copyOf(symbols);
+  }
+
+  private ActiveSymbolChanges resolveSymbolChanges(
+      Set<String> previousSymbols, Set<String> currentSymbols) {
+    Set<String> safePreviousSymbols = previousSymbols == null ? Set.of() : previousSymbols;
+    Set<String> safeCurrentSymbols = currentSymbols == null ? Set.of() : currentSymbols;
+
+    Set<String> addedSymbols = new LinkedHashSet<>(safeCurrentSymbols);
+    addedSymbols.removeAll(safePreviousSymbols);
+
+    Set<String> removedSymbols = new LinkedHashSet<>(safePreviousSymbols);
+    removedSymbols.removeAll(safeCurrentSymbols);
+
+    return new ActiveSymbolChanges(Set.copyOf(addedSymbols), Set.copyOf(removedSymbols));
+  }
+}

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/ActiveSymbolStore.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/ActiveSymbolStore.java
@@ -1,0 +1,10 @@
+package com.tychewealth.service.activesymbol;
+
+import java.util.Set;
+
+public interface ActiveSymbolStore {
+
+  void replaceAll(Set<String> symbols);
+
+  Set<String> findAll();
+}

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStore.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStore.java
@@ -1,0 +1,45 @@
+package com.tychewealth.service.activesymbol;
+
+import static com.tychewealth.constants.RedisConstants.ACTIVE_SYMBOLS_KEY;
+import static com.tychewealth.constants.RedisConstants.ACTIVE_SYMBOLS_TEMP_KEY_PREFIX;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisActiveSymbolStore implements ActiveSymbolStore {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  @Override
+  public void replaceAll(Set<String> symbols) {
+    if (symbols == null || symbols.isEmpty()) {
+      redisTemplate.delete(ACTIVE_SYMBOLS_KEY);
+      return;
+    }
+
+    String tempKey = ACTIVE_SYMBOLS_TEMP_KEY_PREFIX + UUID.randomUUID();
+    try {
+      redisTemplate.opsForSet().add(tempKey, symbols.toArray(String[]::new));
+      redisTemplate.rename(tempKey, ACTIVE_SYMBOLS_KEY);
+    } catch (RuntimeException ex) {
+      redisTemplate.delete(tempKey);
+      throw ex;
+    }
+  }
+
+  @Override
+  public Set<String> findAll() {
+    Set<String> members = redisTemplate.opsForSet().members(ACTIVE_SYMBOLS_KEY);
+    if (members == null || members.isEmpty()) {
+      return Set.of();
+    }
+
+    return Set.copyOf(new LinkedHashSet<>(members));
+  }
+}

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStore.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStore.java
@@ -3,6 +3,7 @@ package com.tychewealth.service.activesymbol;
 import static com.tychewealth.constants.RedisConstants.ACTIVE_SYMBOLS_KEY;
 import static com.tychewealth.constants.RedisConstants.ACTIVE_SYMBOLS_TEMP_KEY_PREFIX;
 
+import java.time.Duration;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class RedisActiveSymbolStore implements ActiveSymbolStore {
+
+  private static final Duration TEMP_KEY_TTL = Duration.ofMinutes(2);
 
   private final RedisTemplate<String, String> redisTemplate;
 
@@ -26,6 +29,7 @@ public class RedisActiveSymbolStore implements ActiveSymbolStore {
     String tempKey = ACTIVE_SYMBOLS_TEMP_KEY_PREFIX + UUID.randomUUID();
     try {
       redisTemplate.opsForSet().add(tempKey, symbols.toArray(String[]::new));
+      redisTemplate.expire(tempKey, TEMP_KEY_TTL);
       redisTemplate.rename(tempKey, ACTIVE_SYMBOLS_KEY);
     } catch (RuntimeException ex) {
       redisTemplate.delete(tempKey);

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/AssetServiceImpl.java
@@ -117,7 +117,7 @@ public class AssetServiceImpl implements AssetService {
   }
 
   @Override
-  @Transactional(isolation = Isolation.SERIALIZABLE)
+  @Transactional()
   public AssetResponseDto update(
       Long userId, Long portfolioId, Long assetId, AssetUpdateRequestDto updateRequest) {
     commonValidationHelper.validateAuthenticatedUser(userId);

--- a/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
+++ b/services/portfolio-service/src/main/java/com/tychewealth/service/impl/PortfolioServiceImpl.java
@@ -68,7 +68,7 @@ public class PortfolioServiceImpl implements PortfolioService {
   }
 
   @Override
-  @Transactional(isolation = Isolation.SERIALIZABLE)
+  @Transactional()
   public PortfolioResponseDto update(
       Long userId, Long portfolioId, PortfolioUpdateRequestDto updateRequest) {
     commonValidationHelper.validateAuthenticatedUser(userId);

--- a/services/portfolio-service/src/main/resources/application.properties
+++ b/services/portfolio-service/src/main/resources/application.properties
@@ -70,6 +70,7 @@ app.security.prometheus.password=${PROMETHEUS_PASSWORD:change-me}
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
 spring.data.redis.timeout=${REDIS_TIMEOUT:2s}
+app.active-symbol.user-id-batch-size=${ACTIVE_SYMBOL_USER_ID_BATCH_SIZE:600}
 
 # Kafka
 kafka.enabled=${KAFKA_ENABLED:true}
@@ -87,3 +88,4 @@ app.kafka.listener.retry-interval-ms=${KAFKA_LISTENER_RETRY_INTERVAL_MS:1000}
 app.kafka.listener.retry-attempts=${KAFKA_LISTENER_RETRY_ATTEMPTS:2}
 app.kafka.dlt.suffix=${KAFKA_DLT_SUFFIX:-dlt}
 app.kafka.topics.active-users=${KAFKA_TOPIC_ACTIVE_USERS:active-users}
+app.kafka.topics.active-symbol-changes=${KAFKA_TOPIC_ACTIVE_SYMBOL_CHANGES:active-symbol-changes}

--- a/services/portfolio-service/src/test/java/com/tychewealth/kafka/consumers/ActiveUsersEventConsumerTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/kafka/consumers/ActiveUsersEventConsumerTest.java
@@ -2,38 +2,51 @@ package com.tychewealth.kafka.consumers;
 
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.tychewealth.kafka.events.ActiveUsersEvent;
+import com.tychewealth.service.activesymbol.ActiveSymbolService;
 import java.time.Instant;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class ActiveUsersEventConsumerTest {
+
+  @Mock private ActiveSymbolService activeSymbolService;
 
   private ActiveUsersEventConsumer consumer;
 
   @BeforeEach
   void setUp() {
-    consumer = new ActiveUsersEventConsumer();
+    consumer = new ActiveUsersEventConsumer(activeSymbolService);
   }
 
   @Test
-  void consumeAcceptsValidActiveUsersEvent() {
+  void consumeDelegatesValidActiveUsersEvent() {
     ActiveUsersEvent event = new ActiveUsersEvent(Instant.now(), Set.of(TEST_USER_ID));
 
     assertDoesNotThrow(() -> consumer.consume(event, "active-users"));
+    verify(activeSymbolService).synchronizeSymbols(Set.of(TEST_USER_ID));
   }
 
   @Test
-  void consumeAcceptsNullEventPayload() {
+  void consumeDelegatesEmptySymbolsWhenPayloadIsNull() {
     assertDoesNotThrow(() -> consumer.consume(null, "active-users"));
+    verify(activeSymbolService).synchronizeSymbols(Set.of());
   }
 
   @Test
-  void consumeAcceptsEventWithNullUserIds() {
+  void consumeDelegatesNullUserIdsAsNullForNow() {
     ActiveUsersEvent event = new ActiveUsersEvent(Instant.now(), null);
 
     assertDoesNotThrow(() -> consumer.consume(event, "active-users"));
+    verify(activeSymbolService).synchronizeSymbols(null);
+    verifyNoMoreInteractions(activeSymbolService);
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/kafka/publishers/ActiveSymbolChangesEventPublisherTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/kafka/publishers/ActiveSymbolChangesEventPublisherTest.java
@@ -1,0 +1,72 @@
+package com.tychewealth.kafka.publishers;
+
+import static com.tychewealth.constants.TestConstants.TEST_ASSET_SYMBOL_MSFT;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.error.exception.EventPublishingException;
+import com.tychewealth.kafka.events.ActiveSymbolChanges;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ActiveSymbolChangesEventPublisherTest {
+
+  private static final String ACTIVE_SYMBOL_CHANGES_TOPIC = "active-symbol-changes";
+
+  @Mock private KafkaTemplate<String, ActiveSymbolChanges> kafkaTemplate;
+
+  private ActiveSymbolChangesEventPublisher activeSymbolChangesEventPublisher;
+
+  @BeforeEach
+  void setUp() {
+    activeSymbolChangesEventPublisher = new ActiveSymbolChangesEventPublisher(kafkaTemplate);
+    ReflectionTestUtils.setField(
+        activeSymbolChangesEventPublisher, "activeSymbolChangesTopic", ACTIVE_SYMBOL_CHANGES_TOPIC);
+    ReflectionTestUtils.setField(activeSymbolChangesEventPublisher, "publishTimeoutMs", 1_000L);
+  }
+
+  @Test
+  void publishLogsSuccessOnlyAfterBrokerAcknowledgement() {
+    ActiveSymbolChanges event =
+        new ActiveSymbolChanges(Set.of(TEST_ASSET_SYMBOL_AAPL), Set.of(TEST_ASSET_SYMBOL_MSFT));
+    CompletableFuture<SendResult<String, ActiveSymbolChanges>> sendFuture =
+        CompletableFuture.completedFuture(null);
+    when(kafkaTemplate.send(ACTIVE_SYMBOL_CHANGES_TOPIC, event)).thenReturn(sendFuture);
+
+    assertDoesNotThrow(() -> activeSymbolChangesEventPublisher.publish(event));
+
+    verify(kafkaTemplate).send(ACTIVE_SYMBOL_CHANGES_TOPIC, event);
+  }
+
+  @Test
+  void publishWrapsDeliveryFailuresWithEventContext() {
+    ActiveSymbolChanges event =
+        new ActiveSymbolChanges(Set.of(TEST_ASSET_SYMBOL_AAPL), Set.of(TEST_ASSET_SYMBOL_MSFT));
+    CompletableFuture<SendResult<String, ActiveSymbolChanges>> sendFuture =
+        new CompletableFuture<>();
+    sendFuture.completeExceptionally(new IllegalStateException("broker unavailable"));
+    when(kafkaTemplate.send(ACTIVE_SYMBOL_CHANGES_TOPIC, event)).thenReturn(sendFuture);
+
+    EventPublishingException exception =
+        assertThrows(
+            EventPublishingException.class, () -> activeSymbolChangesEventPublisher.publish(event));
+
+    assertEquals(ACTIVE_SYMBOL_CHANGES_TOPIC, exception.getMetadata().get("topic"));
+    assertEquals("1", exception.getMetadata().get("addedSymbols"));
+    assertEquals("1", exception.getMetadata().get("removedSymbols"));
+    verify(kafkaTemplate).send(ACTIVE_SYMBOL_CHANGES_TOPIC, event);
+  }
+}

--- a/services/portfolio-service/src/test/java/com/tychewealth/repository/AssetRepositoryTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/repository/AssetRepositoryTest.java
@@ -4,6 +4,7 @@ import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static com.tychewealth.testdata.EntityBuilder.buildAsset;
 import static com.tychewealth.testdata.EntityBuilder.buildPortfolio;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -114,5 +115,36 @@ class AssetRepositoryTest {
     boolean exists = assetRepository.existsByPortfolioIdAndName(portfolio.getId(), "Tesla, Inc.");
 
     assertTrue(exists);
+  }
+
+  @Test
+  void findDistinctSymbolsByUserIdsReturnsDistinctSymbolsForMatchingUsersOnly() {
+    PortfolioEntity otherPortfolio =
+        portfolioRepository.save(
+            buildPortfolio(
+                TEST_USER_ID + 1,
+                "Other Asset Book",
+                CurrencyCodeEnum.EUR,
+                RiskProfileEnum.LOW,
+                StrategyTypeEnum.INDEX,
+                InvestmentHorizonEnum.MEDIUM));
+
+    assetRepository.save(
+        buildAsset(portfolio, "Apple Inc.", "AAPL", AssetTypeEnum.STOCK, CurrencyCodeEnum.USD));
+    assetRepository.save(
+        buildAsset(portfolio, "Apple Again", "AAPL", AssetTypeEnum.ETF, CurrencyCodeEnum.USD));
+    assetRepository.save(
+        buildAsset(
+            portfolio, "Microsoft Corporation", "MSFT", AssetTypeEnum.STOCK, CurrencyCodeEnum.USD));
+    assetRepository.save(
+        buildAsset(otherPortfolio, "Bitcoin", "BTC", AssetTypeEnum.CRYPTO, CurrencyCodeEnum.EUR));
+
+    List<String> result = assetRepository.findDistinctSymbolsByUserIds(List.of(TEST_USER_ID));
+
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertTrue(result.contains("AAPL"));
+    assertTrue(result.contains("MSFT"));
+    assertFalse(result.contains("BTC"));
   }
 }

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/ActiveSymbolServiceTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/ActiveSymbolServiceTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.InOrder;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -74,7 +74,9 @@ class ActiveSymbolServiceTest {
 
     InOrder inOrder = inOrder(activeSymbolChangesEventPublisher, activeSymbolStore);
     inOrder.verify(activeSymbolChangesEventPublisher).publish(changesCaptor.getValue());
-    inOrder.verify(activeSymbolStore).replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
+    inOrder
+        .verify(activeSymbolStore)
+        .replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
   }
 
   @Test
@@ -100,10 +102,13 @@ class ActiveSymbolServiceTest {
         .publish(org.mockito.ArgumentMatchers.any());
 
     assertThrows(
-        IllegalStateException.class, () -> activeSymbolService.synchronizeSymbols(Set.of(TEST_USER_ID)));
+        IllegalStateException.class,
+        () -> activeSymbolService.synchronizeSymbols(Set.of(TEST_USER_ID)));
 
     verify(activeSymbolChangesEventPublisher)
-        .publish(new ActiveSymbolChanges(Set.of(TEST_ASSET_SYMBOL_AAPL), Set.of(TEST_ASSET_SYMBOL_MSFT)));
+        .publish(
+            new ActiveSymbolChanges(
+                Set.of(TEST_ASSET_SYMBOL_AAPL), Set.of(TEST_ASSET_SYMBOL_MSFT)));
     verify(activeSymbolStore, never()).replaceAll(org.mockito.ArgumentMatchers.anySet());
   }
 

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/ActiveSymbolServiceTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/ActiveSymbolServiceTest.java
@@ -5,6 +5,10 @@ import static com.tychewealth.constants.TestConstants.TEST_OTHER_USER_ID;
 import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
 import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -38,6 +43,15 @@ class ActiveSymbolServiceTest {
   }
 
   @Test
+  void validateUserIdBatchSizeRejectsZeroOrNegativeValues() {
+    ReflectionTestUtils.setField(activeSymbolService, "userIdBatchSize", 0);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> ReflectionTestUtils.invokeMethod(activeSymbolService, "validateUserIdBatchSize"));
+  }
+
+  @Test
   void synchronizeSymbolsResolvesSymbolsInBatchesReplacesSnapshotAndPublishesChanges() {
     Set<Long> userIds = new LinkedHashSet<>(List.of(TEST_USER_ID, TEST_OTHER_USER_ID, 126L));
     when(assetRepository.findDistinctSymbolsByUserIds(List.of(TEST_USER_ID, TEST_OTHER_USER_ID)))
@@ -51,13 +65,46 @@ class ActiveSymbolServiceTest {
     verify(assetRepository).findDistinctSymbolsByUserIds(List.of(TEST_USER_ID, TEST_OTHER_USER_ID));
     verify(assetRepository).findDistinctSymbolsByUserIds(List.of(126L));
     verify(activeSymbolStore).findAll();
-    verify(activeSymbolStore).replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
 
     ArgumentCaptor<ActiveSymbolChanges> changesCaptor =
         ArgumentCaptor.forClass(ActiveSymbolChanges.class);
     verify(activeSymbolChangesEventPublisher).publish(changesCaptor.capture());
     assertEquals(Set.of(TEST_ASSET_SYMBOL_AAPL), changesCaptor.getValue().addedSymbols());
     assertEquals(Set.of("GOOG"), changesCaptor.getValue().removedSymbols());
+
+    InOrder inOrder = inOrder(activeSymbolChangesEventPublisher, activeSymbolStore);
+    inOrder.verify(activeSymbolChangesEventPublisher).publish(changesCaptor.getValue());
+    inOrder.verify(activeSymbolStore).replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
+  }
+
+  @Test
+  void synchronizeSymbolsReplacesSnapshotAndDoesNotPublishWhenThereAreNoChanges() {
+    when(assetRepository.findDistinctSymbolsByUserIds(List.of(TEST_USER_ID)))
+        .thenReturn(List.of(TEST_ASSET_SYMBOL_AAPL));
+    when(activeSymbolStore.findAll()).thenReturn(Set.of(TEST_ASSET_SYMBOL_AAPL));
+
+    activeSymbolService.synchronizeSymbols(Set.of(TEST_USER_ID));
+
+    verify(activeSymbolStore).findAll();
+    verify(activeSymbolStore).replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL));
+    verify(activeSymbolChangesEventPublisher, never()).publish(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void synchronizeSymbolsDoesNotReplaceSnapshotWhenPublishFails() {
+    when(assetRepository.findDistinctSymbolsByUserIds(List.of(TEST_USER_ID)))
+        .thenReturn(List.of(TEST_ASSET_SYMBOL_AAPL));
+    when(activeSymbolStore.findAll()).thenReturn(Set.of(TEST_ASSET_SYMBOL_MSFT));
+    doThrow(new IllegalStateException("broker unavailable"))
+        .when(activeSymbolChangesEventPublisher)
+        .publish(org.mockito.ArgumentMatchers.any());
+
+    assertThrows(
+        IllegalStateException.class, () -> activeSymbolService.synchronizeSymbols(Set.of(TEST_USER_ID)));
+
+    verify(activeSymbolChangesEventPublisher)
+        .publish(new ActiveSymbolChanges(Set.of(TEST_ASSET_SYMBOL_AAPL), Set.of(TEST_ASSET_SYMBOL_MSFT)));
+    verify(activeSymbolStore, never()).replaceAll(org.mockito.ArgumentMatchers.anySet());
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/ActiveSymbolServiceTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/ActiveSymbolServiceTest.java
@@ -1,0 +1,93 @@
+package com.tychewealth.service.activesymbol;
+
+import static com.tychewealth.constants.TestConstants.TEST_ASSET_SYMBOL_MSFT;
+import static com.tychewealth.constants.TestConstants.TEST_OTHER_USER_ID;
+import static com.tychewealth.constants.TestConstants.TEST_USER_ID;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tychewealth.kafka.events.ActiveSymbolChanges;
+import com.tychewealth.kafka.publishers.ActiveSymbolChangesEventPublisher;
+import com.tychewealth.repository.AssetRepository;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ActiveSymbolServiceTest {
+
+  @Mock private AssetRepository assetRepository;
+  @Mock private ActiveSymbolStore activeSymbolStore;
+  @Mock private ActiveSymbolChangesEventPublisher activeSymbolChangesEventPublisher;
+
+  @InjectMocks private ActiveSymbolService activeSymbolService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(activeSymbolService, "userIdBatchSize", 2);
+  }
+
+  @Test
+  void synchronizeSymbolsResolvesSymbolsInBatchesReplacesSnapshotAndPublishesChanges() {
+    Set<Long> userIds = new LinkedHashSet<>(List.of(TEST_USER_ID, TEST_OTHER_USER_ID, 126L));
+    when(assetRepository.findDistinctSymbolsByUserIds(List.of(TEST_USER_ID, TEST_OTHER_USER_ID)))
+        .thenReturn(List.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
+    when(assetRepository.findDistinctSymbolsByUserIds(List.of(126L)))
+        .thenReturn(List.of(TEST_ASSET_SYMBOL_AAPL));
+    when(activeSymbolStore.findAll()).thenReturn(Set.of(TEST_ASSET_SYMBOL_MSFT, "GOOG"));
+
+    activeSymbolService.synchronizeSymbols(userIds);
+
+    verify(assetRepository).findDistinctSymbolsByUserIds(List.of(TEST_USER_ID, TEST_OTHER_USER_ID));
+    verify(assetRepository).findDistinctSymbolsByUserIds(List.of(126L));
+    verify(activeSymbolStore).findAll();
+    verify(activeSymbolStore).replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
+
+    ArgumentCaptor<ActiveSymbolChanges> changesCaptor =
+        ArgumentCaptor.forClass(ActiveSymbolChanges.class);
+    verify(activeSymbolChangesEventPublisher).publish(changesCaptor.capture());
+    assertEquals(Set.of(TEST_ASSET_SYMBOL_AAPL), changesCaptor.getValue().addedSymbols());
+    assertEquals(Set.of("GOOG"), changesCaptor.getValue().removedSymbols());
+  }
+
+  @Test
+  void synchronizeSymbolsPublishesWhenOnlyAddedSymbolsExist() {
+    when(assetRepository.findDistinctSymbolsByUserIds(List.of(TEST_USER_ID)))
+        .thenReturn(List.of(TEST_ASSET_SYMBOL_AAPL));
+    when(activeSymbolStore.findAll()).thenReturn(Set.of());
+
+    activeSymbolService.synchronizeSymbols(Set.of(TEST_USER_ID));
+
+    verify(activeSymbolStore).replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL));
+    ArgumentCaptor<ActiveSymbolChanges> changesCaptor =
+        ArgumentCaptor.forClass(ActiveSymbolChanges.class);
+    verify(activeSymbolChangesEventPublisher).publish(changesCaptor.capture());
+    assertEquals(Set.of(TEST_ASSET_SYMBOL_AAPL), changesCaptor.getValue().addedSymbols());
+    assertEquals(Set.of(), changesCaptor.getValue().removedSymbols());
+  }
+
+  @Test
+  void synchronizeSymbolsPublishesWhenOnlyRemovedSymbolsExist() {
+    when(activeSymbolStore.findAll()).thenReturn(Set.of(TEST_ASSET_SYMBOL_AAPL));
+
+    activeSymbolService.synchronizeSymbols(Set.of());
+
+    verify(activeSymbolStore).findAll();
+    verify(activeSymbolStore).replaceAll(Set.of());
+    ArgumentCaptor<ActiveSymbolChanges> changesCaptor =
+        ArgumentCaptor.forClass(ActiveSymbolChanges.class);
+    verify(activeSymbolChangesEventPublisher).publish(changesCaptor.capture());
+    assertEquals(Set.of(), changesCaptor.getValue().addedSymbols());
+    assertEquals(Set.of(TEST_ASSET_SYMBOL_AAPL), changesCaptor.getValue().removedSymbols());
+  }
+}

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStoreTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStoreTest.java
@@ -7,17 +7,20 @@ import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -58,7 +61,11 @@ class RedisActiveSymbolStoreTest {
     assertEquals(
         Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT),
         Set.copyOf(Arrays.asList(membersCaptor.getValue())));
-    verify(redisTemplate).rename(tempKey, ACTIVE_SYMBOLS_KEY);
+
+    InOrder inOrder = inOrder(setOperations, redisTemplate);
+    inOrder.verify(setOperations).add(tempKey, membersCaptor.getValue());
+    inOrder.verify(redisTemplate).expire(tempKey, Duration.ofMinutes(2));
+    inOrder.verify(redisTemplate).rename(tempKey, ACTIVE_SYMBOLS_KEY);
   }
 
   @Test

--- a/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStoreTest.java
+++ b/services/portfolio-service/src/test/java/com/tychewealth/service/activesymbol/RedisActiveSymbolStoreTest.java
@@ -1,0 +1,86 @@
+package com.tychewealth.service.activesymbol;
+
+import static com.tychewealth.constants.RedisConstants.ACTIVE_SYMBOLS_KEY;
+import static com.tychewealth.constants.RedisConstants.ACTIVE_SYMBOLS_TEMP_KEY_PREFIX;
+import static com.tychewealth.constants.TestConstants.TEST_ASSET_SYMBOL_MSFT;
+import static com.tychewealth.testdata.AssetTestData.TEST_ASSET_SYMBOL_AAPL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisActiveSymbolStoreTest {
+
+  @Mock private RedisTemplate<String, String> redisTemplate;
+
+  private RedisActiveSymbolStore redisActiveSymbolStore;
+
+  @BeforeEach
+  void setUp() {
+    redisActiveSymbolStore = new RedisActiveSymbolStore(redisTemplate);
+  }
+
+  @Test
+  void replaceAllDeletesActiveSymbolsKeyWhenSetIsEmpty() {
+    redisActiveSymbolStore.replaceAll(Set.of());
+
+    verify(redisTemplate).delete(ACTIVE_SYMBOLS_KEY);
+    verify(redisTemplate, never()).rename(any(), any());
+  }
+
+  @Test
+  void replaceAllStoresSymbolsInTempSetAndRenamesItToActiveSymbolsKey() {
+    SetOperations<String, String> setOperations = mock(SetOperations.class);
+    when(redisTemplate.opsForSet()).thenReturn(setOperations);
+    ArgumentCaptor<String> tempKeyCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String[]> membersCaptor = ArgumentCaptor.forClass(String[].class);
+
+    redisActiveSymbolStore.replaceAll(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
+
+    verify(setOperations).add(tempKeyCaptor.capture(), membersCaptor.capture());
+    String tempKey = tempKeyCaptor.getValue();
+    assertTrue(tempKey.startsWith(ACTIVE_SYMBOLS_TEMP_KEY_PREFIX));
+    assertEquals(
+        Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT),
+        Set.copyOf(Arrays.asList(membersCaptor.getValue())));
+    verify(redisTemplate).rename(tempKey, ACTIVE_SYMBOLS_KEY);
+  }
+
+  @Test
+  void findAllReturnsEmptySetWhenRedisHasNoActiveSymbols() {
+    SetOperations<String, String> setOperations = mock(SetOperations.class);
+    when(redisTemplate.opsForSet()).thenReturn(setOperations);
+    when(setOperations.members(ACTIVE_SYMBOLS_KEY)).thenReturn(Set.of());
+
+    Set<String> result = redisActiveSymbolStore.findAll();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void findAllReturnsStoredSymbols() {
+    SetOperations<String, String> setOperations = mock(SetOperations.class);
+    when(redisTemplate.opsForSet()).thenReturn(setOperations);
+    when(setOperations.members(ACTIVE_SYMBOLS_KEY))
+        .thenReturn(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT));
+
+    Set<String> result = redisActiveSymbolStore.findAll();
+
+    assertEquals(Set.of(TEST_ASSET_SYMBOL_AAPL, TEST_ASSET_SYMBOL_MSFT), result);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic tracking of active investment symbols based on active users.
  * Added synchronization of active-symbol changes through Kafka events.
  * Added reliable Redis storage for the current active-symbol set.
  * Added clearer error handling for event publishing failures.

* **Configuration**
  * Added settings for user batching and active-symbol event topics.

* **Tests**
  * Added coverage for active-symbol synchronization, storage, repository queries, and event publishing.

Closes #118 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->