### PR TITLE
[TYCHE-66] consume user active symbols

### DIFF
--- a/services/market-data-service/src/main/java/com/tychewealth/config/KafkaConfig.java
+++ b/services/market-data-service/src/main/java/com/tychewealth/config/KafkaConfig.java
@@ -1,0 +1,63 @@
+package com.tychewealth.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@EnableKafka
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class KafkaConfig {
+
+  @Value("${app.kafka.dlt.suffix:-dlt}")
+  private String deadLetterTopicSuffix;
+
+  @Value("${app.kafka.listener.retry-interval-ms:1000}")
+  private long retryIntervalMs;
+
+  @Value("${app.kafka.listener.retry-attempts:2}")
+  private long retryAttempts;
+
+  @Bean
+  DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(
+      KafkaTemplate<Object, Object> kafkaTemplate) {
+    return new DeadLetterPublishingRecoverer(
+        kafkaTemplate,
+        (consumerRecord, exception) ->
+            new TopicPartition(
+                consumerRecord.topic() + deadLetterTopicSuffix, consumerRecord.partition()));
+  }
+
+  @Bean
+  DefaultErrorHandler kafkaErrorHandler(
+      DeadLetterPublishingRecoverer deadLetterPublishingRecoverer) {
+    DefaultErrorHandler errorHandler =
+        new DefaultErrorHandler(
+            deadLetterPublishingRecoverer, new FixedBackOff(retryIntervalMs, retryAttempts));
+    errorHandler.setCommitRecovered(true);
+    return errorHandler;
+  }
+
+  @Bean
+  ConcurrentKafkaListenerContainerFactory<Object, Object> kafkaListenerContainerFactory(
+      ConcurrentKafkaListenerContainerFactoryConfigurer configurer,
+      ConsumerFactory<Object, Object> consumerFactory,
+      DefaultErrorHandler kafkaErrorHandler) {
+
+    ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    configurer.configure(factory, consumerFactory);
+    factory.setCommonErrorHandler(kafkaErrorHandler);
+    return factory;
+  }
+}

--- a/services/market-data-service/src/main/java/com/tychewealth/config/KafkaConfig.java
+++ b/services/market-data-service/src/main/java/com/tychewealth/config/KafkaConfig.java
@@ -1,5 +1,6 @@
 package com.tychewealth.config;
 
+import java.time.Duration;
 import org.apache.kafka.common.TopicPartition;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,14 +29,21 @@ public class KafkaConfig {
   @Value("${app.kafka.listener.retry-attempts:2}")
   private long retryAttempts;
 
+  @Value("${spring.kafka.producer.properties.delivery.timeout.ms:30000}")
+  private long dltSendTimeoutMs;
+
   @Bean
   DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(
       KafkaTemplate<Object, Object> kafkaTemplate) {
-    return new DeadLetterPublishingRecoverer(
-        kafkaTemplate,
-        (consumerRecord, exception) ->
-            new TopicPartition(
-                consumerRecord.topic() + deadLetterTopicSuffix, consumerRecord.partition()));
+    DeadLetterPublishingRecoverer recoverer =
+        new DeadLetterPublishingRecoverer(
+            kafkaTemplate,
+            (consumerRecord, exception) ->
+                new TopicPartition(
+                    consumerRecord.topic() + deadLetterTopicSuffix, consumerRecord.partition()));
+    recoverer.setFailIfSendResultIsError(true);
+    recoverer.setWaitForSendResultTimeout(Duration.ofMillis(dltSendTimeoutMs));
+    return recoverer;
   }
 
   @Bean

--- a/services/market-data-service/src/main/java/com/tychewealth/constants/LogConstants.java
+++ b/services/market-data-service/src/main/java/com/tychewealth/constants/LogConstants.java
@@ -9,6 +9,7 @@ public final class LogConstants {
   public static final String RESOURCES_CLIENT = "[resources-client]";
   public static final String TWELVE_DATA_CLIENT = "[twelve-data-client]";
   public static final String VEHICLE_POLLING_SCHEDULER = "[vehicle-polling-scheduler]";
+  public static final String ACTIVE_SYMBOL_CHANGES_EVENT = "[active-symbol-changes-event]";
   public static final String ERROR_HANDLER = "[error-handler]";
   public static final String FETCH_ACTION = "[fetch]";
   public static final String POLL_ACTION = "[poll]";
@@ -16,6 +17,7 @@ public final class LogConstants {
   public static final String PRICE_ACTION = "[price]";
   public static final String QUOTE_ACTION = "[quote]";
   public static final String TIME_SERIES_ACTION = "[time-series]";
+  public static final String SYNC_ACTION = "[sync]";
 
   public static final String REQUEST_START = BASE_LOG + " Request started";
   public static final String REQUEST_SUCCESS = BASE_LOG + " Request succeeded count={}";

--- a/services/market-data-service/src/main/java/com/tychewealth/kafka/consumers/ActiveSymbolChangesEventConsumer.java
+++ b/services/market-data-service/src/main/java/com/tychewealth/kafka/consumers/ActiveSymbolChangesEventConsumer.java
@@ -1,0 +1,35 @@
+package com.tychewealth.kafka.consumers;
+
+import static com.tychewealth.constants.LogConstants.ACTIVE_SYMBOL_CHANGES_EVENT;
+import static com.tychewealth.constants.LogConstants.REQUEST_SUCCESS;
+import static com.tychewealth.constants.LogConstants.SYNC_ACTION;
+
+import com.tychewealth.kafka.events.ActiveSymbolChanges;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class ActiveSymbolChangesEventConsumer {
+
+  @KafkaListener(
+      topics = "${app.kafka.topics.active-symbol-changes}",
+      groupId = "${spring.kafka.consumer.group-id}",
+      containerFactory = "kafkaListenerContainerFactory")
+  public void consume(
+      ActiveSymbolChanges event, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+    int changedSymbolsCount =
+        event == null ? 0 : event.addedSymbols().size() + event.removedSymbols().size();
+    log.info(
+        REQUEST_SUCCESS + " topic={}",
+        ACTIVE_SYMBOL_CHANGES_EVENT,
+        SYNC_ACTION,
+        changedSymbolsCount,
+        receivedTopic);
+  }
+}

--- a/services/market-data-service/src/main/java/com/tychewealth/kafka/events/ActiveSymbolChanges.java
+++ b/services/market-data-service/src/main/java/com/tychewealth/kafka/events/ActiveSymbolChanges.java
@@ -2,4 +2,10 @@ package com.tychewealth.kafka.events;
 
 import java.util.Set;
 
-public record ActiveSymbolChanges(Set<String> addedSymbols, Set<String> removedSymbols) {}
+public record ActiveSymbolChanges(Set<String> addedSymbols, Set<String> removedSymbols) {
+
+  public ActiveSymbolChanges {
+    addedSymbols = addedSymbols == null ? Set.of() : Set.copyOf(addedSymbols);
+    removedSymbols = removedSymbols == null ? Set.of() : Set.copyOf(removedSymbols);
+  }
+}

--- a/services/market-data-service/src/main/java/com/tychewealth/kafka/events/ActiveSymbolChanges.java
+++ b/services/market-data-service/src/main/java/com/tychewealth/kafka/events/ActiveSymbolChanges.java
@@ -1,0 +1,5 @@
+package com.tychewealth.kafka.events;
+
+import java.util.Set;
+
+public record ActiveSymbolChanges(Set<String> addedSymbols, Set<String> removedSymbols) {}

--- a/services/market-data-service/src/main/resources/application.yaml
+++ b/services/market-data-service/src/main/resources/application.yaml
@@ -10,6 +10,23 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       timeout: ${REDIS_TIMEOUT:2s}
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      auto-offset-reset: ${KAFKA_AUTO_OFFSET_RESET:earliest}
+      group-id: ${KAFKA_CONSUMER_GROUP_ID:market-data-service-active-symbol-changes}
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: com.tychewealth.kafka.events
+    producer:
+      client-id: ${KAFKA_PRODUCER_CLIENT_ID:market-data-service}
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        delivery.timeout.ms: ${KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS:30000}
 
 server:
   port: 8081
@@ -60,20 +77,16 @@ clients:
     max-retries: 2
     retry-backoff: 500ms
 
-vehicle:
-  polling:
-    enabled: true
-    fixed-delay: 90s
-    initial-delay: 0s
+kafka:
+  enabled: ${KAFKA_ENABLED:true}
 
-mock:
-  provider:
-    enabled: true
-    port: 8089
-    min-vehicles-per-response: 20
-    max-vehicles-per-response: 50
-    min-vehicles-changed-per-refresh: 0
-    max-vehicles-changed-per-refresh: 8
-    min-response-duration-seconds: 20
-    max-response-duration-seconds: 180
+app:
+  kafka:
+    listener:
+      retry-interval-ms: ${KAFKA_LISTENER_RETRY_INTERVAL_MS:1000}
+      retry-attempts: ${KAFKA_LISTENER_RETRY_ATTEMPTS:2}
+    dlt:
+      suffix: ${KAFKA_DLT_SUFFIX:-dlt}
+    topics:
+      active-symbol-changes: ${KAFKA_TOPIC_ACTIVE_SYMBOL_CHANGES:active-symbol-changes}
 

--- a/services/market-data-service/src/test/java/com/tychewealth/config/KafkaConfigTest.java
+++ b/services/market-data-service/src/test/java/com/tychewealth/config/KafkaConfigTest.java
@@ -1,0 +1,82 @@
+package com.tychewealth.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.BiFunction;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class KafkaConfigTest {
+
+  private KafkaConfig kafkaConfig;
+
+  @BeforeEach
+  void setUp() {
+    kafkaConfig = new KafkaConfig();
+    ReflectionTestUtils.setField(kafkaConfig, "deadLetterTopicSuffix", "-dlt");
+    ReflectionTestUtils.setField(kafkaConfig, "retryIntervalMs", 1000L);
+    ReflectionTestUtils.setField(kafkaConfig, "retryAttempts", 2L);
+  }
+
+  @Test
+  void deadLetterPublishingRecovererRoutesToTopicWithSuffix() {
+    @SuppressWarnings("unchecked")
+    KafkaTemplate<Object, Object> kafkaTemplate = mock(KafkaTemplate.class);
+
+    DeadLetterPublishingRecoverer recoverer =
+        kafkaConfig.deadLetterPublishingRecoverer(kafkaTemplate);
+
+    @SuppressWarnings("unchecked")
+    BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> destinationResolver =
+        (BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition>)
+            ReflectionTestUtils.getField(recoverer, "destinationResolver");
+
+    TopicPartition topicPartition =
+        destinationResolver.apply(
+            new ConsumerRecord<>("active-symbol-changes", 3, 0L, "key", "value"),
+            new IllegalStateException("boom"));
+
+    assertNotNull(recoverer);
+    assertNotNull(destinationResolver);
+    assertEquals("active-symbol-changes-dlt", topicPartition.topic());
+    assertEquals(3, topicPartition.partition());
+  }
+
+  @Test
+  void kafkaErrorHandlerCommitsRecoveredOffsets() {
+    DeadLetterPublishingRecoverer recoverer = mock(DeadLetterPublishingRecoverer.class);
+
+    DefaultErrorHandler errorHandler = kafkaConfig.kafkaErrorHandler(recoverer);
+
+    assertNotNull(errorHandler);
+    assertEquals(true, ReflectionTestUtils.getField(errorHandler, "commitRecovered"));
+  }
+
+  @Test
+  void kafkaListenerContainerFactoryConfiguresFactoryAndSetsCommonErrorHandler() {
+    ConcurrentKafkaListenerContainerFactoryConfigurer configurer =
+        mock(ConcurrentKafkaListenerContainerFactoryConfigurer.class);
+    @SuppressWarnings("unchecked")
+    ConsumerFactory<Object, Object> consumerFactory = mock(ConsumerFactory.class);
+    DefaultErrorHandler errorHandler = mock(DefaultErrorHandler.class);
+
+    ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+        kafkaConfig.kafkaListenerContainerFactory(configurer, consumerFactory, errorHandler);
+
+    assertNotNull(factory);
+    verify(configurer).configure(factory, consumerFactory);
+    assertEquals(errorHandler, ReflectionTestUtils.getField(factory, "commonErrorHandler"));
+  }
+}

--- a/services/market-data-service/src/test/java/com/tychewealth/config/KafkaConfigTest.java
+++ b/services/market-data-service/src/test/java/com/tychewealth/config/KafkaConfigTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.util.function.BiFunction;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -28,6 +29,7 @@ class KafkaConfigTest {
     ReflectionTestUtils.setField(kafkaConfig, "deadLetterTopicSuffix", "-dlt");
     ReflectionTestUtils.setField(kafkaConfig, "retryIntervalMs", 1000L);
     ReflectionTestUtils.setField(kafkaConfig, "retryAttempts", 2L);
+    ReflectionTestUtils.setField(kafkaConfig, "dltSendTimeoutMs", 30000L);
   }
 
   @Test
@@ -52,6 +54,10 @@ class KafkaConfigTest {
     assertNotNull(destinationResolver);
     assertEquals("active-symbol-changes-dlt", topicPartition.topic());
     assertEquals(3, topicPartition.partition());
+    assertEquals(true, ReflectionTestUtils.getField(recoverer, "failIfSendResultIsError"));
+    assertEquals(
+        Duration.ofMillis(30000L),
+        ReflectionTestUtils.getField(recoverer, "waitForSendResultTimeout"));
   }
 
   @Test

--- a/services/market-data-service/src/test/java/com/tychewealth/kafka/consumers/ActiveSymbolChangesEventConsumerTest.java
+++ b/services/market-data-service/src/test/java/com/tychewealth/kafka/consumers/ActiveSymbolChangesEventConsumerTest.java
@@ -1,0 +1,24 @@
+package com.tychewealth.kafka.consumers;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.tychewealth.kafka.events.ActiveSymbolChanges;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ActiveSymbolChangesEventConsumerTest {
+
+  private final ActiveSymbolChangesEventConsumer consumer = new ActiveSymbolChangesEventConsumer();
+
+  @Test
+  void consumeDoesNotThrowWhenEventContainsAddedAndRemovedSymbols() {
+    ActiveSymbolChanges event = new ActiveSymbolChanges(Set.of("AAPL"), Set.of("MSFT"));
+
+    assertDoesNotThrow(() -> consumer.consume(event, "active-symbol-changes"));
+  }
+
+  @Test
+  void consumeDoesNotThrowWhenEventIsNull() {
+    assertDoesNotThrow(() -> consumer.consume(null, "active-symbol-changes"));
+  }
+}

--- a/services/market-data-service/src/test/java/com/tychewealth/kafka/events/ActiveSymbolChangesTest.java
+++ b/services/market-data-service/src/test/java/com/tychewealth/kafka/events/ActiveSymbolChangesTest.java
@@ -1,0 +1,26 @@
+package com.tychewealth.kafka.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ActiveSymbolChangesTest {
+
+  @Test
+  void constructorNormalizesNullAddedSymbolsToEmptySet() {
+    ActiveSymbolChanges changes = new ActiveSymbolChanges(null, Set.of("MSFT"));
+
+    assertTrue(changes.addedSymbols().isEmpty());
+    assertEquals(Set.of("MSFT"), changes.removedSymbols());
+  }
+
+  @Test
+  void constructorNormalizesNullRemovedSymbolsToEmptySet() {
+    ActiveSymbolChanges changes = new ActiveSymbolChanges(Set.of("AAPL"), null);
+
+    assertEquals(Set.of("AAPL"), changes.addedSymbols());
+    assertTrue(changes.removedSymbols().isEmpty());
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for receiving active-symbol change events, including added and removed symbols.
  * Added configurable Kafka messaging for active-symbol updates.
* **Reliability**
  * Failed Kafka messages are retried automatically and routed to a dead-letter topic after configured attempts.
  * Recovered messages are committed to prevent repeated processing.
* **Tests**
  * Added coverage for active-symbol event handling and Kafka error recovery behavior.

closes #119 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->